### PR TITLE
Use dgst field for FIPS instead of cert_id.

### DIFF
--- a/sec_certs/helpers.py
+++ b/sec_certs/helpers.py
@@ -71,6 +71,10 @@ def download_parallel(items: Sequence[Tuple[str, Path]], num_threads: int) -> Se
     return responses
 
 
+def fips_dgst(cert_id: Union[int, str]):
+    return get_first_16_bytes_sha256(str(cert_id))
+
+
 def get_first_16_bytes_sha256(string: str) -> str:
     return hashlib.sha256(string.encode("utf-8")).hexdigest()[:16]
 

--- a/sec_certs/helpers.py
+++ b/sec_certs/helpers.py
@@ -71,7 +71,7 @@ def download_parallel(items: Sequence[Tuple[str, Path]], num_threads: int) -> Se
     return responses
 
 
-def fips_dgst(cert_id: Union[int, str]):
+def fips_dgst(cert_id: Union[int, str]) -> str:
     return get_first_16_bytes_sha256(str(cert_id))
 
 

--- a/sec_certs/sample/fips.py
+++ b/sec_certs/sample/fips.py
@@ -16,7 +16,7 @@ from sec_certs.cert_rules import REGEXEC_SEP, fips_common_rules, fips_rules
 from sec_certs.config.configuration import config
 from sec_certs.constants import LINE_SEPARATOR
 from sec_certs.dataset.cpe import CPEDataset
-from sec_certs.helpers import load_cert_file, normalize_match_string, save_modified_cert_file
+from sec_certs.helpers import fips_dgst, load_cert_file, normalize_match_string, save_modified_cert_file
 from sec_certs.model.cpe_matching import CPEClassifier
 from sec_certs.sample.certificate import Certificate, logger
 from sec_certs.sample.cpe import CPE
@@ -193,7 +193,7 @@ class FIPSCertificate(Certificate, ComplexSerializableType):
 
     @property
     def dgst(self) -> str:
-        return self.cert_id
+        return fips_dgst(self.cert_id)
 
     @property
     def label_studio_title(self):
@@ -219,7 +219,7 @@ class FIPSCertificate(Certificate, ComplexSerializableType):
 
     def __init__(
         self,
-        cert_id: str,
+        cert_id: int,
         web_scan: "FIPSCertificate.WebScan",
         pdf_scan: "FIPSCertificate.PdfScan",
         heuristics: "FIPSCertificate.FIPSHeuristics",
@@ -440,7 +440,7 @@ class FIPSCertificate(Certificate, ComplexSerializableType):
         }
         if not initialized:
             items_found = FIPSCertificate.initialize_dictionary()
-            items_found["cert_id"] = file.stem
+            items_found["cert_id"] = int(file.stem)
         else:
             items_found = initialized.web_scan.__dict__
             items_found["cert_id"] = initialized.cert_id
@@ -454,7 +454,7 @@ class FIPSCertificate(Certificate, ComplexSerializableType):
 
         if redo:
             items_found = FIPSCertificate.initialize_dictionary()
-            items_found["cert_id"] = file.stem
+            items_found["cert_id"] = int(file.stem)
 
         text = helpers.load_cert_html_file(file)
         soup = BeautifulSoup(text, "html.parser")

--- a/tests/test_fips_oop.py
+++ b/tests/test_fips_oop.py
@@ -102,6 +102,13 @@ class TestFipsOOP(TestCase):
     def setUpClass(cls) -> None:
         config.load(cls.data_dir.parent / "settings_test.yaml")
 
+    def test_regress_125(self):
+        with TemporaryDirectory() as tmp_dir:
+            dst = _set_up_dataset(tmp_dir, ["3493", "3495"])
+            self.assertEqual(set(dst.certs), {fips_dgst("3493"), fips_dgst("3495")})
+            self.assertIsInstance(dst.certs[fips_dgst("3493")].cert_id, int)
+            self.assertEqual(dst.certs[fips_dgst("3493")].cert_id, 3493)
+
     def test_size(self):
         for certs in self.certs_to_parse.values():
             with TemporaryDirectory() as tmp_dir:

--- a/tests/test_fips_oop.py
+++ b/tests/test_fips_oop.py
@@ -8,6 +8,7 @@ import tests.data.test_fips_oop
 from sec_certs.config.configuration import config
 from sec_certs.dataset.fips import FIPSDataset
 from sec_certs.dataset.fips_algorithm import FIPSAlgorithmDataset
+from sec_certs.helpers import fips_dgst
 from tests.fips_test_utils import generate_html
 
 
@@ -112,84 +113,88 @@ class TestFipsOOP(TestCase):
         with TemporaryDirectory() as tmp_dir:
             dataset = _set_up_dataset_for_full(tmp_dir, certs, self.cpe_dset_path, self.cve_dset_path)
 
