### PR TITLE
Docs: upload to web on tag revision

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ jobs:
   upload:
     runs-on: ubuntu-latest
     needs: build
-    if: github.ref == 'refs/heads/main' && github.repository == 'crocs-muni/sec-certs' # Potentially change this into a check on release.
+    if: (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main') && github.repository == 'crocs-muni/sec-certs' # Potentially change this into a check on release.
     steps:
       - name: Get docs artifact
         uses: actions/download-artifact@v3


### PR DESCRIPTION
Currently, job `upload` of `docs` action is not invoked on release. This is because revision is `refs/tags/`, while the job requires it to be `refs/heads/main` in order ro be triggered. This PR relaxes this requirement.