### PR TITLE
[WIP] Unify handling of references in CC & FIPS.

### DIFF
--- a/sec_certs/dataset/common_criteria.py
+++ b/sec_certs/dataset/common_criteria.py
@@ -699,9 +699,11 @@ class CCDataset(Dataset[CommonCriteriaCert], ComplexSerializableType):
                 if not kws:
                     return set()
                 return set(kws["rules_cert_id"].keys())
+
             return func
+
         finder = DependencyFinder()
-        finder.fit(self.certs, lambda cert: cert.pdf_data.processed_cert_id, ref_lookup("report_keywords"))
+        finder.fit(self.certs, lambda cert: cert.pdf_data.processed_cert_id, ref_lookup("report_keywords"))  # type: ignore
 
         for dgst in self.certs:
             self.certs[dgst].heuristics.directly_referencing = finder.get_directly_referencing(dgst)

--- a/sec_certs/dataset/common_criteria.py
+++ b/sec_certs/dataset/common_criteria.py
@@ -697,10 +697,10 @@ class CCDataset(Dataset[CommonCriteriaCert], ComplexSerializableType):
         finder.fit(self.certs)
 
         for dgst in self.certs:
-            self.certs[dgst].heuristics.directly_affecting = finder.get_directly_affecting(dgst)
-            self.certs[dgst].heuristics.indirectly_affecting = finder.get_indirectly_affecting(dgst)
-            self.certs[dgst].heuristics.directly_affected_by = finder.get_directly_affected_by(dgst)
-            self.certs[dgst].heuristics.indirectly_affected_by = finder.get_indirectly_affected_by(dgst)
+            self.certs[dgst].heuristics.directly_referencing = finder.get_directly_referencing(dgst)
+            self.certs[dgst].heuristics.indirectly_referencing = finder.get_indirectly_referencing(dgst)
+            self.certs[dgst].heuristics.directly_referenced_by = finder.get_directly_referenced_by(dgst)
+            self.certs[dgst].heuristics.indirectly_referenced_by = finder.get_indirectly_referenced_by(dgst)
 
     @serialize
     def analyze_certificates(self, fresh: bool = True) -> None:

--- a/sec_certs/helpers.py
+++ b/sec_certs/helpers.py
@@ -698,7 +698,7 @@ def search_only_headers_nscib(filepath: Path):  # noqa: C901
             items_found[constants.TAG_CERT_LAB] = cert_lab
 
     except Exception as e:
-        error_msg = f"Failed to parse BSI headers from frontpage: {filepath}; {e}"
+        error_msg = f"Failed to parse NSCIB headers from frontpage: {filepath}; {e}"
         logger.error(error_msg)
         return error_msg, None
 
@@ -749,7 +749,7 @@ def search_only_headers_niap(filepath: Path):
             items_found[constants.TAG_CERT_LAB] = "US NIAP"
 
     except Exception as e:
-        error_msg = f"Failed to parse BSI headers from frontpage: {filepath}; {e}"
+        error_msg = f"Failed to parse NIAP headers from frontpage: {filepath}; {e}"
         logger.error(error_msg)
         return error_msg, None
 
@@ -822,7 +822,7 @@ def search_only_headers_canada(filepath: Path):  # noqa: C901
             items_found[constants.TAG_CERT_LAB] = "CANADA"
 
     except Exception as e:
-        error_msg = f"Failed to parse BSI headers from frontpage: {filepath}; {e}"
+        error_msg = f"Failed to parse Canada headers from frontpage: {filepath}; {e}"
         logger.error(error_msg)
         return error_msg, None
 

--- a/sec_certs/model/dependency_finder.py
+++ b/sec_certs/model/dependency_finder.py
@@ -1,6 +1,8 @@
+from dataclasses import dataclass, field
 from typing import Callable, Dict, Optional, Set, Tuple
 
 from sec_certs.sample.certificate import Certificate
+from sec_certs.serialization.json import ComplexSerializableType
 
 Certificates = Dict[str, Certificate]
 ReferencedByDirect = Dict[str, Set[str]]
@@ -8,6 +10,14 @@ ReferencedByIndirect = Dict[str, Set[str]]
 Dependencies = Dict[str, Dict[str, Optional[Set[str]]]]
 IDLookupFunc = Callable[[Certificate], str]
 ReferenceLookupFunc = Callable[[Certificate], Set[str]]
+
+
+@dataclass
+class References(ComplexSerializableType):
+    directly_referenced_by: Optional[Set[str]] = field(default=None)
+    indirectly_referenced_by: Optional[Set[str]] = field(default=None)
+    directly_referencing: Optional[Set[str]] = field(default=None)
+    indirectly_referencing: Optional[Set[str]] = field(default=None)
 
 
 class DependencyFinder:
@@ -138,3 +148,11 @@ class DependencyFinder:
     def get_indirectly_referencing(self, dgst: str) -> Optional[Set[str]]:
         res = self.dependencies[dgst].get("indirectly_referencing", None)
         return set(res) if res else None
+
+    def get_references(self, dgst: str) -> References:
+        return References(
+            self.get_directly_referenced_by(dgst),
+            self.get_indirectly_referenced_by(dgst),
+            self.get_directly_referencing(dgst),
+            self.get_indirectly_referencing(dgst),
+        )

--- a/sec_certs/model/dependency_finder.py
+++ b/sec_certs/model/dependency_finder.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Set, Tuple, Callable
+from typing import Callable, Dict, Optional, Set, Tuple
 
 from sec_certs.sample.certificate import Certificate
 
@@ -40,7 +40,9 @@ class DependencyFinder:
                         new_change_detected = True if newly_discovered_references else False
 
     @staticmethod
-    def _build_cert_references(certificates: Certificates, id_func: IDLookupFunc, ref_lookup_func: ReferenceLookupFunc) -> Tuple[ReferencedByDirect, ReferencedByIndirect]:
+    def _build_cert_references(
+        certificates: Certificates, id_func: IDLookupFunc, ref_lookup_func: ReferenceLookupFunc
+    ) -> Tuple[ReferencedByDirect, ReferencedByIndirect]:
         referenced_by: ReferencedByDirect = {}
 
         for cert_obj in certificates.values():
@@ -94,7 +96,9 @@ class DependencyFinder:
         return referenced_by_indirect.get(cert, None)
 
     def fit(self, certificates: Certificates, id_func: IDLookupFunc, ref_lookup_func: ReferenceLookupFunc) -> None:
-        referenced_by_direct, referenced_by_indirect = DependencyFinder._build_cert_references(certificates, id_func, ref_lookup_func)
+        referenced_by_direct, referenced_by_indirect = DependencyFinder._build_cert_references(
+            certificates, id_func, ref_lookup_func
+        )
 
         for dgst in certificates:
             cert_id = id_func(certificates[dgst])

--- a/sec_certs/model/dependency_finder.py
+++ b/sec_certs/model/dependency_finder.py
@@ -65,7 +65,7 @@ class DependencyFinder:
         return referenced_by, referenced_by_indirect
 
     @staticmethod
-    def _get_affecting_directly(cert: str, referenced_by_direct: ReferencedByDirect) -> Optional[Set[str]]:
+    def _get_referencing_directly(cert: str, referenced_by_direct: ReferencedByDirect) -> Optional[Set[str]]:
         filter_direct = set()
 
         for cert_id in referenced_by_direct:
