### PR TITLE
Serialize digest of the certificate

### DIFF
--- a/sec_certs/certificate.py
+++ b/sec_certs/certificate.py
@@ -809,6 +809,7 @@ class CommonCriteriaCert(Certificate, ComplexSerializableType):
         report_pdf_path: Path
         st_txt_path: Path
         report_txt_path: Path
+        errors: List[str]
 
         def __init__(self, st_link_ok: bool = True, report_link_ok: bool = True,
                      st_convert_ok: bool = True, report_convert_ok: bool = True,

--- a/sec_certs/dataset.py
+++ b/sec_certs/dataset.py
@@ -70,11 +70,11 @@ class Dataset(ABC):
     def to_dict(self):
         return {'timestamp': self.timestamp, 'sha256_digest': self.sha256_digest,
                 'name': self.name, 'description': self.description,
-                'n_certs': len(self), 'certs': list(self.certs.values())}
+                'n_certs': len(self), 'certs': self.certs}
 
     @classmethod
     def from_dict(cls, dct: Dict):
-        certs = {x.dgst: x for x in dct['certs']}
+        certs = {x.dgst: x for x in dct['certs'].values()}
         dset = cls(certs, Path('./'), dct['name'], dct['description'])
         if len(dset) != (claimed := dct['n_certs']):
             logger.error(

--- a/test/data/test_cc_oop/toy_dataset.json
+++ b/test/data/test_cc_oop/toy_dataset.json
@@ -13,8 +13,8 @@
     "name": "toy dataset",
     "description": "toy dataset description",
     "n_certs": 2,
-    "certs": [
-        {
+    "certs": {
+        "7ef8227c1aed06bb": {
             "_type": "CommonCriteriaCert",
             "status": "active",
             "category": "Access Control Devices and Systems",
@@ -53,7 +53,7 @@
                 "st_keywords": null
             }
         },
-        {
+        "561a012d9a30e960": {
             "_type": "CommonCriteriaCert",
             "status": "active",
             "category": "Access Control Devices and Systems",
@@ -95,5 +95,5 @@
                 "st_keywords": null
             }
         }
-    ]
+    }
 }


### PR DESCRIPTION
The certificates are not serialized as `certs: []` in `Dataset` class, but rather as `certs: {dgst: cert_serialization}`. This helps when localizing errors that bind to specific certificate (the error log always shows the digest of the certificate, but finding the certificate data in the serialized dataset was impossible until now).