### PR TITLE
allow empty dataset constructors

### DIFF
--- a/sec_certs/dataset/common_criteria.py
+++ b/sec_certs/dataset/common_criteria.py
@@ -40,10 +40,10 @@ class CCDataset(Dataset[CommonCriteriaCert], ComplexSerializableType):
 
     def __init__(
         self,
-        certs: Dict[str, CommonCriteriaCert],
-        root_dir: Path,
-        name: str = "dataset name",
-        description: str = "dataset_description",
+        certs: Dict[str, CommonCriteriaCert] = dict(),
+        root_dir: Optional[Path] = None,
+        name: str = "Common Criteria Dataset",
+        description: str = "No description",
         state: Optional[DatasetInternalState] = None,
     ):
         super().__init__(certs, root_dir, name, description)

--- a/sec_certs/dataset/dataset.py
+++ b/sec_certs/dataset/dataset.py
@@ -29,11 +29,13 @@ DatasetSubType = TypeVar("DatasetSubType", bound="Dataset")
 class Dataset(Generic[CertSubType], ABC):
     def __init__(
         self,
-        certs: Dict[str, CertSubType],
-        root_dir: Path,
+        certs: Dict[str, CertSubType] = dict(),
+        root_dir: Optional[Path] = None,
         name: str = "dataset name",
         description: str = "dataset_description",
     ):
+        if not root_dir:
+            root_dir = Path.cwd() / (type(self).__name__).lower()
         self._root_dir = root_dir
         self.timestamp = datetime.now()
         self.sha256_digest = "not implemented"

--- a/sec_certs/dataset/fips.py
+++ b/sec_certs/dataset/fips.py
@@ -25,10 +25,10 @@ logger = logging.getLogger(__name__)
 class FIPSDataset(Dataset[FIPSCertificate], ComplexSerializableType):
     def __init__(
         self,
-        certs: Dict[str, FIPSCertificate],
-        root_dir: Path,
-        name: str = "dataset name",
-        description: str = "dataset_description",
+        certs: Dict[str, FIPSCertificate] = dict(),
+        root_dir: Optional[Path] = None,
+        name: str = "FIPS Dataset",
+        description: str = "No description",
     ):
         super().__init__(certs, root_dir, name, description)
         self.keywords: Dict[str, Dict] = {}


### PR DESCRIPTION
Allows empty dataset constructors:
- `certs` set to `dict()`
- `root_path` set to `cwd() + class name`