@@ -75,7 +75,7 @@ class DependencyFinder:
         return filter_direct if filter_direct else None
 
     @staticmethod
-    def _get_affecting_indirectly(cert: str, referenced_by_indirect: ReferencedByIndirect) -> Optional[Set[str]]:
+    def _get_referencing_indirectly(cert: str, referenced_by_indirect: ReferencedByIndirect) -> Optional[Set[str]]:
         filter_indirect = set()
 
         for cert_id in referenced_by_indirect:
@@ -85,11 +85,11 @@ class DependencyFinder:
         return filter_indirect if filter_indirect else None
 
     @staticmethod
-    def _get_affected_directly(cert: str, referenced_by_direct: ReferencedByDirect) -> Optional[Set[str]]:
+    def _get_referenced_directly(cert: str, referenced_by_direct: ReferencedByDirect) -> Optional[Set[str]]:
         return referenced_by_direct.get(cert, None)
 
     @staticmethod
-    def _get_affected_indirectly(cert: str, referenced_by_indirect: ReferencedByIndirect) -> Optional[Set[str]]:
+    def _get_referenced_indirectly(cert: str, referenced_by_indirect: ReferencedByIndirect) -> Optional[Set[str]]:
         return referenced_by_indirect.get(cert, None)
 
     def fit(self, certificates: Certificates) -> None:
@@ -102,34 +102,34 @@ class DependencyFinder:
             if not cert_id:
                 continue
 
