### PR TITLE
release action only on publishing a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,7 @@
 name: Release with GitHub, PyPi, DockerHub
-on: release
+on: 
+  release:
+    types: [published]
 
 jobs:
   pypi_release:
@@ -22,7 +24,7 @@ jobs:
         with:
           user: ${{ secrets.PYPI_USERNAME }}
           password: ${{ secrets.PYPI_PASSWORD }}
-  docker:
+  docker_release:
     name: Release on dockerhub
     runs-on: ubuntu-latest
     if: github.repository == 'crocs-muni/sec-certs'  


### PR DESCRIPTION
It turns out that`on: release` GitHub actions are triggered multiple times during the release life cycle. See more in https://github.community/t/action-run-being-trigger-multiple-times/16144. 

This PR specifies that the release action is to be run only on *publishing* a release.