### PR TITLE
Fix from_dict ordering issue.

### DIFF
--- a/sec_certs/sample/certificate.py
+++ b/sec_certs/sample/certificate.py
@@ -51,7 +51,7 @@ class Certificate(ABC, ComplexSerializableType):
     @classmethod
     def from_dict(cls: Type[T], dct: dict) -> T:
         dct.pop("dgst")
-        return cls(*(tuple(dct.values())))
+        return cls(**dct)
 
     def to_json(self, output_path: Optional[Union[str, Path]] = None):
         if output_path is None:

--- a/sec_certs/serialization/json.py
+++ b/sec_certs/serialization/json.py
@@ -24,7 +24,7 @@ class ComplexSerializableType:
     @classmethod
     def from_dict(cls, dct: Dict):
         try:
-            return cls(*(tuple(dct.values())))
+            return cls(**dct)
         except TypeError as e:
             raise TypeError(f"Dict: {dct} on {cls.__mro__}") from e
 

--- a/tests/data/test_cc_heuristics/auxillary_datasets/cve_dataset.json
+++ b/tests/data/test_cc_heuristics/auxillary_datasets/cve_dataset.json
@@ -17,10 +17,10 @@
                 "_type": "Impact",
                 "base_score": 5.3,
                 "severity": "MEDIUM",
-                "explotability_score": 3.9,
+                "exploitability_score": 3.9,
                 "impact_score": 1.4
             },
-            "publishedDate": "2021-05-26T04:15Z"
+            "published_date": "2021-05-26T04:15Z"
         },
         "CVE-2019-4513": {
             "_type": "CVE",
@@ -38,10 +38,10 @@
                 "_type": "Impact",
                 "base_score": 8.2,
                 "severity": "HIGH",
-                "explotability_score": 3.9,
+                "exploitability_score": 3.9,
                 "impact_score": 4.2
             },
-            "publishedDate": "2000-05-26T04:15Z"
+            "published_date": "2000-05-26T04:15Z"
         }
     }
 }

--- a/tests/data/test_cc_heuristics/dependency_dataset.json
+++ b/tests/data/test_cc_heuristics/dependency_dataset.json
@@ -325,7 +325,6 @@
                     "10.1.5"
                 ],
                 "cpe_matches": null,
-                "labeled": false,
                 "verified_cpe_matches": null,
                 "related_cves": null,
                 "cert_lab": [
@@ -676,7 +675,6 @@
                     "9.1.6"
                 ],
                 "cpe_matches": null,
-                "labeled": false,
                 "verified_cpe_matches": null,
                 "related_cves": null,
                 "cert_lab": [
@@ -1028,7 +1026,6 @@
                     "8.1.10"
                 ],
                 "cpe_matches": null,
-                "labeled": false,
                 "verified_cpe_matches": null,
                 "related_cves": null,
                 "cert_lab": [

--- a/tests/data/test_cc_oop/fictional_cert.json
+++ b/tests/data/test_cc_oop/fictional_cert.json
@@ -11,9 +11,6 @@
     ],
     "not_valid_before": "1900-01-02",
     "not_valid_after": "1900-01-03",
-    "report_link": "https://path.to/report/link",
-    "st_link": "https://path.to/st/link",
-    "cert_link": "https://path.to/cert/link",
     "manufacturer_web": "https://path.to/manufacturer/web",
     "protection_profiles": [
         {
@@ -63,5 +60,8 @@
         "indirectly_affected_by": null,
         "directly_affecting": null,
         "indirectly_affecting": null
-    }
+    },
+    "report_link": "https://path.to/report/link",
+    "st_link": "https://path.to/st/link",
+    "cert_link": "https://path.to/cert/link"
 }

--- a/tests/test_cc_oop.py
+++ b/tests/test_cc_oop.py
@@ -162,7 +162,7 @@ class TestCommonCriteriaOOP(TestCase):
                 out = json.load(f)
             with open(self.test_data_dir / "fictional_cert.json") as f:
                 template = json.load(f)
-            assert out == template
+            self.assertEqual(out, template, "Serialized cert differs from cert json template.")
 
     def test_dataset_to_json(self):
         with NamedTemporaryFile("w") as tmp:

--- a/tests/test_cc_oop.py
+++ b/tests/test_cc_oop.py
@@ -1,4 +1,5 @@
 import filecmp
+import json
 import os
 import shutil
 import tempfile
@@ -157,10 +158,11 @@ class TestCommonCriteriaOOP(TestCase):
     def test_cert_to_json(self):
         with NamedTemporaryFile("w") as tmp:
             self.fictional_cert.to_json(tmp.name)
-            self.assertTrue(
-                filecmp.cmp(self.test_data_dir / "fictional_cert.json", tmp.name),
-                "The sample serialized to json differs from a template.",
-            )
+            with open(tmp.name) as f:
+                out = json.load(f)
+            with open(self.test_data_dir / "fictional_cert.json") as f:
+                template = json.load(f)
+            assert out == template
 
     def test_dataset_to_json(self):
         with NamedTemporaryFile("w") as tmp:


### PR DESCRIPTION
This moves from passing the dict data to the class as a tuple and instead uses `**kwargs`. Some fixes to the stored test data were also necessary to fix mistypes and a badly named key. The tes `fictional_cert` was changed to detect if this issue regresses.