-            self.dependencies[dgst]["directly_affected_by"] = DependencyFinder._get_affected_directly(
+            self.dependencies[dgst]["directly_referenced_by"] = DependencyFinder._get_referenced_directly(
                 cert_id, referenced_by_direct
             )
 
-            self.dependencies[dgst]["indirectly_affected_by"] = DependencyFinder._get_affected_indirectly(
+            self.dependencies[dgst]["indirectly_referenced_by"] = DependencyFinder._get_referenced_indirectly(
                 cert_id, referenced_by_indirect
             )
 
-            self.dependencies[dgst]["directly_affecting"] = DependencyFinder._get_affecting_directly(
+            self.dependencies[dgst]["directly_referencing"] = DependencyFinder._get_referencing_directly(
                 cert_id, referenced_by_direct
             )
 
-            self.dependencies[dgst]["indirectly_affecting"] = DependencyFinder._get_affecting_indirectly(
+            self.dependencies[dgst]["indirectly_referencing"] = DependencyFinder._get_referencing_indirectly(
                 cert_id, referenced_by_indirect
             )
 
-    def get_directly_affected_by(self, dgst: str) -> Optional[Set[str]]:
-        res = self.dependencies[dgst].get("directly_affected_by", None)
+    def get_directly_referenced_by(self, dgst: str) -> Optional[Set[str]]:
+        res = self.dependencies[dgst].get("directly_referenced_by", None)
         return set(res) if res else None
 
-    def get_indirectly_affected_by(self, dgst: str) -> Optional[Set[str]]:
-        res = self.dependencies[dgst].get("indirectly_affected_by", None)
+    def get_indirectly_referenced_by(self, dgst: str) -> Optional[Set[str]]:
+        res = self.dependencies[dgst].get("indirectly_referenced_by", None)
         return set(res) if res else None
 
-    def get_directly_affecting(self, dgst: str) -> Optional[Set[str]]:
-        res = self.dependencies[dgst].get("directly_affecting", None)
+    def get_directly_referencing(self, dgst: str) -> Optional[Set[str]]:
+        res = self.dependencies[dgst].get("directly_referencing", None)
         return set(res) if res else None
 
-    def get_indirectly_affecting(self, dgst: str) -> Optional[Set[str]]:
-        res = self.dependencies[dgst].get("indirectly_affecting", None)
+    def get_indirectly_referencing(self, dgst: str) -> Optional[Set[str]]:
+        res = self.dependencies[dgst].get("indirectly_referencing", None)
         return set(res) if res else None

--- a/sec_certs/sample/common_criteria.py
+++ b/sec_certs/sample/common_criteria.py
@@ -350,7 +350,7 @@ class CommonCriteriaCert(
             self.heuristics.report_references.directly_referenced_by,
             self.heuristics.report_references.indirectly_referenced_by,
             self.heuristics.report_references.directly_referencing,
-            self.heuristics.report_references.indirectly_referencing
+            self.heuristics.report_references.indirectly_referencing,
         )
 
     def __str__(self) -> str:

--- a/sec_certs/sample/common_criteria.py
+++ b/sec_certs/sample/common_criteria.py
@@ -12,6 +12,7 @@ from bs4 import Tag
 from sec_certs import constants as constants
 from sec_certs import helpers
 from sec_certs.model.cpe_matching import CPEClassifier
+from sec_certs.model.dependency_finder import References
 from sec_certs.sample.certificate import Certificate, Heuristics, logger
 from sec_certs.sample.protection_profile import ProtectionProfile
 from sec_certs.serialization.json import ComplexSerializableType
@@ -238,10 +239,8 @@ class CommonCriteriaCert(
         related_cves: Optional[Set[str]] = field(default=None)
         cert_lab: Optional[List[str]] = field(default=None)
         cert_id: Optional[str] = field(default=None)
-        directly_referenced_by: Optional[Set[str]] = field(default=None)
-        indirectly_referenced_by: Optional[Set[str]] = field(default=None)
-        directly_referencing: Optional[Set[str]] = field(default=None)
-        indirectly_referencing: Optional[Set[str]] = field(default=None)
+        st_references: References = field(default_factory=References)
+        report_references: References = field(default_factory=References)
 
         @property
         def serialized_attributes(self) -> List[str]:
@@ -348,10 +347,10 @@ class CommonCriteriaCert(
             self.heuristics.cpe_matches,
             self.heuristics.verified_cpe_matches,
             self.heuristics.related_cves,
-            self.heuristics.directly_referenced_by,
-            self.heuristics.indirectly_referenced_by,
-            self.heuristics.directly_referencing,
-            self.heuristics.indirectly_referencing,
+            self.heuristics.report_references.directly_referenced_by,
+            self.heuristics.report_references.indirectly_referenced_by,
+            self.heuristics.report_references.directly_referencing,
+            self.heuristics.report_references.indirectly_referencing
         )
 
     def __str__(self) -> str:

--- a/sec_certs/sample/common_criteria.py
+++ b/sec_certs/sample/common_criteria.py
@@ -209,10 +209,10 @@ class CommonCriteriaCert(
         related_cves: Optional[Set[str]] = field(default=None)
         cert_lab: Optional[List[str]] = field(default=None)
         cert_id: Optional[str] = field(default=None)
-        directly_affected_by: Optional[Set[str]] = field(default=None)
-        indirectly_affected_by: Optional[Set[str]] = field(default=None)
-        directly_affecting: Optional[Set[str]] = field(default=None)
-        indirectly_affecting: Optional[Set[str]] = field(default=None)
+        directly_referenced_by: Optional[Set[str]] = field(default=None)
+        indirectly_referenced_by: Optional[Set[str]] = field(default=None)
+        directly_referencing: Optional[Set[str]] = field(default=None)
+        indirectly_referencing: Optional[Set[str]] = field(default=None)
 
         @property
         def serialized_attributes(self) -> List[str]:
@@ -236,10 +236,10 @@ class CommonCriteriaCert(
         "cpe_matches",
         "verified_cpe_matches",
         "related_cves",
-        "directly_affected_by",
-        "indirectly_affected_by",
-        "directly_affecting",
-        "indirectly_affecting",
+        "directly_referenced_by",
+        "indirectly_referenced_by",
+        "directly_referencing",
+        "indirectly_referencing",
     ]
 
     def __init__(
@@ -319,10 +319,10 @@ class CommonCriteriaCert(
             self.heuristics.cpe_matches,
             self.heuristics.verified_cpe_matches,
             self.heuristics.related_cves,
-            self.heuristics.directly_affected_by,
-            self.heuristics.indirectly_affected_by,
-            self.heuristics.directly_affecting,
-            self.heuristics.indirectly_affecting,
+            self.heuristics.directly_referenced_by,
+            self.heuristics.indirectly_referenced_by,
+            self.heuristics.directly_referencing,
+            self.heuristics.indirectly_referencing,
         )
 
     def __str__(self) -> str:

--- a/sec_certs/sample/fips.py
+++ b/sec_certs/sample/fips.py
@@ -17,6 +17,7 @@ from sec_certs.config.configuration import config
 from sec_certs.constants import LINE_SEPARATOR
 from sec_certs.helpers import fips_dgst, load_cert_file, normalize_match_string, save_modified_cert_file
 from sec_certs.model.cpe_matching import CPEClassifier
+from sec_certs.model.dependency_finder import References
 from sec_certs.sample.certificate import Certificate, Heuristics, logger
 from sec_certs.sample.cpe import CPE
 from sec_certs.serialization.json import ComplexSerializableType
@@ -115,7 +116,6 @@ class FIPSCertificate(Certificate["FIPSCertificate", "FIPSCertificate.FIPSHeuris
         revoked_link: Optional[str]
         sw_versions: Optional[str]
         product_url: Optional[str]
-        connections: List[str]
 
         @property
         def dgst(self) -> str:
@@ -152,7 +152,6 @@ class FIPSCertificate(Certificate["FIPSCertificate", "FIPSCertificate.FIPSHeuris
         cert_id: int
         keywords: Dict
         algorithms: List
-        connections: List[str]
 
         @property
         def dgst(self) -> str:
@@ -170,7 +169,6 @@ class FIPSCertificate(Certificate["FIPSCertificate", "FIPSCertificate.FIPSHeuris
     class FIPSHeuristics(Heuristics, ComplexSerializableType):
         keywords: Dict[str, Dict]
         algorithms: List[Dict[str, Dict]]
-        connections: List[str]
         unmatched_algs: int
 
         extracted_versions: Optional[Set[str]] = field(default=None)
@@ -178,10 +176,8 @@ class FIPSCertificate(Certificate["FIPSCertificate", "FIPSCertificate.FIPSHeuris
         verified_cpe_matches: Optional[Set[CPE]] = field(default=None)
         related_cves: Optional[Set[str]] = field(default=None)
 
-        directly_referenced_by: Optional[Set] = field(default=None)
-        indirectly_referenced_by: Optional[Set] = field(default=None)
-        directly_referencing: Optional[Set] = field(default=None)
-        indirectly_referencing: Optional[Set] = field(default=None)
+        st_references: References = field(default_factory=References)
+        web_references: References = field(default_factory=References)
 
         @property
         def serialized_attributes(self) -> List[str]:
@@ -474,7 +470,6 @@ class FIPSCertificate(Certificate["FIPSCertificate", "FIPSCertificate.FIPSHeuris
             state.tables_done = initialized.state.tables_done
             state.file_status = initialized.state.file_status
             state.txt_state = initialized.state.txt_state
-            initialized.heuristics.connections = []
 
         if redo:
             items_found = FIPSCertificate.initialize_dictionary()
@@ -530,15 +525,13 @@ class FIPSCertificate(Certificate["FIPSCertificate", "FIPSCertificate.FIPSHeuris
                 items_found["revoked_link"] if "revoked_link" in items_found else None,
                 items_found["sw_versions"] if "sw_versions" in items_found else None,
                 items_found["product_url"] if "product_url" in items_found else None,
-                [],
-            ),  # connections
+            ),
             FIPSCertificate.PdfScan(
                 items_found["cert_id"],
                 {} if not initialized else initialized.pdf_scan.keywords,
                 [] if not initialized else initialized.pdf_scan.algorithms,
-                [],  # connections
             ),
-            FIPSCertificate.FIPSHeuristics(dict(), [], [], 0),
+            FIPSCertificate.FIPSHeuristics(dict(), [], 0),
             state,
         )
 

--- a/sec_certs/sample/fips.py
+++ b/sec_certs/sample/fips.py
@@ -178,10 +178,10 @@ class FIPSCertificate(Certificate["FIPSCertificate", "FIPSCertificate.FIPSHeuris
         verified_cpe_matches: Optional[Set[CPE]] = field(default=None)
         related_cves: Optional[Set[str]] = field(default=None)
 
-        directly_affected_by: Optional[Set] = field(default=None)
-        indirectly_affected_by: Optional[Set] = field(default=None)
-        directly_affecting: Optional[Set] = field(default=None)
-        indirectly_affecting: Optional[Set] = field(default=None)
+        directly_referenced_by: Optional[Set] = field(default=None)
+        indirectly_referenced_by: Optional[Set] = field(default=None)
+        directly_referencing: Optional[Set] = field(default=None)
+        indirectly_referencing: Optional[Set] = field(default=None)
 
         @property
         def serialized_attributes(self) -> List[str]:

--- a/tests/data/test_cc_oop/fictional_cert.json
+++ b/tests/data/test_cc_oop/fictional_cert.json
@@ -61,10 +61,10 @@
         "related_cves": null,
         "cert_lab": null,
         "cert_id": null,
-        "directly_affected_by": null,
-        "indirectly_affected_by": null,
-        "directly_affecting": null,
-        "indirectly_affecting": null
+        "directly_referenced_by": null,
+        "indirectly_referenced_by": null,
+        "directly_referencing": null,
+        "indirectly_referencing": null
     },
     "report_link": "https://path.to/report/link",
     "st_link": "https://path.to/st/link",

--- a/tests/data/test_cc_oop/fictional_cert.json
+++ b/tests/data/test_cc_oop/fictional_cert.json
@@ -1,72 +1,86 @@
 {
-    "_type": "CommonCriteriaCert",
-    "dgst": "a9ccb81a92e547dc",
-    "status": "archived",
-    "category": "Sample category",
-    "name": "Sample certificate name",
-    "manufacturer": "Sample manufacturer",
-    "scheme": "Sample scheme",
-    "security_level": {
-        "_type": "Set",
-        "elements": [
-            "Sample security level"
-        ]
+  "_type": "CommonCriteriaCert",
+  "dgst": "a9ccb81a92e547dc",
+  "status": "archived",
+  "category": "Sample category",
+  "name": "Sample certificate name",
+  "manufacturer": "Sample manufacturer",
+  "scheme": "Sample scheme",
+  "security_level": {
+    "_type": "Set",
+    "elements": [
+      "Sample security level"
+    ]
+  },
+  "not_valid_before": "1900-01-02",
+  "not_valid_after": "1900-01-03",
+  "manufacturer_web": "https://path.to/manufacturer/web",
+  "protection_profiles": {
+    "_type": "Set",
+    "elements": [
+      {
+        "_type": "ProtectionProfile",
+        "pp_name": "sample_pp",
+        "pp_link": "https://sample.pp",
+        "pp_ids": null
+      }
+    ]
+  },
+  "maintenance_updates": {
+    "_type": "Set",
+    "elements": [
+      {
+        "_type": "MaintenanceReport",
+        "maintenance_date": "1900-01-01",
+        "maintenance_title": "Sample maintenance",
+        "maintenance_report_link": "https://maintenance.up",
+        "maintenance_st_link": "https://maintenance.up"
+      }
+    ]
+  },
+  "state": {
+    "_type": "InternalState",
+    "st_download_ok": true,
+    "report_download_ok": true,
+    "st_convert_ok": true,
+    "report_convert_ok": true,
+    "st_extract_ok": true,
+    "report_extract_ok": true,
+    "errors": []
+  },
+  "pdf_data": {
+    "_type": "PdfData",
+    "report_metadata": null,
+    "st_metadata": null,
+    "report_frontpage": null,
+    "st_frontpage": null,
+    "report_keywords": null,
+    "st_keywords": null
+  },
+  "heuristics": {
+    "_type": "CCHeuristics",
+    "extracted_versions": null,
+    "cpe_matches": null,
+    "verified_cpe_matches": null,
+    "related_cves": null,
+    "cert_lab": null,
+    "cert_id": null,
+    "report_references": {
+      "_type": "References",
+      "directly_referenced_by": null,
+      "directly_referencing": null,
+      "indirectly_referenced_by": null,
+      "indirectly_referencing": null
     },
-    "not_valid_before": "1900-01-02",
-    "not_valid_after": "1900-01-03",
-    "manufacturer_web": "https://path.to/manufacturer/web",
-    "protection_profiles": {
-        "_type": "Set",
-        "elements": [{
-            "_type": "ProtectionProfile",
-            "pp_name": "sample_pp",
-            "pp_link": "https://sample.pp",
-            "pp_ids": null
-        }]
-    },
-    "maintenance_updates": {
-        "_type": "Set",
-        "elements": [{
-            "_type": "MaintenanceReport",
-            "maintenance_date": "1900-01-01",
-            "maintenance_title": "Sample maintenance",
-            "maintenance_report_link": "https://maintenance.up",
-            "maintenance_st_link": "https://maintenance.up"
-        }]
-    },
-    "state": {
-        "_type": "InternalState",
-        "st_download_ok": true,
-        "report_download_ok": true,
-        "st_convert_ok": true,
-        "report_convert_ok": true,
-        "st_extract_ok": true,
-        "report_extract_ok": true,
-        "errors": []
-    },
-    "pdf_data": {
-        "_type": "PdfData",
-        "report_metadata": null,
-        "st_metadata": null,
-        "report_frontpage": null,
-        "st_frontpage": null,
-        "report_keywords": null,
-        "st_keywords": null
-    },
-    "heuristics": {
-        "_type": "CCHeuristics",
-        "extracted_versions": null,
-        "cpe_matches": null,
-        "verified_cpe_matches": null,
-        "related_cves": null,
-        "cert_lab": null,
-        "cert_id": null,
-        "directly_referenced_by": null,
-        "indirectly_referenced_by": null,
-        "directly_referencing": null,
-        "indirectly_referencing": null
-    },
-    "report_link": "https://path.to/report/link",
-    "st_link": "https://path.to/st/link",
-    "cert_link": "https://path.to/cert/link"
+    "st_references": {
+      "_type": "References",
+      "directly_referenced_by": null,
+      "directly_referencing": null,
+      "indirectly_referenced_by": null,
+      "indirectly_referencing": null
+    }
+  },
+  "report_link": "https://path.to/report/link",
+  "st_link": "https://path.to/st/link",
+  "cert_link": "https://path.to/cert/link"
 }

--- a/tests/data/test_cc_oop/toy_dataset.json
+++ b/tests/data/test_cc_oop/toy_dataset.json
@@ -1,142 +1,165 @@
 {
-    "_type": "CCDataset",
-    "state": {
-        "_type": "DatasetInternalState",
-        "meta_sources_parsed": true,
-        "pdfs_downloaded": false,
-        "pdfs_converted": false,
-        "certs_analyzed": false
-    },
-    "timestamp": "2020-11-16 17:04:14.770153",
-    "sha256_digest": "not implemented",
-    "name": "toy dataset",
-    "description": "toy dataset description",
-    "n_certs": 2,
-    "certs": [{
-            "_type": "CommonCriteriaCert",
-            "dgst": "309ac2fd7f2dcf17",
-            "status": "active",
-            "category": "Access Control Devices and Systems",
-            "name": "NetIQ Identity Manager 4.7",
-            "manufacturer": "NetIQ Corporation",
-            "scheme": "SE",
-            "security_level": {
-                "_type": "Set",
-                "elements": [
-                    "ALC_FLR.2",
-                    "EAL3+"
-                ]
-            },
-            "not_valid_before": "2020-06-15",
-            "not_valid_after": "2025-06-15",
-            "report_link": "https://www.commoncriteriaportal.org/files/epfiles/Certification%20Report%20-%20NetIQ®%20Identity%20Manager%204.7.pdf",
-            "st_link": "https://www.commoncriteriaportal.org/files/epfiles/ST%20-%20NetIQ%20Identity%20Manager%204.7.pdf",
-            "cert_link": "https://www.commoncriteriaportal.org/files/epfiles/Certifikat%20CCRA%20-%20NetIQ%20Identity%20Manager%204.7_signed.pdf",
-            "manufacturer_web": "https://www.netiq.com/",
-            "protection_profiles": {
-                "_type": "Set",
-                "elements": []
-            },
-            "maintenance_updates": {
-                "_type": "Set",
-                "elements": []
-            },
-            "state": {
-                "_type": "InternalState",
-                "st_download_ok": true,
-                "report_download_ok": true,
-                "st_convert_ok": true,
-                "report_convert_ok": true,
-                "st_extract_ok": true,
-                "report_extract_ok": true,
-                "errors": []
-            },
-            "pdf_data": {
-                "_type": "PdfData",
-                "report_metadata": null,
-                "st_metadata": null,
-                "report_frontpage": null,
-                "st_frontpage": null,
-                "report_keywords": null,
-                "st_keywords": null
-            },
-            "heuristics": {
-                "_type": "CCHeuristics",
-                "extracted_versions": null,
-                "cpe_matches": null,
-                "verified_cpe_matches": null,
-                "related_cves": null,
-                "cert_lab": null,
-                "cert_id": null,
-                "directly_referenced_by": null,
-                "indirectly_referenced_by": null,
-                "directly_referencing": null,
-                "indirectly_referencing": null
-            }
+  "_type": "CCDataset",
+  "state": {
+    "_type": "DatasetInternalState",
+    "meta_sources_parsed": true,
+    "pdfs_downloaded": false,
+    "pdfs_converted": false,
+    "certs_analyzed": false
+  },
+  "timestamp": "2020-11-16 17:04:14.770153",
+  "sha256_digest": "not implemented",
+  "name": "toy dataset",
+  "description": "toy dataset description",
+  "n_certs": 2,
+  "certs": [
+    {
+      "_type": "CommonCriteriaCert",
+      "dgst": "309ac2fd7f2dcf17",
+      "status": "active",
+      "category": "Access Control Devices and Systems",
+      "name": "NetIQ Identity Manager 4.7",
+      "manufacturer": "NetIQ Corporation",
+      "scheme": "SE",
+      "security_level": {
+        "_type": "Set",
+        "elements": [
+          "ALC_FLR.2",
+          "EAL3+"
+        ]
+      },
+      "not_valid_before": "2020-06-15",
+      "not_valid_after": "2025-06-15",
+      "report_link": "https://www.commoncriteriaportal.org/files/epfiles/Certification%20Report%20-%20NetIQ®%20Identity%20Manager%204.7.pdf",
+      "st_link": "https://www.commoncriteriaportal.org/files/epfiles/ST%20-%20NetIQ%20Identity%20Manager%204.7.pdf",
+      "cert_link": "https://www.commoncriteriaportal.org/files/epfiles/Certifikat%20CCRA%20-%20NetIQ%20Identity%20Manager%204.7_signed.pdf",
+      "manufacturer_web": "https://www.netiq.com/",
+      "protection_profiles": {
+        "_type": "Set",
+        "elements": []
+      },
+      "maintenance_updates": {
+        "_type": "Set",
+        "elements": []
+      },
+      "state": {
+        "_type": "InternalState",
+        "st_download_ok": true,
+        "report_download_ok": true,
+        "st_convert_ok": true,
+        "report_convert_ok": true,
+        "st_extract_ok": true,
+        "report_extract_ok": true,
+        "errors": []
+      },
+      "pdf_data": {
+        "_type": "PdfData",
+        "report_metadata": null,
+        "st_metadata": null,
+        "report_frontpage": null,
+        "st_frontpage": null,
+        "report_keywords": null,
+        "st_keywords": null
+      },
+      "heuristics": {
+        "_type": "CCHeuristics",
+        "extracted_versions": null,
+        "cpe_matches": null,
+        "verified_cpe_matches": null,
+        "related_cves": null,
+        "cert_lab": null,
+        "cert_id": null,
+        "report_references": {
+          "_type": "References",
+          "directly_referenced_by": null,
+          "directly_referencing": null,
+          "indirectly_referenced_by": null,
+          "indirectly_referencing": null
         },
-        {
-            "_type": "CommonCriteriaCert",
-            "dgst": "8cf86948f02f047d",
-            "status": "active",
-            "category": "Access Control Devices and Systems",
-            "name": "Magic SSO V4.0",
-            "manufacturer": "Dreamsecurity Co., Ltd.",
-            "scheme": "KR",
-            "security_level": {
-                "_type": "Set",
-                "elements": []
-            },
-            "not_valid_before": "2019-11-15",
-            "not_valid_after": "2024-11-15",
-            "report_link": "https://www.commoncriteriaportal.org/files/epfiles/KECS-CR-19-70%20Magic%20SSO%20V4.0(eng)%20V1.0.pdf",
-            "st_link": "https://www.commoncriteriaportal.org/files/epfiles/Magic_SSO_V4.0-ST-v1.4_EN.pdf",
-            "cert_link": null,
-            "manufacturer_web": "https://www.dreamsecurity.com/",
-            "protection_profiles": {
-                "_type": "Set",
-                "elements": [{
-                    "_type": "ProtectionProfile",
-                    "pp_name": "Korean National Protection Profile for Single Sign On V1.0",
-                    "pp_link": "https://www.commoncriteriaportal.org/files/ppfiles/KECS-PP-0822-2017%20Korean%20National%20PP%20for%20Single%20Sign%20On%20V1.0(eng).pdf",
-                    "pp_ids": null
-                }]
-            },
-            "maintenance_updates": {
-                "_type": "Set",
-                "elements": []
-            },
-            "state": {
-                "_type": "InternalState",
-                "st_download_ok": true,
-                "report_download_ok": true,
-                "st_convert_ok": true,
-                "report_convert_ok": true,
-                "st_extract_ok": true,
-                "report_extract_ok": true,
-                "errors": []
-            },
-            "pdf_data": {
-                "_type": "PdfData",
-                "report_metadata": null,
-                "st_metadata": null,
-                "report_frontpage": null,
-                "st_frontpage": null,
-                "report_keywords": null,
-                "st_keywords": null
-            },
-            "heuristics": {
-                "_type": "CCHeuristics",
-                "extracted_versions": null,
-                "cpe_matches": null,
-                "verified_cpe_matches": null,
-                "related_cves": null,
-                "cert_lab": null,
-                "cert_id": null,
-                "directly_referenced_by": null,
-                "indirectly_referenced_by": null,
-                "directly_referencing": null,
-                "indirectly_referencing": null
-            }
+        "st_references": {
+          "_type": "References",
+          "directly_referenced_by": null,
+          "directly_referencing": null,
+          "indirectly_referenced_by": null,
+          "indirectly_referencing": null
         }
-    ]
+      }
+    },
+    {
+      "_type": "CommonCriteriaCert",
+      "dgst": "8cf86948f02f047d",
+      "status": "active",
+      "category": "Access Control Devices and Systems",
+      "name": "Magic SSO V4.0",
+      "manufacturer": "Dreamsecurity Co., Ltd.",
+      "scheme": "KR",
+      "security_level": {
+        "_type": "Set",
+        "elements": []
+      },
+      "not_valid_before": "2019-11-15",
+      "not_valid_after": "2024-11-15",
+      "report_link": "https://www.commoncriteriaportal.org/files/epfiles/KECS-CR-19-70%20Magic%20SSO%20V4.0(eng)%20V1.0.pdf",
+      "st_link": "https://www.commoncriteriaportal.org/files/epfiles/Magic_SSO_V4.0-ST-v1.4_EN.pdf",
+      "cert_link": null,
+      "manufacturer_web": "https://www.dreamsecurity.com/",
+      "protection_profiles": {
+        "_type": "Set",
+        "elements": [
+          {
+            "_type": "ProtectionProfile",
+            "pp_name": "Korean National Protection Profile for Single Sign On V1.0",
+            "pp_link": "https://www.commoncriteriaportal.org/files/ppfiles/KECS-PP-0822-2017%20Korean%20National%20PP%20for%20Single%20Sign%20On%20V1.0(eng).pdf",
+            "pp_ids": null
+          }
+        ]
+      },
+      "maintenance_updates": {
+        "_type": "Set",
+        "elements": []
+      },
+      "state": {
+        "_type": "InternalState",
+        "st_download_ok": true,
+        "report_download_ok": true,
+        "st_convert_ok": true,
+        "report_convert_ok": true,
+        "st_extract_ok": true,
+        "report_extract_ok": true,
+        "errors": []
+      },
+      "pdf_data": {
+        "_type": "PdfData",
+        "report_metadata": null,
+        "st_metadata": null,
+        "report_frontpage": null,
+        "st_frontpage": null,
+        "report_keywords": null,
+        "st_keywords": null
+      },
+      "heuristics": {
+        "_type": "CCHeuristics",
+        "extracted_versions": null,
+        "cpe_matches": null,
+        "verified_cpe_matches": null,
+        "related_cves": null,
+        "cert_lab": null,
+        "cert_id": null,
+        "report_references": {
+          "_type": "References",
+          "directly_referenced_by": null,
+          "directly_referencing": null,
+          "indirectly_referenced_by": null,
+          "indirectly_referencing": null
+        },
+        "st_references": {
+          "_type": "References",
+          "directly_referenced_by": null,
+          "directly_referencing": null,
+          "indirectly_referenced_by": null,
+          "indirectly_referencing": null
+        }
+      }
+    }
+  ]
 }

--- a/tests/data/test_cc_oop/toy_dataset.json
+++ b/tests/data/test_cc_oop/toy_dataset.json
@@ -68,10 +68,10 @@
                 "related_cves": null,
                 "cert_lab": null,
                 "cert_id": null,
-                "directly_affected_by": null,
-                "indirectly_affected_by": null,
-                "directly_affecting": null,
-                "indirectly_affecting": null
+                "directly_referenced_by": null,
+                "indirectly_referenced_by": null,
+                "directly_referencing": null,
+                "indirectly_referencing": null
             }
         },
         {
@@ -132,10 +132,10 @@
                 "related_cves": null,
                 "cert_lab": null,
                 "cert_id": null,
-                "directly_affected_by": null,
-                "indirectly_affected_by": null,
-                "directly_affecting": null,
-                "indirectly_affecting": null
+                "directly_referenced_by": null,
+                "indirectly_referenced_by": null,
+                "directly_referencing": null,
+                "indirectly_referencing": null
             }
         }
     ]

--- a/tests/test_cc_heuristics.py
+++ b/tests/test_cc_heuristics.py
@@ -266,17 +266,19 @@ class TestCommonCriteriaHeuristics(TestCase):
     def test_single_record_dependency_heuristics(self):
         # Single record in daset is not affecting nor affected by other records
         heuristics = self.cc_dset["ebd276cca70fd723"].heuristics
-        self.assertEqual(heuristics.directly_affected_by, None)
-        self.assertEqual(heuristics.indirectly_affected_by, None)
-        self.assertEqual(heuristics.directly_affecting, None)
-        self.assertEqual(heuristics.indirectly_affecting, None)
+        self.assertEqual(heuristics.directly_referenced_by, None)
+        self.assertEqual(heuristics.indirectly_referenced_by, None)
+        self.assertEqual(heuristics.directly_referencing, None)
+        self.assertEqual(heuristics.indirectly_referencing, None)
 
     def test_dependency_dataset(self):
         dependency_dataset = CCDataset.from_json(self.data_dir_path / "dependency_dataset.json")
         dependency_dataset._compute_dependencies()
         test_cert = dependency_dataset["692e91451741ef49"]
 
-        self.assertEqual(test_cert.heuristics.directly_affected_by, {"BSI-DSZ-CC-0370-2006"})
-        self.assertEqual(test_cert.heuristics.indirectly_affected_by, {"BSI-DSZ-CC-0370-2006", "BSI-DSZ-CC-0517-2009"})
-        self.assertEqual(test_cert.heuristics.directly_affecting, {"BSI-DSZ-CC-0268-2005"})
-        self.assertEqual(test_cert.heuristics.indirectly_affecting, {"BSI-DSZ-CC-0268-2005"})
+        self.assertEqual(test_cert.heuristics.directly_referenced_by, {"BSI-DSZ-CC-0370-2006"})
+        self.assertEqual(
+            test_cert.heuristics.indirectly_referenced_by, {"BSI-DSZ-CC-0370-2006", "BSI-DSZ-CC-0517-2009"}
+        )
+        self.assertEqual(test_cert.heuristics.directly_referencing, {"BSI-DSZ-CC-0268-2005"})
+        self.assertEqual(test_cert.heuristics.indirectly_referencing, {"BSI-DSZ-CC-0268-2005"})

--- a/tests/test_cc_heuristics.py
+++ b/tests/test_cc_heuristics.py
@@ -266,19 +266,20 @@ class TestCommonCriteriaHeuristics(TestCase):
     def test_single_record_dependency_heuristics(self):
         # Single record in daset is not affecting nor affected by other records
         heuristics = self.cc_dset["ebd276cca70fd723"].heuristics
-        self.assertEqual(heuristics.directly_referenced_by, None)
-        self.assertEqual(heuristics.indirectly_referenced_by, None)
-        self.assertEqual(heuristics.directly_referencing, None)
-        self.assertEqual(heuristics.indirectly_referencing, None)
+        self.assertEqual(heuristics.report_references.directly_referenced_by, None)
+        self.assertEqual(heuristics.report_references.indirectly_referenced_by, None)
+        self.assertEqual(heuristics.report_references.directly_referencing, None)
+        self.assertEqual(heuristics.report_references.indirectly_referencing, None)
 
     def test_dependency_dataset(self):
         dependency_dataset = CCDataset.from_json(self.data_dir_path / "dependency_dataset.json")
         dependency_dataset._compute_dependencies()
         test_cert = dependency_dataset["692e91451741ef49"]
 
-        self.assertEqual(test_cert.heuristics.directly_referenced_by, {"BSI-DSZ-CC-0370-2006"})
+        self.assertEqual(test_cert.heuristics.report_references.directly_referenced_by, {"BSI-DSZ-CC-0370-2006"})
         self.assertEqual(
-            test_cert.heuristics.indirectly_referenced_by, {"BSI-DSZ-CC-0370-2006", "BSI-DSZ-CC-0517-2009"}
+            test_cert.heuristics.report_references.indirectly_referenced_by,
+            {"BSI-DSZ-CC-0370-2006", "BSI-DSZ-CC-0517-2009"},
         )
-        self.assertEqual(test_cert.heuristics.directly_referencing, {"BSI-DSZ-CC-0268-2005"})
-        self.assertEqual(test_cert.heuristics.indirectly_referencing, {"BSI-DSZ-CC-0268-2005"})
+        self.assertEqual(test_cert.heuristics.report_references.directly_referencing, {"BSI-DSZ-CC-0268-2005"})
+        self.assertEqual(test_cert.heuristics.report_references.indirectly_referencing, {"BSI-DSZ-CC-0268-2005"})

--- a/tests/test_fips_oop.py
+++ b/tests/test_fips_oop.py
@@ -120,88 +120,234 @@ class TestFipsOOP(TestCase):
         with TemporaryDirectory() as tmp_dir:
             dataset = _set_up_dataset_for_full(tmp_dir, certs, self.cpe_dset_path, self.cve_dset_path)
 
-            self.assertEqual(set(dataset.certs[fips_dgst("3095")].heuristics.connections), {"3093", "3096", "3094"})
-            self.assertEqual(set(dataset.certs[fips_dgst("3651")].heuristics.connections), {"3615"})
-            self.assertEqual(set(dataset.certs[fips_dgst("3093")].heuristics.connections), {"3090", "3091"})
-            self.assertEqual(set(dataset.certs[fips_dgst("3090")].heuristics.connections), {"3089"})
             self.assertEqual(
-                set(dataset.certs[fips_dgst("3197")].heuristics.connections),
-                {x for x in ["3195", "3096", "3196", "3644", "3651"]},
+                set(dataset.certs[fips_dgst("3095")].heuristics.st_references.directly_referencing), {"3096"}
             )
             self.assertEqual(
-                set(dataset.certs[fips_dgst("3196")].heuristics.connections),
-                {x for x in ["3194", "3091", "3480", "3615"]},
-            )
-            self.assertEqual(set(dataset.certs[fips_dgst("3089")].heuristics.connections), set())
-            self.assertEqual(set(dataset.certs[fips_dgst("3195")].heuristics.connections), {"3194", "3091", "3480"})
-            self.assertEqual(set(dataset.certs[fips_dgst("3480")].heuristics.connections), {"3089"})
-            self.assertEqual(set(dataset.certs[fips_dgst("3615")].heuristics.connections), {"3089"})
-            self.assertEqual(set(dataset.certs[fips_dgst("3194")].heuristics.connections), {"3089"})
-            self.assertEqual(set(dataset.certs[fips_dgst("3091")].heuristics.connections), {"3089"})
-            self.assertEqual(set(dataset.certs[fips_dgst("3690")].heuristics.connections), {"3644", "3196", "3651"})
-            self.assertEqual(set(dataset.certs[fips_dgst("3644")].heuristics.connections), {"3615"})
-            self.assertEqual(set(dataset.certs[fips_dgst("3527")].heuristics.connections), {"3090", "3091"})
-            self.assertEqual(set(dataset.certs[fips_dgst("3094")].heuristics.connections), {"3090", "3091"})
-            self.assertEqual(set(dataset.certs[fips_dgst("3544")].heuristics.connections), {"3093", "3096", "3527"})
-            self.assertEqual(
-                set(dataset.certs[fips_dgst("3096")].heuristics.connections), {"3090", "3194", "3091", "3480"}
+                set(dataset.certs[fips_dgst("3095")].heuristics.web_references.directly_referencing),
+                {"3093", "3096", "3094"},
             )
             self.assertEqual(
-                set(dataset.certs[fips_dgst("3092")].heuristics.connections), {"3093", "3195", "3096", "3644", "3651"}
+                set(dataset.certs[fips_dgst("3651")].heuristics.st_references.directly_referencing), {"3615"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3093")].heuristics.st_references.directly_referencing), {"3091"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3093")].heuristics.web_references.directly_referencing), {"3090", "3091"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3090")].heuristics.st_references.directly_referencing), {"3089"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3197")].heuristics.web_references.directly_referencing),
+                {"3195", "3096", "3196", "3644", "3651"},
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3196")].heuristics.st_references.directly_referencing), {"3091"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3196")].heuristics.web_references.directly_referencing),
+                {"3194", "3091", "3480", "3615"},
+            )
+            self.assertIsNone(dataset.certs[fips_dgst("3089")].heuristics.st_references.directly_referencing)
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3195")].heuristics.st_references.directly_referencing), {"3091"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3195")].heuristics.web_references.directly_referencing),
+                {"3194", "3091", "3480"},
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3480")].heuristics.st_references.directly_referencing), {"3089"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3615")].heuristics.st_references.directly_referencing), {"3089"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3194")].heuristics.st_references.directly_referencing), {"3089"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3091")].heuristics.st_references.directly_referencing), {"3089"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3690")].heuristics.st_references.directly_referencing), {"3651"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3690")].heuristics.web_references.directly_referencing),
+                {"3644", "3196", "3651"},
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3644")].heuristics.st_references.directly_referencing), {"3615"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3527")].heuristics.st_references.directly_referencing), {"3091"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3527")].heuristics.web_references.directly_referencing), {"3090", "3091"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3094")].heuristics.st_references.directly_referencing), {"3091"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3544")].heuristics.st_references.directly_referencing), {"3096"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3544")].heuristics.web_references.directly_referencing),
+                {"3093", "3096", "3527"},
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3096")].heuristics.st_references.directly_referencing), {"3091"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3096")].heuristics.web_references.directly_referencing),
+                {"3090", "3194", "3091", "3480"},
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3092")].heuristics.web_references.directly_referencing),
+                {"3093", "3195", "3096", "3644", "3651"},
             )
 
     def test_connections_redhat(self):
         certs = self.certs_to_parse["redhat"]
         with TemporaryDirectory() as tmp_dir:
             dataset = _set_up_dataset_for_full(tmp_dir, certs, self.cpe_dset_path, self.cve_dset_path)
