### PR TITLE
simplify serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project is developed by the [Centre for Research On Cryptography and Securi
 
 ## Installation (CC)
 
-The tool requires `Python >=3.8` and `pdftotext` binary somewhere on the `PATH` ([More info about pdftotext dependencies](https://pypi.org/project/pdftotext/)).
+The tool requires `Python >=3.8` and [pdftotext](https://www.xpdfreader.com/pdftotext-man.html) binary somewhere on the `PATH`.
 
 The stable release is published on [PyPi](https://pypi.org/project/sec-certs/) as well as on [DockerHub](https://hub.docker.com/repository/docker/seccerts/sec-certs), you can install it with:
 

--- a/sec_certs/serialization.py
+++ b/sec_certs/serialization.py
@@ -23,6 +23,20 @@ class ComplexSerializableType:
         return cls(*(tuple(dct.values())))
 
 
+# Decorator for serialization
+def serialize(func: callable):
+    def inner_func(*args, **kwargs):
+        if not args or not issubclass(type(args[0]), ComplexSerializableType):
+            raise ValueError('@serialize decorator is to be used only on instance methods of ComplexSerializableType child classes.')
+
+        update_json = kwargs.pop('update_json', False)
+        func(*args, **kwargs)
+
+        if update_json:
+            args[0].to_json()
+    return inner_func
+
+
 class CustomJSONEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, ComplexSerializableType):


### PR DESCRIPTION
Implements a decorator that handles dataset json serialization on public methods. Before pull request, each public method (that updates the dataset json) was supposed to contain keyword argument `update_json: bool`. Value would then be checked at the end of the function and serialization possibly invoked

New behaviour is as follows. Each public method that should end with serialization can get decorated with `@serialize` that will handle the functionality. When definition

```python
@serialize
def analyze_certs(self):
    pass
```
is called as `dset.analyze_certs(update_json=True)`, effectively the following happens:

```python
dset.analyze_certs()
dset.to_json()
```

see [sec-certs/serialization.py](https://github.com/crocs-muni/sec-certs/pull/85/files#diff-7a49b00177c646d4a177c0c5e34d2341e46f13cc80eb0920d962b169cd681571) for implementation.

#procrastination. 