-            self.assertEqual(set(dataset.certs["3095"].heuristics.connections), {"3093", "3096", "3094"})
-            self.assertEqual(set(dataset.certs["3651"].heuristics.connections), {"3615"})
-            self.assertEqual(set(dataset.certs["3093"].heuristics.connections), {"3090", "3091"})
-            self.assertEqual(set(dataset.certs["3090"].heuristics.connections), {"3089"})
+            self.assertEqual(set(dataset.certs[fips_dgst("3095")].heuristics.connections), {"3093", "3096", "3094"})
+            self.assertEqual(set(dataset.certs[fips_dgst("3651")].heuristics.connections), {"3615"})
+            self.assertEqual(set(dataset.certs[fips_dgst("3093")].heuristics.connections), {"3090", "3091"})
+            self.assertEqual(set(dataset.certs[fips_dgst("3090")].heuristics.connections), {"3089"})
             self.assertEqual(
-                set(dataset.certs["3197"].heuristics.connections), {x for x in ["3195", "3096", "3196", "3644", "3651"]}
+                set(dataset.certs[fips_dgst("3197")].heuristics.connections),
+                {x for x in ["3195", "3096", "3196", "3644", "3651"]},
             )
             self.assertEqual(
-                set(dataset.certs["3196"].heuristics.connections), {x for x in ["3194", "3091", "3480", "3615"]}
+                set(dataset.certs[fips_dgst("3196")].heuristics.connections),
+                {x for x in ["3194", "3091", "3480", "3615"]},
             )