-            self.assertEqual(set(dataset.certs[fips_dgst("2630")].heuristics.connections), {"2441"})
-            self.assertEqual(set(dataset.certs[fips_dgst("2633")].heuristics.connections), {"2441"})
-            self.assertEqual(set(dataset.certs[fips_dgst("2441")].heuristics.connections), set())
-            self.assertEqual(set(dataset.certs[fips_dgst("2997")].heuristics.connections), {"2711"})
-            self.assertEqual(set(dataset.certs[fips_dgst("2446")].heuristics.connections), {"2441"})
-            self.assertEqual(set(dataset.certs[fips_dgst("2447")].heuristics.connections), {"2441"})
-            self.assertEqual(set(dataset.certs[fips_dgst("3733")].heuristics.connections), {"2441"})
-            self.assertEqual(set(dataset.certs[fips_dgst("2441")].heuristics.connections), set())
-            self.assertEqual(set(dataset.certs[fips_dgst("2711")].heuristics.connections), set())
-            self.assertEqual(set(dataset.certs[fips_dgst("2908")].heuristics.connections), {"2711"})
-            self.assertEqual(set(dataset.certs[fips_dgst("3613")].heuristics.connections), {"2997"})
-            self.assertEqual(set(dataset.certs[fips_dgst("2721")].heuristics.connections), {"2441", "2711"})
-            self.assertEqual(set(dataset.certs[fips_dgst("2798")].heuristics.connections), {"2721", "2711"})
-            self.assertEqual(set(dataset.certs[fips_dgst("2711")].heuristics.connections), set())
-            self.assertEqual(set(dataset.certs[fips_dgst("2997")].heuristics.connections), {"2711"})
-            self.assertEqual(set(dataset.certs[fips_dgst("2742")].heuristics.connections), {"2721", "2711"})
-            self.assertEqual(set(dataset.certs[fips_dgst("2721")].heuristics.connections), {"2441", "2711"})
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("2630")].heuristics.st_references.directly_referencing), {"2441"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("2633")].heuristics.st_references.directly_referencing), {"2441"}
+            )
+            self.assertIsNone(dataset.certs[fips_dgst("2441")].heuristics.st_references.directly_referencing)
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("2997")].heuristics.st_references.directly_referencing), {"2711"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("2446")].heuristics.st_references.directly_referencing), {"2441"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("2447")].heuristics.st_references.directly_referencing), {"2441"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3733")].heuristics.st_references.directly_referencing), {"2441"}
+            )
+            self.assertIsNone(dataset.certs[fips_dgst("2441")].heuristics.st_references.directly_referencing)
+            self.assertIsNone(dataset.certs[fips_dgst("2711")].heuristics.st_references.directly_referencing)
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("2908")].heuristics.st_references.directly_referencing), {"2711"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3613")].heuristics.st_references.directly_referencing), {"2997"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("2721")].heuristics.st_references.directly_referencing), {"2441"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("2721")].heuristics.web_references.directly_referencing), {"2441", "2711"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("2798")].heuristics.st_references.directly_referencing), {"2721"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("2798")].heuristics.web_references.directly_referencing), {"2711", "2721"}
+            )
+            self.assertIsNone(dataset.certs[fips_dgst("2711")].heuristics.st_references.directly_referencing)
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("2997")].heuristics.st_references.directly_referencing), {"2711"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("2742")].heuristics.st_references.directly_referencing), {"2721"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("2742")].heuristics.web_references.directly_referencing), {"2721", "2711"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("2721")].heuristics.st_references.directly_referencing), {"2441"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("2721")].heuristics.web_references.directly_referencing), {"2441", "2711"}
+            )
 
     def test_docusign_chunk(self):
         certs = self.certs_to_parse["docusign"]
         with TemporaryDirectory() as tmp_dir:
             dataset = _set_up_dataset_for_full(tmp_dir, certs, self.cpe_dset_path, self.cve_dset_path)
