### PR TITLE
Explicitly terminate the Thread or Process pool.

### DIFF
--- a/sec_certs/parallel_processing.py
+++ b/sec_certs/parallel_processing.py
@@ -36,5 +36,6 @@ def process_parallel(
 
     pool.close()
     pool.join()
+    pool.terminate()
 
     return [r.get() for r in results]


### PR DESCRIPTION
Should help deal with https://github.com/celery/billiard/issues/282
which manifests each two weeks or so on seccerts.org when the celery process runs
out of open file descriptors and the updates stop working in weird
ways.