-            self.assertEqual(set(dataset.certs["3089"].heuristics.connections), set())
-            self.assertEqual(set(dataset.certs["3195"].heuristics.connections), {"3194", "3091", "3480"})
-            self.assertEqual(set(dataset.certs["3480"].heuristics.connections), {"3089"})
-            self.assertEqual(set(dataset.certs["3615"].heuristics.connections), {"3089"})
-            self.assertEqual(set(dataset.certs["3194"].heuristics.connections), {"3089"})
-            self.assertEqual(set(dataset.certs["3091"].heuristics.connections), {"3089"})
-            self.assertEqual(set(dataset.certs["3690"].heuristics.connections), {"3644", "3196", "3651"})
-            self.assertEqual(set(dataset.certs["3644"].heuristics.connections), {"3615"})
-            self.assertEqual(set(dataset.certs["3527"].heuristics.connections), {"3090", "3091"})
-            self.assertEqual(set(dataset.certs["3094"].heuristics.connections), {"3090", "3091"})
-            self.assertEqual(set(dataset.certs["3544"].heuristics.connections), {"3093", "3096", "3527"})
-            self.assertEqual(set(dataset.certs["3096"].heuristics.connections), {"3090", "3194", "3091", "3480"})
+            self.assertEqual(set(dataset.certs[fips_dgst("3089")].heuristics.connections), set())
+            self.assertEqual(set(dataset.certs[fips_dgst("3195")].heuristics.connections), {"3194", "3091", "3480"})
+            self.assertEqual(set(dataset.certs[fips_dgst("3480")].heuristics.connections), {"3089"})
+            self.assertEqual(set(dataset.certs[fips_dgst("3615")].heuristics.connections), {"3089"})
+            self.assertEqual(set(dataset.certs[fips_dgst("3194")].heuristics.connections), {"3089"})
+            self.assertEqual(set(dataset.certs[fips_dgst("3091")].heuristics.connections), {"3089"})
+            self.assertEqual(set(dataset.certs[fips_dgst("3690")].heuristics.connections), {"3644", "3196", "3651"})
+            self.assertEqual(set(dataset.certs[fips_dgst("3644")].heuristics.connections), {"3615"})
+            self.assertEqual(set(dataset.certs[fips_dgst("3527")].heuristics.connections), {"3090", "3091"})
+            self.assertEqual(set(dataset.certs[fips_dgst("3094")].heuristics.connections), {"3090", "3091"})
+            self.assertEqual(set(dataset.certs[fips_dgst("3544")].heuristics.connections), {"3093", "3096", "3527"})
             self.assertEqual(
-                set(dataset.certs["3092"].heuristics.connections), {"3093", "3195", "3096", "3644", "3651"}
+                set(dataset.certs[fips_dgst("3096")].heuristics.connections), {"3090", "3194", "3091", "3480"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3092")].heuristics.connections), {"3093", "3195", "3096", "3644", "3651"}
             )
 
     def test_connections_redhat(self):
         certs = self.certs_to_parse["redhat"]
         with TemporaryDirectory() as tmp_dir:
             dataset = _set_up_dataset_for_full(tmp_dir, certs, self.cpe_dset_path, self.cve_dset_path)
-            self.assertEqual(set(dataset.certs["2630"].heuristics.connections), {"2441"})
-            self.assertEqual(set(dataset.certs["2633"].heuristics.connections), {"2441"})
-            self.assertEqual(set(dataset.certs["2441"].heuristics.connections), set())
-            self.assertEqual(set(dataset.certs["2997"].heuristics.connections), {"2711"})
-            self.assertEqual(set(dataset.certs["2446"].heuristics.connections), {"2441"})
-            self.assertEqual(set(dataset.certs["2447"].heuristics.connections), {"2441"})
-            self.assertEqual(set(dataset.certs["3733"].heuristics.connections), {"2441"})
-            self.assertEqual(set(dataset.certs["2441"].heuristics.connections), set())
-            self.assertEqual(set(dataset.certs["2711"].heuristics.connections), set())
-            self.assertEqual(set(dataset.certs["2908"].heuristics.connections), {"2711"})
-            self.assertEqual(set(dataset.certs["3613"].heuristics.connections), {"2997"})
-            self.assertEqual(set(dataset.certs["2721"].heuristics.connections), {"2441", "2711"})
-            self.assertEqual(set(dataset.certs["2798"].heuristics.connections), {"2721", "2711"})
-            self.assertEqual(set(dataset.certs["2711"].heuristics.connections), set())
-            self.assertEqual(set(dataset.certs["2997"].heuristics.connections), {"2711"})
-            self.assertEqual(set(dataset.certs["2742"].heuristics.connections), {"2721", "2711"})
-            self.assertEqual(set(dataset.certs["2721"].heuristics.connections), {"2441", "2711"})
+            self.assertEqual(set(dataset.certs[fips_dgst("2630")].heuristics.connections), {"2441"})
+            self.assertEqual(set(dataset.certs[fips_dgst("2633")].heuristics.connections), {"2441"})
+            self.assertEqual(set(dataset.certs[fips_dgst("2441")].heuristics.connections), set())
+            self.assertEqual(set(dataset.certs[fips_dgst("2997")].heuristics.connections), {"2711"})
+            self.assertEqual(set(dataset.certs[fips_dgst("2446")].heuristics.connections), {"2441"})
+            self.assertEqual(set(dataset.certs[fips_dgst("2447")].heuristics.connections), {"2441"})
+            self.assertEqual(set(dataset.certs[fips_dgst("3733")].heuristics.connections), {"2441"})
+            self.assertEqual(set(dataset.certs[fips_dgst("2441")].heuristics.connections), set())
+            self.assertEqual(set(dataset.certs[fips_dgst("2711")].heuristics.connections), set())
+            self.assertEqual(set(dataset.certs[fips_dgst("2908")].heuristics.connections), {"2711"})
+            self.assertEqual(set(dataset.certs[fips_dgst("3613")].heuristics.connections), {"2997"})
+            self.assertEqual(set(dataset.certs[fips_dgst("2721")].heuristics.connections), {"2441", "2711"})
+            self.assertEqual(set(dataset.certs[fips_dgst("2798")].heuristics.connections), {"2721", "2711"})
+            self.assertEqual(set(dataset.certs[fips_dgst("2711")].heuristics.connections), set())
+            self.assertEqual(set(dataset.certs[fips_dgst("2997")].heuristics.connections), {"2711"})
+            self.assertEqual(set(dataset.certs[fips_dgst("2742")].heuristics.connections), {"2721", "2711"})
+            self.assertEqual(set(dataset.certs[fips_dgst("2721")].heuristics.connections), {"2441", "2711"})
 
     def test_docusign_chunk(self):
         certs = self.certs_to_parse["docusign"]
         with TemporaryDirectory() as tmp_dir:
             dataset = _set_up_dataset_for_full(tmp_dir, certs, self.cpe_dset_path, self.cve_dset_path)
-            self.assertEqual(set(dataset.certs["3850"].heuristics.connections), {"3518", "1883"})
-            self.assertEqual(set(dataset.certs["2779"].heuristics.connections), {"1883"})
-            self.assertEqual(set(dataset.certs["2860"].heuristics.connections), {"1883"})
-            self.assertEqual(set(dataset.certs["2665"].heuristics.connections), {"1883"})
-            self.assertEqual(set(dataset.certs["1883"].heuristics.connections), set())
-            self.assertEqual(set(dataset.certs["3518"].heuristics.connections), {"1883"})
-            self.assertEqual(set(dataset.certs["3141"].heuristics.connections), {"1883"})
-            self.assertEqual(set(dataset.certs["2590"].heuristics.connections), {"1883"})
+            self.assertEqual(set(dataset.certs[fips_dgst("3850")].heuristics.connections), {"3518", "1883"})
+            self.assertEqual(set(dataset.certs[fips_dgst("2779")].heuristics.connections), {"1883"})
+            self.assertEqual(set(dataset.certs[fips_dgst("2860")].heuristics.connections), {"1883"})
+            self.assertEqual(set(dataset.certs[fips_dgst("2665")].heuristics.connections), {"1883"})
+            self.assertEqual(set(dataset.certs[fips_dgst("1883")].heuristics.connections), set())
+            self.assertEqual(set(dataset.certs[fips_dgst("3518")].heuristics.connections), {"1883"})
+            self.assertEqual(set(dataset.certs[fips_dgst("3141")].heuristics.connections), {"1883"})
+            self.assertEqual(set(dataset.certs[fips_dgst("2590")].heuristics.connections), {"1883"})
 
     def test_openssl_chunk(self):
         certs = self.certs_to_parse["referencing_openssl"]
         with TemporaryDirectory() as tmp_dir:
             dataset = _set_up_dataset_for_full(tmp_dir, certs, self.cpe_dset_path, self.cve_dset_path)
-            self.assertEqual(set(dataset.certs["3493"].heuristics.connections), {"2398"})
-            self.assertEqual(set(dataset.certs["3495"].heuristics.connections), {"2398"})
-            self.assertEqual(set(dataset.certs["3711"].heuristics.connections), {"3220"})
-            self.assertEqual(set(dataset.certs["3176"].heuristics.connections), {"2398"})
-            self.assertEqual(set(dataset.certs["3488"].heuristics.connections), {"2398"})
-            self.assertEqual(set(dataset.certs["3126"].heuristics.connections), {"3126", "2398"})
-            self.assertEqual(set(dataset.certs["3269"].heuristics.connections), {"3269", "3220"})
-            self.assertEqual(set(dataset.certs["3524"].heuristics.connections), {"3220"})
-            self.assertEqual(set(dataset.certs["3220"].heuristics.connections), {"3220", "2398"})
-            self.assertEqual(set(dataset.certs["2398"].heuristics.connections), set())
-            self.assertEqual(set(dataset.certs["3543"].heuristics.connections), {"2398"})
-            self.assertEqual(set(dataset.certs["2676"].heuristics.connections), {"2398"})
-            self.assertEqual(set(dataset.certs["3313"].heuristics.connections), {"3313", "3220"})
-            self.assertEqual(set(dataset.certs["3363"].heuristics.connections), set())
-            self.assertEqual(set(dataset.certs["3608"].heuristics.connections), {"2398"})
-            self.assertEqual(set(dataset.certs["3158"].heuristics.connections), {"2398"})
+            self.assertEqual(set(dataset.certs[fips_dgst("3493")].heuristics.connections), {"2398"})
+            self.assertEqual(set(dataset.certs[fips_dgst("3495")].heuristics.connections), {"2398"})
+            self.assertEqual(set(dataset.certs[fips_dgst("3711")].heuristics.connections), {"3220"})
+            self.assertEqual(set(dataset.certs[fips_dgst("3176")].heuristics.connections), {"2398"})
+            self.assertEqual(set(dataset.certs[fips_dgst("3488")].heuristics.connections), {"2398"})
+            self.assertEqual(set(dataset.certs[fips_dgst("3126")].heuristics.connections), {"3126", "2398"})
+            self.assertEqual(set(dataset.certs[fips_dgst("3269")].heuristics.connections), {"3269", "3220"})
+            self.assertEqual(set(dataset.certs[fips_dgst("3524")].heuristics.connections), {"3220"})
+            self.assertEqual(set(dataset.certs[fips_dgst("3220")].heuristics.connections), {"3220", "2398"})
+            self.assertEqual(set(dataset.certs[fips_dgst("2398")].heuristics.connections), set())
+            self.assertEqual(set(dataset.certs[fips_dgst("3543")].heuristics.connections), {"2398"})
+            self.assertEqual(set(dataset.certs[fips_dgst("2676")].heuristics.connections), {"2398"})
+            self.assertEqual(set(dataset.certs[fips_dgst("3313")].heuristics.connections), {"3313", "3220"})
+            self.assertEqual(set(dataset.certs[fips_dgst("3363")].heuristics.connections), set())
+            self.assertEqual(set(dataset.certs[fips_dgst("3608")].heuristics.connections), {"2398"})
+            self.assertEqual(set(dataset.certs[fips_dgst("3158")].heuristics.connections), {"2398"})


### PR DESCRIPTION
This tries to fix #125 and unify the handling of `cert.dgst` among the two datasets. Tests pass, however it may not be complete as we have only about 70% coverage.