-            self.assertEqual(set(dataset.certs[fips_dgst("3850")].heuristics.connections), {"3518", "1883"})
-            self.assertEqual(set(dataset.certs[fips_dgst("2779")].heuristics.connections), {"1883"})
-            self.assertEqual(set(dataset.certs[fips_dgst("2860")].heuristics.connections), {"1883"})
-            self.assertEqual(set(dataset.certs[fips_dgst("2665")].heuristics.connections), {"1883"})
-            self.assertEqual(set(dataset.certs[fips_dgst("1883")].heuristics.connections), set())
-            self.assertEqual(set(dataset.certs[fips_dgst("3518")].heuristics.connections), {"1883"})
-            self.assertEqual(set(dataset.certs[fips_dgst("3141")].heuristics.connections), {"1883"})
-            self.assertEqual(set(dataset.certs[fips_dgst("2590")].heuristics.connections), {"1883"})
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3850")].heuristics.st_references.directly_referencing), {"1883"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3850")].heuristics.web_references.directly_referencing), {"1883"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("2779")].heuristics.st_references.directly_referencing), {"1883"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("2860")].heuristics.st_references.directly_referencing), {"1883"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("2665")].heuristics.st_references.directly_referencing), {"1883"}
+            )
+            self.assertIsNone(dataset.certs[fips_dgst("1883")].heuristics.st_references.directly_referencing)
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3518")].heuristics.st_references.directly_referencing), {"1883"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3141")].heuristics.st_references.directly_referencing), {"1883"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("2590")].heuristics.st_references.directly_referencing), {"1883"}
+            )
 
     def test_openssl_chunk(self):
         certs = self.certs_to_parse["referencing_openssl"]
         with TemporaryDirectory() as tmp_dir:
             dataset = _set_up_dataset_for_full(tmp_dir, certs, self.cpe_dset_path, self.cve_dset_path)
