### PR TITLE
Bump numpy to 1.21.4 to get rid of weird error.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ idna==2.10
 kiwisolver==1.3.1
 lxml==4.6.3
 matplotlib==3.3.2
-numpy==1.19.4
+numpy==1.21.4
 pandas==1.1.4
 pikepdf==2.10.0
 Pillow==8.3.2


### PR DESCRIPTION

The error is:
```
RuntimeError: module compiled against API version 0xe but this version of numpy is 0xd
```

According to [stack overflow](https://stackoverflow.com/questions/48054531/runtimeerror-module-compiled-against-api-version-0xc-but-this-version-of-numpy) it might be due to a version conflict between pandas and numpy.