### PR TITLE
get_certs_from_web() calls web_scan()

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Usage: fips-certs [OPTIONS] [new-run|all|build|convert|update|web-scan|pdf-
 
   Specify actions, sequence of one or more strings from the following list:
 
-  ["new-run", "all", "build", "convert", "update", "web-scan", "pdf-scan",
+  ["new-run", "all", "build", "convert", "update", "pdf-scan",
   "table-search", "analysis", "graphs"]
 
   If 'new-run' is specified, a new dataset will be created and all the
@@ -158,8 +158,6 @@ Usage: fips-certs [OPTIONS] [new-run|all|build|convert|update|web-scan|pdf-
   Analysis preparation:
 
       'convert'       Convert all downloaded PDFs.
-
-      'web-scan'      Perform a scan of downloaded CMVP webpages.
 
       'pdf-scan'      Perform a scan of downloaded CMVP security policy
       documents - Keyword extraction.

--- a/fips_cli.py
+++ b/fips_cli.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
     required=True,
     nargs=-1,
     type=click.Choice(
-        ["new-run", "all", "build", "convert", "update", "web-scan", "pdf-scan", "table-search", "analysis", "graphs"],
+        ["new-run", "all", "build", "convert", "update", "pdf-scan", "table-search", "analysis", "graphs"],
         case_sensitive=False,
     ),
 )
@@ -77,7 +77,7 @@ def main(
     """
     Specify actions, sequence of one or more strings from the following list:
 
-    ["new-run", "all", "build", "convert", "update", "web-scan", "pdf-scan", "table-search", "analysis", "graphs"]
+    ["new-run", "all", "build", "convert", "update", "pdf-scan", "table-search", "analysis", "graphs"]
 
     If 'new-run' is specified, a new dataset will be created and all the actions will be run.
     If 'all' is specified, dataset will be updated and all actions run against the dataset.
@@ -94,8 +94,6 @@ def main(
     Analysis preparation:
 
         'convert'       Convert all downloaded PDFs.
-
-        'web-scan'      Perform a scan of downloaded CMVP webpages.
 
         'pdf-scan'      Perform a scan of downloaded CMVP security policy documents - Keyword extraction.
 
@@ -153,7 +151,7 @@ def main(
         sys.exit(1)
 
     r_actions = (
-        {"convert", "web-scan", "pdf-scan", "table-search", "analysis", "graphs"}
+        {"convert", "pdf-scan", "table-search", "analysis", "graphs"}
         if "all" in actions or "new-run" in actions
         else set(actions)
     )
@@ -201,11 +199,8 @@ def main(
         dset.to_json(output)
 
     if 'update' in actions:
-        dset.get_certs_from_web(no_download_algorithms=no_download_algs, update=True)
-
-    if "web-scan" in actions or "update" in actions:
-        dset.web_scan(redo=redo_web_scan)
-
+        dset.get_certs_from_web(no_download_algorithms=no_download_algs, update=True, redo_web_scan=redo_web_scan)
+        
     if "convert" in actions or "update" in actions:
         dset.convert_all_pdfs()
 

--- a/sec_certs/dataset/fips.py
+++ b/sec_certs/dataset/fips.py
@@ -240,7 +240,18 @@ class FIPSDataset(Dataset, ComplexSerializableType):
         test: Optional[Path] = None,
         no_download_algorithms: bool = False,
         update: bool = False,
+        redo_web_scan = False
     ):
+        """Downloads HTML search pages, parses them, populates the dataset,
+        and performs `web-scan` - extracting information from CMVP pages for 
+        each certificate.
+
+        Args:
+            test (Optional[Path], optional): Path to dataset used in testing. Defaults to None.
+            no_download_algorithms (bool, optional): Whether to reuse CAVP algorithm dataset. Defaults to False.
+            update (bool, optional): Whether to update dataset with new entries. Defaults to False.
+            redo_web_scan (bool, optional): Whether to redo the `web-scan` functionality. Defaults to False.
+        """
         logger.info("Downloading required html files")
 
         self.web_dir.mkdir(parents=True, exist_ok=True)
@@ -259,6 +270,8 @@ class FIPSDataset(Dataset, ComplexSerializableType):
             logging.info(f'Finished parsing. Have algorithm dataset with {len(aset)} algorithm numbers.')
 
             self.algorithms = aset
+        
+        self.web_scan(redo=redo_web_scan)
 
     @serialize
     def deprocess(self):

--- a/tests/test_fips_oop.py
+++ b/tests/test_fips_oop.py
@@ -17,7 +17,6 @@ def _set_up_dataset(td, certs):
 
 def _set_up_dataset_for_full(td, certs):
     dataset = _set_up_dataset(td, certs)
-    dataset.web_scan()
     dataset.convert_all_pdfs()
     dataset.pdf_scan()
     dataset.extract_certs_from_tables(high_precision=True)


### PR DESCRIPTION
FIPS module's `get_certs_from_web()` now behaves in the same way as the one from CC module - it also performs scan of HTML files. Resolves #111.