-            self.assertEqual(set(dataset.certs[fips_dgst("3493")].heuristics.connections), {"2398"})
-            self.assertEqual(set(dataset.certs[fips_dgst("3495")].heuristics.connections), {"2398"})
-            self.assertEqual(set(dataset.certs[fips_dgst("3711")].heuristics.connections), {"3220"})
-            self.assertEqual(set(dataset.certs[fips_dgst("3176")].heuristics.connections), {"2398"})
-            self.assertEqual(set(dataset.certs[fips_dgst("3488")].heuristics.connections), {"2398"})
-            self.assertEqual(set(dataset.certs[fips_dgst("3126")].heuristics.connections), {"3126", "2398"})
-            self.assertEqual(set(dataset.certs[fips_dgst("3269")].heuristics.connections), {"3269", "3220"})
-            self.assertEqual(set(dataset.certs[fips_dgst("3524")].heuristics.connections), {"3220"})
-            self.assertEqual(set(dataset.certs[fips_dgst("3220")].heuristics.connections), {"3220", "2398"})
-            self.assertEqual(set(dataset.certs[fips_dgst("2398")].heuristics.connections), set())
-            self.assertEqual(set(dataset.certs[fips_dgst("3543")].heuristics.connections), {"2398"})
-            self.assertEqual(set(dataset.certs[fips_dgst("2676")].heuristics.connections), {"2398"})
-            self.assertEqual(set(dataset.certs[fips_dgst("3313")].heuristics.connections), {"3313", "3220"})
-            self.assertEqual(set(dataset.certs[fips_dgst("3363")].heuristics.connections), set())
-            self.assertEqual(set(dataset.certs[fips_dgst("3608")].heuristics.connections), {"2398"})
-            self.assertEqual(set(dataset.certs[fips_dgst("3158")].heuristics.connections), {"2398"})
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3493")].heuristics.st_references.directly_referencing), {"2398"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3495")].heuristics.st_references.directly_referencing), {"2398"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3711")].heuristics.st_references.directly_referencing), {"3220"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3176")].heuristics.st_references.directly_referencing), {"2398"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3488")].heuristics.st_references.directly_referencing), {"2398"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3126")].heuristics.st_references.directly_referencing), {"2398"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3126")].heuristics.st_references.directly_referencing), {"2398"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3126")].heuristics.web_references.directly_referencing), {"2398"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3269")].heuristics.st_references.directly_referencing), {"3220"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3524")].heuristics.st_references.directly_referencing), {"3220"}
+            )
+            self.assertIsNone(dataset.certs[fips_dgst("3220")].heuristics.st_references.directly_referencing)
+            self.assertIsNone(dataset.certs[fips_dgst("3220")].heuristics.web_references.directly_referencing)
+            self.assertIsNone(dataset.certs[fips_dgst("2398")].heuristics.st_references.directly_referencing)
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3543")].heuristics.st_references.directly_referencing), {"2398"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("2676")].heuristics.st_references.directly_referencing), {"2398"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3313")].heuristics.st_references.directly_referencing), {"3220"}
+            )
+            self.assertIsNone(dataset.certs[fips_dgst("3363")].heuristics.st_references.directly_referencing)
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3608")].heuristics.st_references.directly_referencing), {"2398"}
+            )
+            self.assertEqual(
+                set(dataset.certs[fips_dgst("3158")].heuristics.st_references.directly_referencing), {"2398"}
+            )


### PR DESCRIPTION
This will unify handling of references in CC and FIPS (and fixes #176 as well).
The current status is:

**CC**
Uses `DependencyFinder` to get the referenced and referencing certs from the certificate report only, then stores these in the `{in,}directly_{affecting,affected}` attributes of the heuristics object.

**FIPS**
Uses the `_find_connections` method of the FIPS dataset class to get the referenced certs from the security policy as well as the "Caveat" field from the web page, then stores the referenced certificates only in the `connections` attribute.

The ideal solution unifies the way these are stored as well as extends the data in the CC case to include the security target as a source of references as well.