### PR TITLE
Cc bugfixes

### DIFF
--- a/sec_certs/certificate/common_criteria.py
+++ b/sec_certs/certificate/common_criteria.py
@@ -94,12 +94,16 @@ class CommonCriteriaCert(Certificate, ComplexSerializableType):
             return self.st_download_ok if fresh else self.st_download_ok and not self.st_convert_ok
 
         def report_is_ok_to_analyze(self, fresh: bool = True):
-            # Currently extract_ok watches two things at once: extraction of stuff from txt and heuristics
-            return self.report_convert_ok and self.report_extract_ok if fresh else self.report_convert_ok and not self.report_extract_ok
+            if fresh is True:
+                return self.report_download_ok and self.report_convert_ok and self.report_extract_ok
+            else:
+                return self.report_download_ok and self.report_convert_ok and not self.report_extract_ok
 
         def st_is_ok_to_analyze(self, fresh: bool = True):
-            # Currently extract_ok watches two things at once: extraction of stuff from txt and heuristics
-            return self.st_convert_ok and self.st_extract_ok if fresh else self.st_convert_ok and not self.st_extract_ok
+            if fresh is True:
+                return self.st_download_ok and self.st_convert_ok and self.st_extract_ok
+            else:
+                return self.st_download_ok and self.st_convert_ok and not self.st_extract_ok
 
     @dataclass(init=False)
     class PdfData(ComplexSerializableType):

--- a/sec_certs/certificate/common_criteria.py
+++ b/sec_certs/certificate/common_criteria.py
@@ -53,11 +53,12 @@ class CommonCriteriaCert(Certificate, ComplexSerializableType):
         report_convert_ok: bool
         st_extract_ok: bool
         report_extract_ok: bool
+        errors: Optional[List[str]]
+
         st_pdf_path: Path
         report_pdf_path: Path
         st_txt_path: Path
         report_txt_path: Path
