### PR TITLE
Fix csv html parsing, closes #126

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ importlib-resources==5.1.2
 scikit-learn
 jsonschema==3.2.0
 packaging
+html5lib

--- a/sec_certs/dataset/common_criteria.py
+++ b/sec_certs/dataset/common_criteria.py
@@ -405,7 +405,7 @@ class CCDataset(Dataset, ComplexSerializableType):
         cat_dict = {x: y for (x, y) in zip(cc_table_ids, cc_categories)}
 
         with file.open('r') as handle:
-            soup = BeautifulSoup(handle, 'html.parser')
+            soup = BeautifulSoup(handle, 'html5lib')
 
         certs = {}
         for key, val in cat_dict.items():

--- a/sec_certs/dataset/fips.py
+++ b/sec_certs/dataset/fips.py
@@ -178,11 +178,13 @@ class FIPSDataset(Dataset, ComplexSerializableType):
     def _get_certificates_from_html(self, html_file: Path, update: bool = False) -> None:
         logger.info(f"Getting sample ids from {html_file}")
         with open(html_file, "r", encoding="utf-8") as handle:
-            html = BeautifulSoup(handle.read(), "html.parser")
+            soup = BeautifulSoup(handle.read(), 'html5lib')
 
-        table = [x for x in html.find(id="searchResultsTable").tbody.contents if x != "\n"]
-        for entry in table:
-            cert_id = entry.find("a").text
+        tables = soup.find_all('table', id='searchResultsTable')
+        assert len(tables) == 1
+
+        for row in tables[0].tbody.find_all('tr'):
+            cert_id = row.find("a").text
             if cert_id not in self.certs:
                 self.certs[cert_id] = None
 


### PR DESCRIPTION
The problems with parsing CSV metadata arose from two changes in CC web:
1. Links in CSV files now contain IP address instead of a hostname
2. Some weird encoding changes affected html files of commoncriteria.org

Following fixes were applied:
- In DataFrame obtained from CSV, map IP back to hostname
- Introduce more resiliant html parser, `html5lib`, creating new Python dependency (and slowing parsing little bit). 