### PR TITLE
Fix and enhance PDF metadata reading

### DIFF
--- a/sec_certs/helpers.py
+++ b/sec_certs/helpers.py
@@ -265,8 +265,11 @@ def extract_pdf_metadata(filepath: Path) -> Tuple[str, Optional[Dict[str, Any]]]
             metadata["pdf_number_of_pages"] = pdf.getNumPages()
             pdf_document_info = pdf.getDocumentInfo()
 
-        for key, val in pdf_document_info.items():
-            metadata[str(key)] = map_metadata_value(val)
+            if pdf_document_info is None:
+                raise ValueError("PDF metadata unavailable")
+
+            for key, val in pdf_document_info.items():
+                metadata[str(key)] = map_metadata_value(val)
 
     except Exception as e:
         relative_filepath = "/".join(str(filepath).split("/")[-4:])


### PR DESCRIPTION
This fixes an issue where we closed the PDF file too early (and if there were IndirectObjects in it PyPDF2 then failed reading metadata). Also, this adds a search of hyperlinks in the PDF metadata and a function for parsing the PDF creation dates (useful for future analysis).