### PR TITLE
cc fix state handleling, merge extract and heuristics public methods

### DIFF
--- a/cc_cli.py
+++ b/cc_cli.py
@@ -89,8 +89,7 @@ def main(configpath: Optional[str], actions: List[str], inputpath: Optional[Path
         if not dset.state.pdfs_converted:
             print('Error: You want to process txt documents of certificates, but pdfs were not converted. You must use \'convert\' action first.')
             sys.exit(1)
-        dset.extract_data()
-        dset.compute_heuristics()
+        dset.analyze_certificates()
 
     if 'maintenances' in actions:
         if not dset.state.meta_sources_parsed:

--- a/examples/cc_cpe_labeling.py
+++ b/examples/cc_cpe_labeling.py
@@ -19,7 +19,7 @@ def main():
 
     dset = CCDataset({}, Path('./my_debug_datset'), 'cc_full_dataset', 'Full CC dataset')
     dset.get_certs_from_web(to_download=True)
-    dset.compute_heuristics()
+    dset._compute_heuristics()
     dset.manually_verify_cpe_matches()
 
     logger.info(f'{dset.json_path} should now contain fully labeled dataset.')

--- a/examples/cc_oop_demo.py
+++ b/examples/cc_oop_demo.py
@@ -40,13 +40,13 @@ def main():
     dset.convert_all_pdfs()
 
     # Extract data from txt files and update json
-    dset.extract_data()
+    dset._extract_data()
 
     # transform to pandas DataFrame
     df = dset.to_pandas()
 
     # Compute heuristics on the dataset
-    dset.compute_heuristics()
+    dset._compute_heuristics()
 
     # Manually verify CPE findings and compute related cves
     # dset.manually_verify_cpe_matches(update_json=True)

--- a/examples/readme.md
+++ b/examples/readme.md
@@ -12,7 +12,7 @@ The tool contains a fuzzy procedure that attempts to map [CPE names](https://nvd
 ```python
 dset = CCDataset({}, Path('./my_debug_datset'), 'cc_full_dataset', 'Full CC dataset')
 dset.get_certs_from_web(to_download=True, update_json=True)
-dset.compute_heuristics()
+dset._compute_heuristics()
 dset.manually_verify_cpe_matches()
 ```
 

--- a/tests/data/test_cc_oop/fictional_cert.json
+++ b/tests/data/test_cc_oop/fictional_cert.json
@@ -34,8 +34,8 @@
     ],
     "state": {
         "_type": "InternalState",
-        "st_link_ok": true,
-        "report_link_ok": true,
+        "st_download_ok": true,
+        "report_download_ok": true,
         "st_convert_ok": true,
         "report_convert_ok": true,
         "st_extract_ok": true,

--- a/tests/data/test_cc_oop/toy_dataset.json
+++ b/tests/data/test_cc_oop/toy_dataset.json
@@ -5,7 +5,6 @@
         "meta_sources_parsed": true,
         "pdfs_downloaded": false,
         "pdfs_converted": false,
-        "txt_data_extracted": false,
         "certs_analyzed": false
     },
     "timestamp": "2020-11-16 17:04:14.770153",
@@ -36,8 +35,8 @@
             "maintainance_updates": [],
             "state": {
                 "_type": "InternalState",
-                "st_link_ok": true,
-                "report_link_ok": true,
+                "st_download_ok": true,
+                "report_download_ok": true,
                 "st_convert_ok": true,
                 "report_convert_ok": true,
                 "st_extract_ok": true,
@@ -90,8 +89,8 @@
             "maintainance_updates": [],
             "state": {
                 "_type": "InternalState",
-                "st_link_ok": true,
-                "report_link_ok": true,
+                "st_download_ok": true,
+                "report_download_ok": true,
                 "st_convert_ok": true,
                 "report_convert_ok": true,
                 "st_extract_ok": true,

--- a/tests/data/test_cpe_cve/vulnerable_dataset.json
+++ b/tests/data/test_cpe_cve/vulnerable_dataset.json
@@ -5,7 +5,6 @@
         "meta_sources_parsed": true,
         "pdfs_downloaded": false,
         "pdfs_converted": false,
-        "txt_data_extracted": false,
         "certs_analyzed": false
     },
     "timestamp": "2021-04-16 15:05:18.386794",
@@ -36,8 +35,8 @@
             "maintainance_updates": [],
             "state": {
                 "_type": "InternalState",
-                "st_link_ok": true,
-                "report_link_ok": true,
+                "st_download_ok": true,
+                "report_download_ok": true,
                 "st_convert_ok": true,
                 "report_convert_ok": true,
                 "st_extract_ok": true,

--- a/tests/test_cc_heuristics.py
+++ b/tests/test_cc_heuristics.py
@@ -25,8 +25,8 @@ class TestCommonCriteriaHeuristics(TestCase):
         cls.cc_dset.process_protection_profiles()
         cls.cc_dset.download_all_pdfs()
         cls.cc_dset.convert_all_pdfs()
-        cls.cc_dset.extract_data()
-        cls.cc_dset.compute_heuristics()
+        cls.cc_dset._extract_data()
+        cls.cc_dset._compute_heuristics()
 
         cls.cpes = [CPE("cpe:2.3:a:ibm:security_access_manager_for_enterprise_single_sign-on:8.2.2:*:*:*:*:*:*:*",
                          "IBM Security Access Manager For Enterprise Single Sign-On 8.2.2"),


### PR DESCRIPTION
- This merge requests closes #82 that was caused by incorrect state handeling. 
- To be specific, heuristics were allowed to be extracted even when conversion `pdf->txt` failed or when extraction of data from `txt` failed.
- Furthermore, methods `extract_txt_data()` and `compute_heuristics()` were made private and accessible through public method that merges their functionality `analyze_certificates()`. This method is exposed in CLI. 
- Instead of complex conditions that watch for appropriate actions on dataset, this functionality was delegated to internal state of the certificates, saving some lines of code. 