-        errors: Optional[List[str]]
 
         def __init__(self, st_download_ok: bool = True, report_download_ok: bool = True,
                      st_convert_ok: bool = True, report_convert_ok: bool = True,
@@ -74,6 +75,11 @@ class CommonCriteriaCert(Certificate, ComplexSerializableType):
                 self.errors = []
             else:
                 self.errors = errors
+
+        @property
+        def serialized_attributes(self) -> List[str]:
+            return ['st_download_ok', 'report_download_ok', 'st_convert_ok', 'report_convert_ok', 'st_extract_ok',
+                    'report_extract_ok', 'errors']
 
         def report_is_ok_to_download(self, fresh: bool = True):
             return True if fresh else not self.report_download_ok

--- a/sec_certs/dataset/common_criteria.py
+++ b/sec_certs/dataset/common_criteria.py
@@ -501,11 +501,11 @@ class CCDataset(Dataset, ComplexSerializableType):
 
     def _extract_report_metadata(self, fresh: bool = True):
         certs_to_process = [x for x in self if x.state.report_is_ok_to_analyze(fresh)]
-        cert_processing.process_parallel(CommonCriteriaCert.extract_report_pdf_metadata, certs_to_process, config.n_threads)
+        cert_processing.process_parallel(CommonCriteriaCert.extract_report_pdf_metadata, certs_to_process, config.n_threads, use_threading=False)
 
     def _extract_targets_metadata(self, fresh: bool = True):
         certs_to_process = [x for x in self if x.state.st_is_ok_to_analyze(fresh)]
-        cert_processing.process_parallel(CommonCriteriaCert.extract_st_pdf_metadata, certs_to_process, config.n_threads)
+        cert_processing.process_parallel(CommonCriteriaCert.extract_st_pdf_metadata, certs_to_process, config.n_threads, use_threading=False)
 
     def extract_pdf_metadata(self, fresh: bool = True):
         logger.info('Extracting pdf metadata from CC dataset')
@@ -514,11 +514,11 @@ class CCDataset(Dataset, ComplexSerializableType):
 
     def _extract_report_frontpage(self, fresh: bool = True):
         certs_to_process = [x for x in self if x.state.report_is_ok_to_analyze(fresh)]
-        cert_processing.process_parallel(CommonCriteriaCert.extract_report_pdf_frontpage, certs_to_process, config.n_threads)
+        cert_processing.process_parallel(CommonCriteriaCert.extract_report_pdf_frontpage, certs_to_process, config.n_threads, use_threading=False)
 
     def _extract_targets_frontpage(self, fresh: bool = True):
         certs_to_process = [x for x in self if x.state.st_is_ok_to_analyze(fresh)]
-        cert_processing.process_parallel(CommonCriteriaCert.extract_st_pdf_frontpage, certs_to_process, config.n_threads)
+        cert_processing.process_parallel(CommonCriteriaCert.extract_st_pdf_frontpage, certs_to_process, config.n_threads, use_threading=False)
 
     def extract_pdf_frontpage(self, fresh: bool = True):
         logger.info('Extracting pdf frontpages from CC dataset.')
@@ -527,11 +527,11 @@ class CCDataset(Dataset, ComplexSerializableType):
 
     def _extract_report_keywords(self, fresh: bool = True):
         certs_to_process = [x for x in self if x.state.report_is_ok_to_analyze(fresh)]
-        cert_processing.process_parallel(CommonCriteriaCert.extract_report_pdf_keywords, certs_to_process, config.n_threads)
+        cert_processing.process_parallel(CommonCriteriaCert.extract_report_pdf_keywords, certs_to_process, config.n_threads, use_threading=False)
 
     def _extract_targets_keywords(self, fresh: bool = True):
         certs_to_process = [x for x in self if x.state.st_is_ok_to_analyze(fresh)]
-        cert_processing.process_parallel(CommonCriteriaCert.extract_st_pdf_keywords, certs_to_process, config.n_threads)
+        cert_processing.process_parallel(CommonCriteriaCert.extract_st_pdf_keywords, certs_to_process, config.n_threads, use_threading=False)
 
     def extract_pdf_keywords(self, fresh: bool = True):
         logger.info('Extracting pdf keywords from CC dataset.')

--- a/sec_certs/dataset/common_criteria.py
+++ b/sec_certs/dataset/common_criteria.py
@@ -440,12 +440,18 @@ class CCDataset(Dataset, ComplexSerializableType):
     def _download_reports(self, fresh=True):
         self.reports_pdf_dir.mkdir(parents=True, exist_ok=True)
         certs_to_process = [x for x in self if x.state.report_is_ok_to_download(fresh)]
-        cert_processing.process_parallel(CommonCriteriaCert.download_pdf_report, certs_to_process, config.n_threads)
+        cert_processing.process_parallel(CommonCriteriaCert.download_pdf_report,
+                                         certs_to_process,
+                                         config.n_threads,
+                                         progress_bar_desc='Downloading reports')
 
     def _download_targets(self, fresh=True):
         self.targets_pdf_dir.mkdir(parents=True, exist_ok=True)
         certs_to_process = [x for x in self if x.state.report_is_ok_to_download(fresh)]
-        cert_processing.process_parallel(CommonCriteriaCert.download_pdf_target, certs_to_process, config.n_threads)
+        cert_processing.process_parallel(CommonCriteriaCert.download_pdf_target,
+                                         certs_to_process,
+                                         config.n_threads,
+                                         progress_bar_desc='Downloading targets')
 
     @serialize
     def download_all_pdfs(self, fresh: bool = True):
@@ -471,12 +477,18 @@ class CCDataset(Dataset, ComplexSerializableType):
     def _convert_reports_to_txt(self, fresh: bool = True):
         self.reports_txt_dir.mkdir(parents=True, exist_ok=True)
         certs_to_process = [x for x in self if x.state.report_is_ok_to_convert(fresh)]
-        cert_processing.process_parallel(CommonCriteriaCert.convert_report_pdf, certs_to_process, config.n_threads)
+        cert_processing.process_parallel(CommonCriteriaCert.convert_report_pdf,
+                                         certs_to_process,
+                                         config.n_threads,
+                                         progress_bar_desc='Converting reports to txt')
 
     def _convert_targets_to_txt(self, fresh: bool = True):
         self.targets_txt_dir.mkdir(parents=True, exist_ok=True)
         certs_to_process = [x for x in self if x.state.st_is_ok_to_convert(fresh)]
-        cert_processing.process_parallel(CommonCriteriaCert.convert_target_pdf, certs_to_process, config.n_threads)
+        cert_processing.process_parallel(CommonCriteriaCert.convert_target_pdf,
+                                         certs_to_process,
+                                         config.n_threads,
+                                         progress_bar_desc='Converting targets to txt')
 
     @serialize
     def convert_all_pdfs(self, fresh: bool = True):
@@ -506,12 +518,20 @@ class CCDataset(Dataset, ComplexSerializableType):
 
     def _extract_report_metadata(self, fresh: bool = True):
         certs_to_process = [x for x in self if x.state.report_is_ok_to_analyze(fresh)]
-        processed_certs = cert_processing.process_parallel(CommonCriteriaCert.extract_report_pdf_metadata, certs_to_process, config.n_threads, use_threading=False)
+        processed_certs = cert_processing.process_parallel(CommonCriteriaCert.extract_report_pdf_metadata,
+                                                           certs_to_process,
+                                                           config.n_threads,
+                                                           use_threading=False,
+                                                           progress_bar_desc='Extracting report metadata')
         self.update_with_certs(processed_certs)
 
     def _extract_targets_metadata(self, fresh: bool = True):
         certs_to_process = [x for x in self if x.state.st_is_ok_to_analyze(fresh)]
-        processed_certs = cert_processing.process_parallel(CommonCriteriaCert.extract_st_pdf_metadata, certs_to_process, config.n_threads, use_threading=False)
+        processed_certs = cert_processing.process_parallel(CommonCriteriaCert.extract_st_pdf_metadata,
+                                                           certs_to_process,
+                                                           config.n_threads,
+                                                           use_threading=False,
+                                                           progress_bar_desc='Extracting target metadata')
         self.update_with_certs(processed_certs)
 
     def extract_pdf_metadata(self, fresh: bool = True):
@@ -521,12 +541,20 @@ class CCDataset(Dataset, ComplexSerializableType):
 
     def _extract_report_frontpage(self, fresh: bool = True):
         certs_to_process = [x for x in self if x.state.report_is_ok_to_analyze(fresh)]
-        processed_certs = cert_processing.process_parallel(CommonCriteriaCert.extract_report_pdf_frontpage, certs_to_process, config.n_threads, use_threading=False)
+        processed_certs = cert_processing.process_parallel(CommonCriteriaCert.extract_report_pdf_frontpage,
+                                                           certs_to_process,
+                                                           config.n_threads,
+                                                           use_threading=False,
+                                                           progress_bar_desc='Extracting report frontpages')
         self.update_with_certs(processed_certs)
 
     def _extract_targets_frontpage(self, fresh: bool = True):
         certs_to_process = [x for x in self if x.state.st_is_ok_to_analyze(fresh)]
-        processed_certs = cert_processing.process_parallel(CommonCriteriaCert.extract_st_pdf_frontpage, certs_to_process, config.n_threads, use_threading=False)
+        processed_certs = cert_processing.process_parallel(CommonCriteriaCert.extract_st_pdf_frontpage,
+                                                           certs_to_process,
+                                                           config.n_threads,
+                                                           use_threading=False,
+                                                           progress_bar_desc='Extracting target frontpages')
         self.update_with_certs(processed_certs)
 
     def extract_pdf_frontpage(self, fresh: bool = True):
@@ -536,12 +564,20 @@ class CCDataset(Dataset, ComplexSerializableType):
 
     def _extract_report_keywords(self, fresh: bool = True):
         certs_to_process = [x for x in self if x.state.report_is_ok_to_analyze(fresh)]
-        processed_certs = cert_processing.process_parallel(CommonCriteriaCert.extract_report_pdf_keywords, certs_to_process, config.n_threads, use_threading=False)
+        processed_certs = cert_processing.process_parallel(CommonCriteriaCert.extract_report_pdf_keywords,
+                                                           certs_to_process,
+                                                           config.n_threads,
+                                                           use_threading=False,
+                                                           progress_bar_desc='Extracting report keywords')
         self.update_with_certs(processed_certs)
 
     def _extract_targets_keywords(self, fresh: bool = True):
         certs_to_process = [x for x in self if x.state.st_is_ok_to_analyze(fresh)]
-        processed_certs = cert_processing.process_parallel(CommonCriteriaCert.extract_st_pdf_keywords, certs_to_process, config.n_threads, use_threading=False)
+        processed_certs = cert_processing.process_parallel(CommonCriteriaCert.extract_st_pdf_keywords,
+                                                           certs_to_process,
+                                                           config.n_threads,
+                                                           use_threading=False,
+                                                           progress_bar_desc='Extracting target keywords')
         self.update_with_certs(processed_certs)
 
     def extract_pdf_keywords(self, fresh: bool = True):
@@ -628,8 +664,7 @@ class CCDataset(Dataset, ComplexSerializableType):
             return
 
         self._extract_data(fresh)
-        self.to_json()
-        # self._compute_heuristics()
+        self._compute_heuristics()
 
         self.state.certs_analyzed = True
 
@@ -717,7 +752,6 @@ class CCDataset(Dataset, ComplexSerializableType):
 
             for c in certs:
                 c.heuristics.verified_cpe_matches = cpes
-
 
     def process_maintenance_updates(self):
         maintained_certs: List[CommonCriteriaCert] = [x for x in self if x.maintainance_updates]

--- a/sec_certs/dataset/dataset.py
+++ b/sec_certs/dataset/dataset.py
@@ -43,6 +43,11 @@ class Dataset(ABC):
     def json_path(self) -> Path:
         return self.root_dir / (self.name + '.json')
 
+    def __contains__(self, item):
+        if not issubclass(type(item), Certificate):
+            return False
+        return item.dgst in self.certs
+
     def __iter__(self):
         yield from self.certs.values()
 

--- a/sec_certs/helpers.py
+++ b/sec_certs/helpers.py
@@ -204,8 +204,8 @@ def extract_pdf_metadata(filepath: Path):
             metadata['pdf_is_encrypted'] = pdf.getIsEncrypted()
             metadata['pdf_number_of_pages'] = pdf.getNumPages()
 
-            for key, val in pdf.getDocumentInfo().items():
-                metadata[key] = str(val)
+            pdf_document_info = pdf.getDocumentInfo()
+            metadata.update({key: str(val) for key, val in pdf_document_info.items()} if pdf_document_info else {})
 
     except Exception as e:
         error_msg = f'Failed to read metadata of {filepath}, error: {e}'

--- a/sec_certs/parallel_processing.py
+++ b/sec_certs/parallel_processing.py
@@ -5,7 +5,8 @@ import time
 
 
 def process_parallel(func: Callable, items: Iterable, max_workers: int, callback: Optional[Callable] = None,
-                     use_threading: bool = True, progress_bar: bool = True, unpack: bool = False):
+                     use_threading: bool = True, progress_bar: bool = True, unpack: bool = False,
+                     progress_bar_desc: Optional[str] = None):
     if use_threading is True:
         pool = ThreadPool(max_workers)
     else:
@@ -16,8 +17,8 @@ def process_parallel(func: Callable, items: Iterable, max_workers: int, callback
     else:
         results = [pool.apply_async(func, (*i, ), callback=callback) for i in items]
 
-    if progress_bar is True:
-        bar = tqdm(total=len(results))
+    if progress_bar is True and items:
+        bar = tqdm(total=len(results), desc=progress_bar_desc)
         while not all([x.ready() for x in results]):
             done_count = len([x.ready() for x in results if x.ready()])
             bar.update(done_count - bar.n)


### PR DESCRIPTION
This PR fixes several bugs during CC processing and implements some improvements (still a draft yet):
- Fixes broken deserialization of `CommonCriteriaCert`s  `InternalState`
- Fixes empty objects being returned by `getPdfInfo()`
- Fixes CC attempting to extract data from pdfs that were not downloaded successfully
- Change default method for multiprocessing in extraction from threading to processing
- Addds `in` operator for Dataset
- Certificates were not properly updated once processed
- Adds progress bar description

TBD some problems with frontpage parsing