### PR TITLE
Fix CCHeuristics attribute lookup.

### DIFF
--- a/sec_certs/dataset/common_criteria.py
+++ b/sec_certs/dataset/common_criteria.py
@@ -620,10 +620,10 @@ class CCDataset(Dataset, ComplexSerializableType):
         finder.fit(self.certs)
 
         for dgst in self.certs:
-            self.certs[dgst].CCHeuristics.directly_affecting = finder.get_directly_affecting(dgst)
-            self.certs[dgst].CCHeuristics.indirectly_affecting = finder.get_indirectly_affecting(dgst)
-            self.certs[dgst].CCHeuristics.directly_affected_by = finder.get_directly_affected_by(dgst)
-            self.certs[dgst].CCHeuristics.indirectly_affected_by = finder.get_indirectly_affected_by(dgst)
+            self.certs[dgst].heuristics.directly_affecting = finder.get_directly_affecting(dgst)
+            self.certs[dgst].heuristics.indirectly_affecting = finder.get_indirectly_affecting(dgst)
+            self.certs[dgst].heuristics.directly_affected_by = finder.get_directly_affected_by(dgst)
+            self.certs[dgst].heuristics.indirectly_affected_by = finder.get_indirectly_affected_by(dgst)
 
     @serialize
     def analyze_certificates(self, fresh: bool = True):

--- a/tests/data/test_cc_heuristics/dependency_dataset.json
+++ b/tests/data/test_cc_heuristics/dependency_dataset.json
@@ -320,7 +320,7 @@
                 }
             },
             "heuristics": {
-                "_type": "Heuristics",
+                "_type": "CCHeuristics",
                 "extracted_versions": [
                     "10.1.5"
                 ],
@@ -671,7 +671,7 @@
                 }
             },
             "heuristics": {
-                "_type": "Heuristics",
+                "_type": "CCHeuristics",
                 "extracted_versions": [
                     "9.1.6"
                 ],
@@ -1023,7 +1023,7 @@
                 }
             },
             "heuristics": {
-                "_type": "Heuristics",
+                "_type": "CCHeuristics",
                 "extracted_versions": [
                     "8.1.10"
                 ],

--- a/tests/test_cc_heuristics.py
+++ b/tests/test_cc_heuristics.py
@@ -155,7 +155,7 @@ class TestCommonCriteriaHeuristics(TestCase):
                 test_cert = cert
                 break
 
-        self.assertEqual(test_cert.CCHeuristics.directly_affected_by, ["BSI-DSZ-CC-0370-2006"])
-        self.assertEqual(test_cert.CCHeuristics.indirectly_affected_by, {"BSI-DSZ-CC-0370-2006", "BSI-DSZ-CC-0517-2009"})
-        self.assertEqual(test_cert.CCHeuristics.directly_affecting, {"BSI-DSZ-CC-0268-2005"})
-        self.assertEqual(test_cert.CCHeuristics.indirectly_affecting, {"BSI-DSZ-CC-0268-2005"})
+        self.assertEqual(test_cert.heuristics.directly_affected_by, ["BSI-DSZ-CC-0370-2006"])
+        self.assertEqual(test_cert.heuristics.indirectly_affected_by, {"BSI-DSZ-CC-0370-2006", "BSI-DSZ-CC-0517-2009"})
+        self.assertEqual(test_cert.heuristics.directly_affecting, {"BSI-DSZ-CC-0268-2005"})
+        self.assertEqual(test_cert.heuristics.indirectly_affecting, {"BSI-DSZ-CC-0268-2005"})


### PR DESCRIPTION
This however fails the tests locally with:

```
self = <tests.test_cc_heuristics.TestCommonCriteriaHeuristics testMethod=test_dependency_dataset>

    def test_dependency_dataset(self):
        dependency_dataset = CCDataset.from_json(self.data_dir_path / 'dependency_dataset.json')
        dependency_dataset._compute_dependencies()
        test_cert = None
    
        for cert in dependency_dataset:
            if cert.pdf_data.cert_id == "BSI-DSZ-CC-0370-2006":
                test_cert = cert
                break
    
>       self.assertEqual(test_cert.heuristics.directly_affected_by, ["BSI-DSZ-CC-0370-2006"])
E       AssertionError: Lists differ: ['BSI-DSZ-CC-0517-2009'] != ['BSI-DSZ-CC-0370-2006']
E       
E       First differing element 0:
E       'BSI-DSZ-CC-0517-2009'
E       'BSI-DSZ-CC-0370-2006'
E       
E       - ['BSI-DSZ-CC-0517-2009']
E       ?               ^^     ^
E       
E       + ['BSI-DSZ-CC-0370-2006']
E       ?               ^ +    ^

tests/test_cc_heuristics.py:158: AssertionError
```