### PR TITLE
Fix to_dict() copies, inherit serialization

### DIFF
--- a/sec_certs/certificate.py
+++ b/sec_certs/certificate.py
@@ -434,9 +434,10 @@ class CommonCriteriaCert(Certificate):
 
     @classmethod
     def from_dict(cls, dct: dict) -> 'CommonCriteriaCert':
-        dct['maintainance_updates'] = set(dct['maintainance_updates'])
-        dct['protection_profiles'] = set(dct['protection_profiles'])
-        return super(cls, CommonCriteriaCert).from_dict(dct)
+        new_dct = dct.copy()
+        new_dct['maintainance_updates'] = set(dct['maintainance_updates'])
+        new_dct['protection_profiles'] = set(dct['protection_profiles'])
+        return super(cls, CommonCriteriaCert).from_dict(new_dct)
 
     @classmethod
     def from_html_row(cls, row: Tag, category: str) -> 'CommonCriteriaCert':

--- a/sec_certs/dataset.py
+++ b/sec_certs/dataset.py
@@ -7,6 +7,7 @@ from typing import Dict, List, ClassVar
 import json
 from importlib import import_module
 
+import copy
 from abc import ABC, abstractmethod
 from pathlib import Path
 import shutil
@@ -59,9 +60,9 @@ class Dataset(ABC):
         pass
 
     def to_dict(self):
-        return copy.deepcopy({'root_dir': self.root_dir, 'timestamp': self.timestamp, 'sha256_digest': self.sha256_digest,
-                              'name': self.name,
-                              'description': self.description, 'n_certs': len(self), 'certs': list(self.certs.values())})
+        return {'root_dir': copy.deepcopy(self.root_dir), 'timestamp': self.timestamp,
+                'sha256_digest': self.sha256_digest, 'name': self.name, 'description': self.description,
+                'n_certs': len(self), 'certs': list(self.certs.values())}
 
     @classmethod
     def from_dict(cls, dct: Dict):


### PR DESCRIPTION
1. The methods `to_dict()` in Certificate and Dataset classes and subclasses
now use copy of their `self.__dict__`. Note that `deepcopy()` is required, since messing with mutable values in `self.__dict__` would still change the class values if mere `self.__dict__.copy()` is called.

2. Furthermore, if possible, `to_dict()` and `from_dict()` methods are now
inherited from the superclass.