### PR TITLE
Harmonize FIPS code

### DIFF
--- a/sec_certs/constants.py
+++ b/sec_certs/constants.py
@@ -14,12 +14,25 @@ MIN_CC_PP_DATASET_SIZE = 2500000
 CPE_VERSION_NA = "-"
 
 FIPS_BASE_URL = "https://csrc.nist.gov"
-FIPS_MODULE_URL = "https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/{}"
-FIPS_ALG_URL = "https://csrc.nist.gov/projects/cryptographic-algorithm-validation-program/validation-search?searchMode=implementation&page="
+FIPS_CMVP_URL = FIPS_BASE_URL + "/projects/cryptographic-module-validation-program"
+FIPS_CAVP_URL = FIPS_BASE_URL + "/projects/Cryptographic-Algorithm-Validation-Program"
+FIPS_MODULE_URL = FIPS_CMVP_URL + "/certificate/{}"
+FIPS_ALG_SEARCH_URL = FIPS_CAVP_URL + "/validation-search?searchMode=implementation&page="
 FIPS_SP_URL = "https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp{}.pdf"
-FIPS_ACTIVE_MODULES_URL = "https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&CertificateStatus=Active&ValidationYear=0"
-FIPS_HISTORICAL_MODULES_URL = "https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&CertificateStatus=Historical&ValidationYear=0"
-FIPS_REVOKED_MODULES_URL = "https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&CertificateStatus=Revoked&ValidationYear=0"
+FIPS_ACTIVE_MODULES_URL = (
+    FIPS_CMVP_URL + "/validated-modules/search?SearchMode=Advanced&CertificateStatus=Active&ValidationYear=0"
+)
+FIPS_HISTORICAL_MODULES_URL = (
+    FIPS_CMVP_URL + "/validated-modules/search?SearchMode=Advanced&CertificateStatus=Historical&ValidationYear=0"
+)
+FIPS_REVOKED_MODULES_URL = (
+    FIPS_CMVP_URL + "/validated-modules/search?SearchMode=Advanced&CertificateStatus=Revoked&ValidationYear=0"
+)
+FIPS_ALG_URL = FIPS_CAVP_URL + "/details?source={}&number={}"
+FIPS_IUT_URL = "https://csrc.nist.gov/Projects/cryptographic-module-validation-program/modules-in-process/IUT-List"
+FIPS_MIP_URL = (
+    "https://csrc.nist.gov/Projects/cryptographic-module-validation-program/modules-in-process/Modules-In-Process-List"
+)
 
 FIPS_DOWNLOAD_DELAY = 1
 

--- a/sec_certs/constants.py
+++ b/sec_certs/constants.py
@@ -25,6 +25,8 @@ FIPS_MODULE_URL = "https://csrc.nist.gov/projects/cryptographic-module-validatio
 FIPS_NOT_AVAILABLE_CERT_SIZE = 10000
 FIPS_ALG_URL = "https://csrc.nist.gov/projects/cryptographic-algorithm-validation-program/validation-search?searchMode=implementation&page="
 
+FIPS_DOWNLOAD_DELAY = 1
+
 FIPS_MIP_STATUS_RE = re.compile(r"^(?P<status>[a-zA-Z ]+?) +\((?P<since>\d{1,2}/\d{1,2}/\d{4})\)$")
 
 TAG_MATCH_COUNTER = "count"

--- a/sec_certs/constants.py
+++ b/sec_certs/constants.py
@@ -1,5 +1,4 @@
 import re
-from enum import Enum
 
 RESPONSE_OK = 200
 RETURNCODE_OK = "ok"
@@ -12,27 +11,19 @@ MIN_CC_HTML_SIZE = 5000000
 MIN_CC_CSV_SIZE = 700000
 MIN_CC_PP_DATASET_SIZE = 2500000
 
-
-class CertFramework(Enum):
-    CC = "Common Criteria"
-    FIPS = "FIPS"
-
-
 CPE_VERSION_NA = "-"
 
 FIPS_BASE_URL = "https://csrc.nist.gov"
-FIPS_MODULE_URL = "https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/"
-FIPS_NOT_AVAILABLE_CERT_SIZE = 10000
+FIPS_MODULE_URL = "https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/{}"
 FIPS_ALG_URL = "https://csrc.nist.gov/projects/cryptographic-algorithm-validation-program/validation-search?searchMode=implementation&page="
+FIPS_SP_URL = "https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp{}.pdf"
+FIPS_ACTIVE_MODULES_URL = "https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&CertificateStatus=Active&ValidationYear=0"
+FIPS_HISTORICAL_MODULES_URL = "https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&CertificateStatus=Historical&ValidationYear=0"
+FIPS_REVOKED_MODULES_URL = "https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search?SearchMode=Advanced&CertificateStatus=Revoked&ValidationYear=0"
 
 FIPS_DOWNLOAD_DELAY = 1
 
 FIPS_MIP_STATUS_RE = re.compile(r"^(?P<status>[a-zA-Z ]+?) +\((?P<since>\d{1,2}/\d{1,2}/\d{4})\)$")
-
-TAG_MATCH_COUNTER = "count"
-TAG_MATCH_MATCHES = "matches"
-
-TAG_CERT_HEADER_PROCESSED = "cert_header_processed"
 
 TAG_CERT_ID = "cert_id"
 TAG_CC_SECURITY_LEVEL = "cc_security_level"
@@ -43,24 +34,8 @@ TAG_CERT_ITEM_VERSION = "cert_item_version"
 TAG_DEVELOPER = "developer"
 TAG_REFERENCED_PROTECTION_PROFILES = "ref_protection_profiles"
 TAG_HEADER_MATCH_RULES = "match_rules"
-TAG_PP_TITLE = "pp_title"
-TAG_PP_GENERAL_STATUS = "pp_general_status"
-TAG_PP_VERSION_NUMBER = "pp_version_number"
-TAG_PP_ID = "pp_id"
-TAG_PP_ID_REGISTRATOR = "pp_id_registrator"
-TAG_PP_DATE = "pp_date"
-TAG_PP_AUTHORS = "pp_authors"
-TAG_PP_REGISTRATOR = "pp_registrator"
-TAG_PP_REGISTRATOR_SIMPLIFIED = "pp_registrator_simplified"
-TAG_PP_SPONSOR = "pp_sponsor"
-TAG_PP_EDITOR = "pp_editor"
-TAG_PP_REVIEWER = "pp_reviewer"
-TAG_KEYWORDS = "keywords"
-
 
 FILE_ERRORS_STRATEGY = "surrogateescape"
-STOP_ON_UNEXPECTED_NUMS = False
-APPEND_DETAILED_MATCH_MATCHES = False
 MAX_ALLOWED_MATCH_LENGTH = 300
 LINE_SEPARATOR = " "
 

--- a/sec_certs/dataset/common_criteria.py
+++ b/sec_certs/dataset/common_criteria.py
@@ -600,7 +600,7 @@ class CCDataset(Dataset[CommonCriteriaCert], ComplexSerializableType):
         cat_dict = {x: y for (x, y) in zip(cc_table_ids, cc_categories)}
 
         with file.open("r") as handle:
-            soup = BeautifulSoup(handle, "html5lib")
+            soup = BeautifulSoup(handle, "html.parser")
 
         certs = {}
         for key, val in cat_dict.items():

--- a/sec_certs/dataset/fips.py
+++ b/sec_certs/dataset/fips.py
@@ -183,11 +183,11 @@ class FIPSDataset(Dataset[FIPSCertificate], ComplexSerializableType):
         return entries
 
     @serialize
-    def web_scan(self, cert_ids: Set[int], redo: bool = False) -> None:
+    def web_scan(self, cert_ids: Set[str], redo: bool = False) -> None:
         """
         Creates FIPSCertificate object from the relevant html file that must be downlaoded.
 
-        :param Set[int] cert_ids: Cert ids to create FIPSCertificate objects for.
+        :param Set[str] cert_ids: Cert ids to create FIPSCertificate objects for.
         :param bool redo: whether to re-attempt with failed certificates, defaults to False
         """
         logger.info("Entering web scan.")

--- a/sec_certs/dataset/fips.py
+++ b/sec_certs/dataset/fips.py
@@ -73,19 +73,6 @@ class FIPSDataset(Dataset[FIPSCertificate], ComplexSerializableType):
         for keyword, cert in keywords:
             self.certs[cert.dgst].pdf_scan.keywords = keyword
 
-    def _match_algs(self) -> Dict[str, int]:
-        output = {}
-        for cert in self.certs.values():
-            # if the pdf has not been processed, no matching can be done
-            if not cert.pdf_scan.keywords or not cert.state.txt_state:
-                continue
-
-            output[cert.dgst] = FIPSCertificate.match_web_algs_to_pdf(cert)
-            cert.heuristics.unmatched_algs = output[cert.dgst]
-
-        output = {k: v for k, v in output.items() if v != 0}
-        return output
-
     def download_all_pdfs(self, cert_ids: Optional[Set[str]] = None) -> None:
         """
         Downloads all pdf files related to the certificates specified with cert_ids.

--- a/sec_certs/dataset/fips.py
+++ b/sec_certs/dataset/fips.py
@@ -389,7 +389,7 @@ class FIPSDataset(Dataset[FIPSCertificate], ComplexSerializableType):
         if not FIPSDataset._match_with_algorithm(processed_cert, cert_candidate_id):
             return False
 
-        algs = self.algorithms.certs[cert_candidate_id]
+        algs = self.algorithms.certs_for_id(int(cert_candidate_id))
         for current_alg in algs:
             if current_alg.vendor is None or processed_cert.web_data.vendor is None:
                 raise RuntimeError("Dataset was probably not built correctly - this should not be happening.")

--- a/sec_certs/dataset/fips.py
+++ b/sec_certs/dataset/fips.py
@@ -41,10 +41,6 @@ class FIPSDataset(Dataset[FIPSCertificate], ComplexSerializableType):
         return self.root_dir / "security_policies"
 
     @property
-    def _fragments_dir(self) -> Path:
-        return self.root_dir / "fragments"
-
-    @property
     def _algs_dir(self) -> Path:
         return self.web_dir / "algorithms"
 
@@ -66,8 +62,6 @@ class FIPSDataset(Dataset[FIPSCertificate], ComplexSerializableType):
         :param bool redo: Whether to try again with failed files, defaults to False
         """
         logger.info("Entering PDF scan.")
-
-        self._fragments_dir.mkdir(parents=True, exist_ok=True)
 
         keywords = cert_processing.process_parallel(
             FIPSCertificate.find_keywords,
@@ -233,7 +227,6 @@ class FIPSDataset(Dataset[FIPSCertificate], ComplexSerializableType):
                 FIPSCertificate.State(
                     (self._policies_dir / str(cert_id)).with_suffix(".pdf"),
                     (self.web_dir / str(cert_id)).with_suffix(".html"),
-                    (self._fragments_dir / str(cert_id)).with_suffix(".txt"),
                     False,
                     None,
                     False,
@@ -270,7 +263,7 @@ class FIPSDataset(Dataset[FIPSCertificate], ComplexSerializableType):
     def _set_local_paths(self) -> None:
         cert: FIPSCertificate
         for cert in self.certs.values():
-            cert.set_local_paths(self._policies_dir, self.web_dir, self._fragments_dir)
+            cert.set_local_paths(self._policies_dir, self.web_dir)
 
     @serialize
     def get_certs_from_web(

--- a/sec_certs/dataset/fips.py
+++ b/sec_certs/dataset/fips.py
@@ -226,9 +226,6 @@ class FIPSDataset(Dataset[FIPSCertificate], ComplexSerializableType):
                 len(dset),
                 len(dset.algorithms) if dset.algorithms is not None else 0,
             )
-            # TODO: Fixme, this is really costly
-            # logger.info("The dataset does not contain the results of the dependency analysis - calculating them now...")
-            # dset.finalize_results()
             return dset
 
     def _set_local_paths(self) -> None:

--- a/sec_certs/dataset/fips_algorithm.py
+++ b/sec_certs/dataset/fips_algorithm.py
@@ -10,6 +10,7 @@ from sec_certs import constants as constants
 from sec_certs.config.configuration import config
 from sec_certs.dataset.dataset import Dataset
 from sec_certs.sample.fips import FIPSCertificate
+from sec_certs.sample.fips_algorithm import FIPSAlgorithm
 from sec_certs.serialization.json import ComplexSerializableType, CustomJSONDecoder, CustomJSONEncoder
 from sec_certs.utils import helpers as helpers
 from sec_certs.utils import parallel_processing as cert_processing
@@ -88,7 +89,7 @@ class FIPSAlgorithmDataset(Dataset, ComplexSerializableType):
                 )
 
                 alg_type, alg_id = split_alg(validation)
-                fips_alg = FIPSCertificate.Algorithm(alg_id, vendor, product, alg_type, date)
+                fips_alg = FIPSAlgorithm(alg_id, vendor, product, alg_type, date)
                 if alg_id not in self.certs:
                     self.certs[alg_id] = []
                 self.certs[alg_id].append(fips_alg)

--- a/sec_certs/dataset/fips_algorithm.py
+++ b/sec_certs/dataset/fips_algorithm.py
@@ -1,7 +1,6 @@
-import json
 import logging
 from pathlib import Path
-from typing import Dict, List, Union
+from typing import Any, Dict, List, Optional, Set
 
 from bs4 import BeautifulSoup
 
@@ -11,7 +10,7 @@ from sec_certs.config.configuration import config
 from sec_certs.dataset.dataset import Dataset
 from sec_certs.sample.fips import FIPSCertificate
 from sec_certs.sample.fips_algorithm import FIPSAlgorithm
-from sec_certs.serialization.json import ComplexSerializableType, CustomJSONDecoder, CustomJSONEncoder
+from sec_certs.serialization.json import ComplexSerializableType
 from sec_certs.utils import helpers as helpers
 from sec_certs.utils import parallel_processing as cert_processing
 
@@ -19,35 +18,48 @@ logger = logging.getLogger(__name__)
 
 
 class FIPSAlgorithmDataset(Dataset, ComplexSerializableType):
+    certs: Dict[str, FIPSAlgorithm]
 
-    certs: Dict[str, List]  # type: ignore # noqa
+    def __init__(
+        self,
+        certs: Dict[str, FIPSAlgorithm] = dict(),
+        root_dir: Optional[Path] = None,
+        name: str = "dataset name",
+        description: str = "dataset_description",
+    ):
+        super().__init__(certs, root_dir, name, description)
+        self._id_map: Dict[int, List[str]] = {}
 
     def get_certs_from_web(self):
         self.root_dir.mkdir(exist_ok=True)
         algs_paths, algs_urls = [], []
 
         # get first page to find out how many pages there are
-        helpers.download_file(constants.FIPS_ALG_URL + "1", self.root_dir / "page1.html")
+        res = helpers.download_file(constants.FIPS_ALG_SEARCH_URL + "1", self.root_dir / "page1.html")
+        if res != 200:
+            logger.error("Couldn't download first page of algo dataset")
 
         with open(self.root_dir / "page1.html", "r") as alg_file:
             soup = BeautifulSoup(alg_file.read(), "html.parser")
-            num_pages = soup.select("span[data-total-pages]")[0].attrs
+            num_pages_elem = soup.select("span[data-total-pages]")[0].attrs
 
-        for i in range(2, int(num_pages["data-total-pages"]) + 1):
+        num_pages = int(num_pages_elem["data-total-pages"])
+
+        for i in range(2, num_pages + 1):
             if not (self.root_dir / f"page{i}.html").exists():
-                algs_urls.append(constants.FIPS_ALG_URL + str(i))
+                algs_urls.append(constants.FIPS_ALG_SEARCH_URL + str(i))
                 algs_paths.append(self.root_dir / f"page{i}.html")
 
         # get the last page, always
-        helpers.download_file(
-            constants.FIPS_ALG_URL + num_pages["data-total-pages"],
-            self.root_dir / f"page{int(num_pages['data-total-pages'])}.html",
-        )
-        logger.info(f"downloading {len(algs_urls)} algs html files")
+        algs_urls.append(constants.FIPS_ALG_SEARCH_URL + str(num_pages))
+        algs_paths.append(self.root_dir / f"page{num_pages}.html")
+
+        logger.info(f"Downloading {len(algs_urls)} algo html files")
         cert_processing.process_parallel(
             FIPSCertificate.download_html_page, list(zip(algs_urls, algs_paths)), config.n_threads
         )
 
+        logger.info(f"Parsing {len(algs_urls)} algo html files")
         self.parse_html()
 
     @staticmethod
@@ -90,41 +102,41 @@ class FIPSAlgorithmDataset(Dataset, ComplexSerializableType):
 
                 alg_type, alg_id = split_alg(validation)
                 fips_alg = FIPSAlgorithm(alg_id, vendor, product, alg_type, date)
-                if alg_id not in self.certs:
-                    self.certs[alg_id] = []
-                self.certs[alg_id].append(fips_alg)
+                self.certs[fips_alg.dgst] = fips_alg
+        # And now rebuild the id map
+        self._build_id_map()
+
+    def _build_id_map(self):
+        for cert in self.certs.values():
+            self._id_map.setdefault(cert.cert_id, [])
+            self._id_map[cert.cert_id].append(cert.dgst)
+
+    def _get_certs_from_name(self, name: str) -> List[FIPSAlgorithm]:
+        raise NotImplementedError("Not meant to be implemented")
+
+    def _set_local_paths(self) -> None:
+        pass
+
+    @classmethod
+    def from_dict(cls, dct: Dict[str, Any]) -> "FIPSAlgorithmDataset":
+        dset: FIPSAlgorithmDataset = super().from_dict(dct)
+        dset._build_id_map()
+        return dset
 
     def convert_all_pdfs(self):
         raise NotImplementedError("Not meant to be implemented")
 
-    def download_all_pdfs(self):
+    def download_all_pdfs(self, cert_ids: Optional[Set[str]] = None) -> None:
         raise NotImplementedError("Not meant to be implemented")
 
-    @property
-    def serialized_attributes(self) -> List[str]:
-        return ["certs"]
+    def __getitem__(self, item: str) -> FIPSAlgorithm:
+        return self.certs.__getitem__(item)
 
-    @classmethod
-    def from_dict(cls, dct: Dict):
-        certs = dct["certs"]
+    def __setitem__(self, key: str, value: FIPSAlgorithm):
+        self.certs.__setitem__(key, value)
 
-        directory = dct["_root_dir"] if "_root_dir" in dct else ""
-        dset = cls(certs, Path(directory), "algorithms", "algorithms used in dataset")
-        return dset
-
-    def to_dict(self):
-        return self.__dict__
-
-    def to_json(self, output_path: Union[str, Path] = None):
-        if not output_path:
-            output_path = self.json_path
-        with Path(output_path).open("w") as handle:
-            json.dump(self, handle, indent=4, cls=CustomJSONEncoder)
-
-    @classmethod
-    def from_json(cls, input_path: Union[str, Path]):
-        input_path = Path(input_path)
-        with input_path.open("r") as handle:
-            dset = json.load(handle, cls=CustomJSONDecoder)
-        dset.root_dir = input_path.parent.absolute()
-        return dset
+    def certs_for_id(self, cert_id: int) -> List[FIPSAlgorithm]:
+        if cert_id in self._id_map:
+            return [self.certs[x] for x in self._id_map[cert_id]]
+        else:
+            return []

--- a/sec_certs/model/evaluation.py
+++ b/sec_certs/model/evaluation.py
@@ -30,7 +30,7 @@ def compute_precision(y: np.ndarray, y_pred: np.ndarray, **kwargs) -> float:
             prec.append(1.0)
         else:
             prec.append(len(set_true.intersection(set_pred)) / len(set_true))
-    return np.mean(prec)
+    return np.mean(prec)  # type: ignore
 
 
 def evaluate(
@@ -56,8 +56,8 @@ def evaluate(
             predicted_cpes = set()
         predicted_cpes_dict = {x: cpe_dset[x].title if cpe_dset[x].title else x for x in predicted_cpes}
 
-        cert_name = cert.name if isinstance(cert, CommonCriteriaCert) else cert.web_scan.module_name
-        vendor = cert.manufacturer if isinstance(cert, CommonCriteriaCert) else cert.web_scan.vendor
+        cert_name = cert.name if isinstance(cert, CommonCriteriaCert) else cert.web_data.module_name
+        vendor = cert.manufacturer if isinstance(cert, CommonCriteriaCert) else cert.web_data.vendor
         record = {
             "certificate_name": cert_name,
             "vendor": vendor,

--- a/sec_certs/sample/__init__.py
+++ b/sec_certs/sample/__init__.py
@@ -7,6 +7,7 @@ from sec_certs.sample.common_criteria import CommonCriteriaCert
 from sec_certs.sample.cpe import CPE, cached_cpe
 from sec_certs.sample.cve import CVE
 from sec_certs.sample.fips import FIPSCertificate
+from sec_certs.sample.fips_algorithm import FIPSAlgorithm
 from sec_certs.sample.fips_iut import IUTEntry, IUTSnapshot
 from sec_certs.sample.fips_mip import MIPEntry, MIPSnapshot, MIPStatus
 from sec_certs.sample.protection_profile import ProtectionProfile
@@ -19,6 +20,7 @@ __all__ = [
     "cached_cpe",
     "CVE",
     "FIPSCertificate",
+    "FIPSAlgorithm",
     "IUTEntry",
     "IUTSnapshot",
     "MIPEntry",

--- a/sec_certs/sample/cc_maintenance_update.py
+++ b/sec_certs/sample/cc_maintenance_update.py
@@ -26,7 +26,7 @@ class CommonCriteriaMaintenanceUpdate(CommonCriteriaCert, ComplexSerializableTyp
         st_link: str,
         state: Optional[CommonCriteriaCert.InternalState],
         pdf_data: Optional[CommonCriteriaCert.PdfData],
-        heuristics: Optional[CommonCriteriaCert.CCHeuristics],
+        heuristics: Optional[CommonCriteriaCert.Heuristics],
         related_cert_digest: str,
         maintenance_date: date,
     ):

--- a/sec_certs/sample/common_criteria.py
+++ b/sec_certs/sample/common_criteria.py
@@ -492,7 +492,7 @@ class CommonCriteriaCert(
         """
         Merges with other CC sample. Assuming they come from different sources, e.g., csv and html.
         Assuming that html source has better protection profiles, they overwrite CSV info
-        On other values (apart from maintenances, see TODO below) the sanity checks are made.
+        On other values the sanity checks are made.
         """
         if self != other:
             logger.warning(

--- a/sec_certs/sample/common_criteria.py
+++ b/sec_certs/sample/common_criteria.py
@@ -19,7 +19,9 @@ import sec_certs.utils.pdf
 import sec_certs.utils.sanitization
 from sec_certs import constants as constants
 from sec_certs.cert_rules import SARS_IMPLIED_FROM_EAL, cc_rules, security_level_csv_scan
-from sec_certs.sample.certificate import Certificate, Heuristics, References, logger
+from sec_certs.sample.certificate import Certificate
+from sec_certs.sample.certificate import Heuristics as BaseHeuristics
+from sec_certs.sample.certificate import References, logger
 from sec_certs.sample.protection_profile import ProtectionProfile
 from sec_certs.sample.sar import SAR
 from sec_certs.serialization.json import ComplexSerializableType
@@ -41,7 +43,7 @@ class DependencyType(Enum):
 
 
 class CommonCriteriaCert(
-    Certificate["CommonCriteriaCert", "CommonCriteriaCert.CCHeuristics"],
+    Certificate["CommonCriteriaCert", "CommonCriteriaCert.Heuristics"],
     PandasSerializableType,
     ComplexSerializableType,
 ):
@@ -315,7 +317,7 @@ class CommonCriteriaCert(
             return self.processed_cert_id if self.processed_cert_id else self.keywords_cert_id
 
     @dataclass
-    class CCHeuristics(Heuristics, ComplexSerializableType):
+    class Heuristics(BaseHeuristics, ComplexSerializableType):
         """
         Class for various heuristics related to CommonCriteriaCert
         """
@@ -381,7 +383,7 @@ class CommonCriteriaCert(
         maintenance_updates: Optional[Set[MaintenanceReport]],
         state: Optional[InternalState],
         pdf_data: Optional[PdfData],
-        heuristics: Optional[CCHeuristics],
+        heuristics: Optional[Heuristics],
     ):
         super().__init__()
 
@@ -405,7 +407,7 @@ class CommonCriteriaCert(
         self.maintenance_updates = maintenance_updates
         self.state = self.InternalState() if not state else state
         self.pdf_data = self.PdfData() if not pdf_data else pdf_data
-        self.heuristics: CommonCriteriaCert.CCHeuristics = self.CCHeuristics() if not heuristics else heuristics
+        self.heuristics: CommonCriteriaCert.Heuristics = self.Heuristics() if not heuristics else heuristics
 
     @property
     def dgst(self) -> str:

--- a/sec_certs/sample/fips.py
+++ b/sec_certs/sample/fips.py
@@ -660,15 +660,25 @@ class FIPSCertificate(Certificate["FIPSCertificate", "FIPSCertificate.Heuristics
                 if int("".join(filter(str.isdigit, cert_no))) == int("".join(filter(str.isdigit, cert))):
                     to_pop.add(cert)
 
-    def remove_algorithms(self) -> None:
+    def compute_heuristics_keywords(self) -> None:
         """
-        Removes algorithms from the certificate.
+        Compute the heuristics keywords.
+
+         - Removes algorithm mentions from the cert_id rule matches.
         """
         self.state.file_status = True
         if not self.pdf_data.keywords:
             return
 
         self.heuristics.keywords = copy.deepcopy(self.pdf_data.keywords)
+
+        # XXX: Do not do this, the heuristics keywords need to be from the Security target only,
+        #      because the "st_references" are computed based on these, and the "web_references"
+        #      are computed based on "web_data.mentioned_certs".
+        # Add the mentioned certs
+        # if self.web_data.mentioned_certs:
+        #     for cert_id, value in self.web_data.mentioned_certs.items():
+        #         self.heuristics.keywords["fips_cert_id"]["Cert"]["#" + str(cert_id)] = value["count"]
 
         alg_set = self._create_alg_set()
         for cert_rule in fips_rules["fips_cert_id"]["Cert"]:

--- a/sec_certs/sample/fips.py
+++ b/sec_certs/sample/fips.py
@@ -71,31 +71,6 @@ class FIPSCertificate(Certificate["FIPSCertificate", "FIPSCertificate.FIPSHeuris
             self.state.html_path = (Path(html_dir) / (str(self.cert_id))).with_suffix(".html")
 
     @dataclass(eq=True)
-    class Algorithm(ComplexSerializableType):
-        """
-        Data structure for algorithm of `FIPSCertificate`
-        """
-
-        cert_id: str
-        vendor: str
-        implementation: str
-        algorithm_type: str
-        date: str
-
-        @property
-        def dgst(self) -> str:
-            # certs in dataset are in format { id: [FIPSAlgorithm] }, there is only one type of algorithm
-            # for each id
-            # TODO: This is probably not a good digest.
-            return self.algorithm_type
-
-        def __repr__(self) -> str:
-            return self.algorithm_type + " algorithm #" + self.cert_id + " created by " + self.vendor
-
-        def __str__(self) -> str:
-            return str(self.algorithm_type + " algorithm #" + self.cert_id + " created by " + self.vendor)
-
-    @dataclass(eq=True)
     class WebData(ComplexSerializableType):
         """
         Data structure for data obtained from scanning certificate webpage at NIST.gov

--- a/sec_certs/sample/fips.py
+++ b/sec_certs/sample/fips.py
@@ -41,7 +41,6 @@ class FIPSCertificate(Certificate["FIPSCertificate", "FIPSCertificate.FIPSHeuris
 
         sp_path: Path
         html_path: Path
-        fragment_path: Path
         tables_done: bool
         file_status: Optional[bool]
         txt_state: bool
@@ -50,14 +49,12 @@ class FIPSCertificate(Certificate["FIPSCertificate", "FIPSCertificate.FIPSHeuris
             self,
             sp_path: Union[str, Path],
             html_path: Union[str, Path],
-            fragment_path: Union[str, Path],
             tables_done: bool,
             file_status: Optional[bool],
             txt_state: bool,
         ):
             self.sp_path = Path(sp_path)
             self.html_path = Path(html_path)
-            self.fragment_path = Path(fragment_path)
             self.tables_done = tables_done
             self.file_status = file_status
             self.txt_state = txt_state
@@ -66,14 +63,11 @@ class FIPSCertificate(Certificate["FIPSCertificate", "FIPSCertificate.FIPSHeuris
         self,
         sp_dir: Optional[Union[str, Path]],
         html_dir: Optional[Union[str, Path]],
-        fragment_dir: Optional[Union[str, Path]],
     ) -> None:
         if sp_dir is not None:
             self.state.sp_path = (Path(sp_dir) / (str(self.cert_id))).with_suffix(".pdf")
         if html_dir is not None:
             self.state.html_path = (Path(html_dir) / (str(self.cert_id))).with_suffix(".html")
-        if fragment_dir is not None:
-            self.state.fragment_path = (Path(fragment_dir) / (str(self.cert_id))).with_suffix(".txt")
 
     @dataclass(eq=True)
     class Algorithm(ComplexSerializableType):

--- a/sec_certs/sample/fips_algorithm.py
+++ b/sec_certs/sample/fips_algorithm.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass
+
+from sec_certs.serialization.json import ComplexSerializableType
+
+
+@dataclass(eq=True)
+class FIPSAlgorithm(ComplexSerializableType):
+    """
+    Data structure for algorithm of `FIPSCertificate`
+    """
+
+    cert_id: str
+    vendor: str
+    implementation: str
+    algorithm_type: str
+    date: str
+
+    @property
+    def dgst(self) -> str:
+        # certs in dataset are in format { id: [FIPSAlgorithm] }, there is only one type of algorithm
+        # for each id
+        # TODO: This is probably not a good digest.
+        return self.algorithm_type
+
+    def __repr__(self) -> str:
+        return self.algorithm_type + " algorithm #" + self.cert_id + " created by " + self.vendor
+
+    def __str__(self) -> str:
+        return str(self.algorithm_type + " algorithm #" + self.cert_id + " created by " + self.vendor)

--- a/sec_certs/sample/fips_algorithm.py
+++ b/sec_certs/sample/fips_algorithm.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 
+from sec_certs import constants
 from sec_certs.serialization.json import ComplexSerializableType
 
 
@@ -9,7 +10,7 @@ class FIPSAlgorithm(ComplexSerializableType):
     Data structure for algorithm of `FIPSCertificate`
     """
 
-    cert_id: str
+    cert_id: int
     vendor: str
     implementation: str
     algorithm_type: str
@@ -17,13 +18,14 @@ class FIPSAlgorithm(ComplexSerializableType):
 
     @property
     def dgst(self) -> str:
-        # certs in dataset are in format { id: [FIPSAlgorithm] }, there is only one type of algorithm
-        # for each id
-        # TODO: This is probably not a good digest.
-        return self.algorithm_type
+        return f"{self.algorithm_type}#{self.cert_id}"
+
+    @property
+    def page_url(self) -> str:
+        return constants.FIPS_ALG_URL.format(self.algorithm_type, self.cert_id)
 
     def __repr__(self) -> str:
-        return self.algorithm_type + " algorithm #" + self.cert_id + " created by " + self.vendor
+        return f"FIPSAlgorithm({self.dgst})"
 
     def __str__(self) -> str:
-        return str(self.algorithm_type + " algorithm #" + self.cert_id + " created by " + self.vendor)
+        return f"{self.algorithm_type} algorithm # {self.cert_id} created by {self.vendor}"

--- a/sec_certs/sample/fips_iut.py
+++ b/sec_certs/sample/fips_iut.py
@@ -6,6 +6,7 @@ from typing import Dict, Iterator, List, Mapping, Optional, Set, Union
 import requests
 from bs4 import BeautifulSoup, Tag
 
+from sec_certs import constants
 from sec_certs.serialization.json import ComplexSerializableType
 from sec_certs.utils.helpers import to_utc
 
@@ -132,10 +133,9 @@ class IUTSnapshot(ComplexSerializableType):
 
     @classmethod
     def from_web(cls) -> "IUTSnapshot":
-        iut_url = "https://csrc.nist.gov/Projects/cryptographic-module-validation-program/modules-in-process/IUT-List"
-        iut_resp = requests.get(iut_url)
+        iut_resp = requests.get(constants.FIPS_IUT_URL)
         if iut_resp.status_code != 200:
-            raise ValueError("Getting MIP snapshot failed")
+            raise ValueError(f"Getting IUT snapshot failed: {iut_resp.status_code}")
 
         snapshot_date = to_utc(datetime.now())
         return cls.from_page(iut_resp.content, snapshot_date)

--- a/sec_certs/sample/fips_mip.py
+++ b/sec_certs/sample/fips_mip.py
@@ -8,6 +8,7 @@ from typing import Dict, Iterator, List, Mapping, Optional, Set, Union
 import requests
 from bs4 import BeautifulSoup, Tag
 
+from sec_certs import constants
 from sec_certs.constants import FIPS_MIP_STATUS_RE
 from sec_certs.serialization.json import ComplexSerializableType
 from sec_certs.utils.helpers import to_utc
@@ -208,10 +209,9 @@ class MIPSnapshot(ComplexSerializableType):
 
     @classmethod
     def from_web(cls) -> "MIPSnapshot":
-        mip_url = "https://csrc.nist.gov/Projects/cryptographic-module-validation-program/modules-in-process/Modules-In-Process-List"
-        mip_resp = requests.get(mip_url)
+        mip_resp = requests.get(constants.FIPS_MIP_URL)
         if mip_resp.status_code != 200:
-            raise ValueError("Getting MIP snapshot failed")
+            raise ValueError(f"Getting MIP snapshot failed: {mip_resp.status_code}")
 
         snapshot_date = to_utc(datetime.now())
         return cls.from_page(mip_resp.content, snapshot_date)

--- a/sec_certs/serialization/json.py
+++ b/sec_certs/serialization/json.py
@@ -3,12 +3,14 @@ import json
 from datetime import date
 from functools import wraps
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union
+from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union, Tuple
 
 T = TypeVar("T")
 
 
 class ComplexSerializableType:
+    __slots__: Tuple[str]
+
     def __init__(self, *args, **kwargs):
         pass
 

--- a/sec_certs/serialization/json.py
+++ b/sec_certs/serialization/json.py
@@ -3,7 +3,7 @@ import json
 from datetime import date
 from functools import wraps
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union
 
 T = TypeVar("T")
 
@@ -74,10 +74,21 @@ def serialize(func: Callable):
     return inner_func
 
 
+def _class_fullname(obj: Any) -> str:
+    if isinstance(obj, type):
+        klass = obj
+    else:
+        klass = obj.__class__
+    module = klass.__module__
+    if module == "builtins":
+        return klass.__qualname__
+    return module + "." + klass.__qualname__
+
+
 class CustomJSONEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, ComplexSerializableType):
-            return {**{"_type": type(obj).__name__}, **obj.to_dict()}
+            return {**{"_type": _class_fullname(obj)}, **obj.to_dict()}
         if isinstance(obj, dict):
             return obj
         if isinstance(obj, set):
@@ -100,7 +111,7 @@ class CustomJSONDecoder(json.JSONDecoder):
 
     def __init__(self, *args, **kwargs):
         json.JSONDecoder.__init__(self, object_hook=self.object_hook, *args, **kwargs)
-        self.serializable_complex_types = {x.__name__: x for x in ComplexSerializableType.__subclasses__()}
+        self.serializable_complex_types = {_class_fullname(x): x for x in ComplexSerializableType.__subclasses__()}
 
     def object_hook(self, obj):
         if "_type" in obj and obj["_type"] == "Set":
@@ -108,5 +119,7 @@ class CustomJSONDecoder(json.JSONDecoder):
         if "_type" in obj and obj["_type"] in self.serializable_complex_types.keys():
             complex_type = obj.pop("_type")
             return self.serializable_complex_types[complex_type].from_dict(obj)
+        elif "_type" in obj:
+            print(obj)
 
         return obj

--- a/sec_certs/utils/extract.py
+++ b/sec_certs/utils/extract.py
@@ -586,20 +586,6 @@ def search_files(folder: str) -> Iterator[str]:
         yield from [os.path.join(root, x) for x in files]
 
 
-def save_modified_cert_file(target_file: Union[str, Path], modified_cert_file_text: str, is_unicode_text: bool) -> None:
-    if is_unicode_text:
-        write_file = Path(target_file).open("w", encoding="utf8", errors="replace")
-    else:
-        write_file = Path(target_file).open("w", errors="replace")
-
-    try:
-        write_file.write(modified_cert_file_text)
-    except UnicodeEncodeError:
-        logger.error("UnicodeDecodeError while writing file fragments back")
-    finally:
-        write_file.close()
-
-
 def flatten_matches(dct: Dict) -> Dict:
     """
     Function to flatten dictionary of matches.

--- a/sec_certs/utils/extract.py
+++ b/sec_certs/utils/extract.py
@@ -581,8 +581,8 @@ def search_only_headers_canada(filepath: Path):  # noqa: C901
     return constants.RETURNCODE_OK, items_found
 
 
-def search_files(folder: str) -> Iterator[str]:
-    for root, _, files in os.walk(folder):
+def search_files(folder: Union[str, Path]) -> Iterator[str]:
+    for root, _, files in os.walk(str(folder)):
         yield from [os.path.join(root, x) for x in files]
 
 

--- a/sec_certs/utils/helpers.py
+++ b/sec_certs/utils/helpers.py
@@ -34,7 +34,7 @@ def download_file(
         time.sleep(delay)
         # See https://github.com/psf/requests/issues/3953 for header justification
         r = requests.get(
-            url, allow_redirects=True, timeout=constants.REQUEST_TIMEOUT, stream=True, headers={"Accept-Encoding": None}
+            url, allow_redirects=True, timeout=constants.REQUEST_TIMEOUT, stream=True, headers={"Accept-Encoding": None}  # type: ignore
         )
         ctx: Any
         if show_progress_bar:

--- a/sec_certs/utils/helpers.py
+++ b/sec_certs/utils/helpers.py
@@ -48,6 +48,7 @@ def download_file(
             )
         else:
             ctx = nullcontext
+
         if r.status_code == requests.codes.ok:
             with ctx() as pbar:
                 with output.open("wb") as f:

--- a/tests/data/test_cc_heuristics/auxillary_datasets/cpe_dataset.json
+++ b/tests/data/test_cc_heuristics/auxillary_datasets/cpe_dataset.json
@@ -1,30 +1,30 @@
 {
-    "_type": "CPEDataset",
+    "_type": "sec_certs.dataset.cpe.CPEDataset",
     "was_enhanced_with_vuln_cpes": true,
     "cpes": {
         "cpe:2.3:a:ibm:security_access_manager_for_enterprise_single_sign-on:8.2.2:*:*:*:*:*:*:*": {
-            "_type": "CPE",
+            "_type": "sec_certs.sample.cpe.CPE",
             "uri": "cpe:2.3:a:ibm:security_access_manager_for_enterprise_single_sign-on:8.2.2:*:*:*:*:*:*:*",
             "title": "IBM Security Access Manager For Enterprise Single Sign-On 8.2.2",
             "start_version": null,
             "end_version": null
         },
         "cpe:2.3:a:ibm:security_key_lifecycle_manager:2.6.0.1:*:*:*:*:*:*:*": {
-            "_type": "CPE",
+            "_type": "sec_certs.sample.cpe.CPE",
             "uri": "cpe:2.3:a:ibm:security_key_lifecycle_manager:2.6.0.1:*:*:*:*:*:*:*",
             "title": "IBM Security Key Lifecycle Manager 2.6.0.1",
             "start_version": null,
             "end_version": null
         },
         "cpe:2.3:a:semperplugins:all_in_one_seo_pack:1.3.6.4:*:*:*:*:wordpress:*:*": {
-            "_type": "CPE",
+            "_type": "sec_certs.sample.cpe.CPE",
             "uri": "cpe:2.3:a:semperplugins:all_in_one_seo_pack:1.3.6.4:*:*:*:*:wordpress:*:*",
             "title": "Semper Plugins All in One SEO Pack 1.3.6.4 for WordPress",
             "start_version": null,
             "end_version": null
         },
         "cpe:2.3:a:tracker-software:pdf-xchange_lite_printer:6.0.320.0:*:*:*:*:*:*:*": {
-            "_type": "CPE",
+            "_type": "sec_certs.sample.cpe.CPE",
             "uri": "cpe:2.3:a:tracker-software:pdf-xchange_lite_printer:6.0.320.0:*:*:*:*:*:*:*",
             "title": "Tracker Software PDF-XChange Lite Printer 6.0.320.0",
             "start_version": null,

--- a/tests/data/test_cc_heuristics/auxillary_datasets/cve_dataset.json
+++ b/tests/data/test_cc_heuristics/auxillary_datasets/cve_dataset.json
@@ -1,12 +1,12 @@
 {
-    "_type": "CVEDataset",
+    "_type": "sec_certs.dataset.cve.CVEDataset",
     "cves": {
         "CVE-2017-1732": {
-            "_type": "CVE",
+            "_type": "sec_certs.sample.cve.CVE",
             "cve_id": "CVE-2017-1732",
             "vulnerable_cpes": [
                 {
-                    "_type": "CPE",
+                    "_type": "sec_certs.sample.cpe.CPE",
                     "uri": "cpe:2.3:a:ibm:security_access_manager_for_enterprise_single_sign-on:8.2.2:*:*:*:*:*:*:*",
                     "title": "IBM Security Access Manager For Enterprise Single Sign-On 8.2.2",
                     "start_version": null,
@@ -14,7 +14,7 @@
                 }
             ],
             "impact": {
-                "_type": "Impact",
+                "_type": "sec_certs.sample.cve.CVE.Impact",
                 "base_score": 5.3,
                 "severity": "MEDIUM",
                 "exploitability_score": 3.9,
@@ -29,11 +29,11 @@
             }
         },
         "CVE-2019-4513": {
-            "_type": "CVE",
+            "_type": "sec_certs.sample.cve.CVE",
             "cve_id": "CVE-2019-4513",
             "vulnerable_cpes": [
                 {
-                    "_type": "CPE",
+                    "_type": "sec_certs.sample.cpe.CPE",
                     "uri": "cpe:2.3:a:ibm:security_access_manager_for_enterprise_single_sign-on:8.2.2:*:*:*:*:*:*:*",
                     "title": "IBM Security Access Manager For Enterprise Single Sign-On 8.2.2",
                     "start_version": null,
@@ -41,7 +41,7 @@
                 }
             ],
             "impact": {
-                "_type": "Impact",
+                "_type": "sec_certs.sample.cve.CVE.Impact",
                 "base_score": 8.2,
                 "severity": "HIGH",
                 "exploitability_score": 3.9,

--- a/tests/data/test_cc_heuristics/dependency_dataset.json
+++ b/tests/data/test_cc_heuristics/dependency_dataset.json
@@ -1,7 +1,7 @@
 {
-  "_type": "CCDataset",
+  "_type": "sec_certs.dataset.common_criteria.CCDataset",
   "state": {
-    "_type": "DatasetInternalState",
+    "_type": "sec_certs.dataset.common_criteria.CCDataset.DatasetInternalState",
     "meta_sources_parsed": false,
     "pdfs_downloaded": false,
     "pdfs_converted": false,
@@ -14,7 +14,7 @@
   "n_certs": 3,
   "certs": [
     {
-      "_type": "CommonCriteriaCert",
+      "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert",
       "dgst": "c30de3192d2e8ec2",
       "status": "archived",
       "category": "Other Devices and Systems",
@@ -43,7 +43,7 @@
         "elements": []
       },
       "state": {
-        "_type": "InternalState",
+        "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert.InternalState",
         "st_download_ok": true,
         "report_download_ok": true,
         "st_convert_ok": true,
@@ -57,7 +57,7 @@
         "report_txt_hash": "460e8010dbc8f5de5b87bf96fd45c71cfd9f3869f34ca6ac1ab02cbd70d2523f"
       },
       "pdf_data": {
-        "_type": "PdfData",
+        "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert.PdfData",
         "report_metadata": {
           "pdf_file_size_bytes": 393439,
           "pdf_is_encrypted": false,
@@ -469,7 +469,7 @@
         }
       },
       "heuristics": {
-        "_type": "CCHeuristics",
+        "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert.Heuristics",
         "extracted_versions": {
           "_type": "Set",
           "elements": [
@@ -484,14 +484,14 @@
         ],
         "cert_id": "BSI-DSZ-CC-0517-2009",
         "st_references": {
-          "_type": "References",
+          "_type": "sec_certs.sample.certificate.References",
           "directly_referenced_by": null,
           "indirectly_referenced_by": null,
           "directly_referencing": null,
           "indirectly_referencing": null
         },
         "report_references": {
-          "_type": "References",
+          "_type": "sec_certs.sample.certificate.References",
           "directly_referenced_by": null,
           "indirectly_referenced_by": null,
           "directly_referencing": {
@@ -513,57 +513,57 @@
           "_type": "Set",
           "elements": [
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ADV_FSP",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ADV_HLD",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ADV_RCR",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "AGD_ADM",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "AGD_USR",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ALC_FLR",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ATE_COV",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ATE_FUN",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ATE_IND",
               "level": 2
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "AVA_SOF",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "AVA_VLA",
               "level": 1
             }
@@ -574,7 +574,7 @@
       }
     },
     {
-      "_type": "CommonCriteriaCert",
+      "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert",
       "dgst": "53fe111411edfa45",
       "status": "archived",
       "category": "Other Devices and Systems",
@@ -603,7 +603,7 @@
         "elements": []
       },
       "state": {
-        "_type": "InternalState",
+        "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert.InternalState",
         "st_download_ok": true,
         "report_download_ok": true,
         "st_convert_ok": true,
@@ -617,7 +617,7 @@
         "report_txt_hash": "0535df1c56fb4f87153cbffee51ba4d77fac47a6f17f024aa7d9df461028bc65"
       },
       "pdf_data": {
-        "_type": "PdfData",
+        "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert.PdfData",
         "report_metadata": {
           "pdf_file_size_bytes": 296713,
           "pdf_is_encrypted": false,
@@ -1058,7 +1058,7 @@
         }
       },
       "heuristics": {
-        "_type": "CCHeuristics",
+        "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert.Heuristics",
         "extracted_versions": {
           "_type": "Set",
           "elements": [
@@ -1073,14 +1073,14 @@
         ],
         "cert_id": "BSI-DSZ-CC-0370-2006",
         "st_references": {
-          "_type": "References",
+          "_type": "sec_certs.sample.certificate.References",
           "directly_referenced_by": null,
           "indirectly_referenced_by": null,
           "directly_referencing": null,
           "indirectly_referencing": null
         },
         "report_references": {
-          "_type": "References",
+          "_type": "sec_certs.sample.certificate.References",
           "directly_referenced_by": {
             "_type": "Set",
             "elements": [
@@ -1111,97 +1111,97 @@
           "_type": "Set",
           "elements": [
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ADV_FSP",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ADV_HLD",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ADV_RCR",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "AGD_ADM",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "AGD_USR",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ALC_FLR",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_DES",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_ENV",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_INT",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_OBJ",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_PPC",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_REQ",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_SRE",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_TSS",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ATE_COV",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ATE_FUN",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ATE_IND",
               "level": 2
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "AVA_SOF",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "AVA_VLA",
               "level": 1
             }
@@ -1212,7 +1212,7 @@
       }
     },
     {
-      "_type": "CommonCriteriaCert",
+      "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert",
       "dgst": "692e91451741ef49",
       "status": "archived",
       "category": "Other Devices and Systems",
@@ -1241,7 +1241,7 @@
         "elements": []
       },
       "state": {
-        "_type": "InternalState",
+        "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert.InternalState",
         "st_download_ok": true,
         "report_download_ok": true,
         "st_convert_ok": true,
@@ -1255,7 +1255,7 @@
         "report_txt_hash": "11e1262fd8f5df1b140f5e8813883b71447503781399427b35adbbecd00b4d63"
       },
       "pdf_data": {
-        "_type": "PdfData",
+        "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert.PdfData",
         "report_metadata": {
           "pdf_file_size_bytes": 628533,
           "pdf_is_encrypted": false,
@@ -1690,7 +1690,7 @@
         }
       },
       "heuristics": {
-        "_type": "CCHeuristics",
+        "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert.Heuristics",
         "extracted_versions": {
           "_type": "Set",
           "elements": [
@@ -1705,14 +1705,14 @@
         ],
         "cert_id": "BSI-DSZ-CC-0325-2006",
         "st_references": {
-          "_type": "References",
+          "_type": "sec_certs.sample.certificate.References",
           "directly_referenced_by": null,
           "indirectly_referenced_by": null,
           "directly_referencing": null,
           "indirectly_referencing": null
         },
         "report_references": {
-          "_type": "References",
+          "_type": "sec_certs.sample.certificate.References",
           "directly_referenced_by": {
             "_type": "Set",
             "elements": [
@@ -1743,97 +1743,97 @@
           "_type": "Set",
           "elements": [
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ADV_FSP",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ADV_HLD",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ADV_RCR",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "AGD_ADM",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "AGD_USR",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ALC_FLR",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_DES",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_ENV",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_INT",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_OBJ",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_PPC",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_REQ",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_SRE",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_TSS",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ATE_COV",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ATE_FUN",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ATE_IND",
               "level": 2
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "AVA_SOF",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "AVA_VLA",
               "level": 1
             }

--- a/tests/data/test_cc_heuristics/dependency_vulnerability_dataset.json
+++ b/tests/data/test_cc_heuristics/dependency_vulnerability_dataset.json
@@ -1,7 +1,7 @@
 {
-  "_type": "CCDataset",
+  "_type": "sec_certs.dataset.common_criteria.CCDataset",
   "state": {
-    "_type": "DatasetInternalState",
+    "_type": "sec_certs.dataset.common_criteria.CCDataset.DatasetInternalState",
     "meta_sources_parsed": false,
     "pdfs_downloaded": false,
     "pdfs_converted": false,
@@ -14,7 +14,7 @@
   "n_certs": 3,
   "certs": [
     {
-      "_type": "CommonCriteriaCert",
+      "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert",
       "dgst": "d0705c9e6fbaeba3",
       "status": "active",
       "category": "Operating Systems",
@@ -38,7 +38,7 @@
         "_type": "Set",
         "elements": [
           {
-            "_type": "ProtectionProfile",
+            "_type": "sec_certs.sample.protection_profile.ProtectionProfile",
             "pp_name": "Operating System Protection Profile, Version 2.0",
             "pp_link": "https://www.commoncriteriaportal.org/files/ppfiles/pp0067b_pdf.pdf",
             "pp_ids": [
@@ -52,7 +52,7 @@
         "elements": []
       },
       "state": {
-        "_type": "InternalState",
+        "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert.InternalState",
         "st_download_ok": true,
         "report_download_ok": true,
         "st_convert_ok": true,
@@ -66,7 +66,7 @@
         "report_txt_hash": "9d360141a98e764b15855f519b456c4e4639f993c4f8b5ab67e9c8ae7fbfc9e4"
       },
       "pdf_data": {
-        "_type": "PdfData",
+        "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert.PdfData",
         "report_metadata": {
           "pdf_file_size_bytes": 1235750,
           "pdf_is_encrypted": false,
@@ -1061,7 +1061,7 @@
         }
       },
       "heuristics": {
-        "_type": "CCHeuristics",
+        "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert.Heuristics",
         "extracted_versions": {
           "_type": "Set",
           "elements": [
@@ -1099,14 +1099,14 @@
         ],
         "cert_id": "BSI-DSZ-CC-0874-2014",
         "st_references": {
-          "_type": "References",
+          "_type": "sec_certs.sample.certificate.References",
           "directly_referenced_by": null,
           "indirectly_referenced_by": null,
           "directly_referencing": null,
           "indirectly_referencing": null
         },
         "report_references": {
-          "_type": "References",
+          "_type": "sec_certs.sample.certificate.References",
           "directly_referenced_by": {
             "_type": "Set",
             "elements": [
@@ -1148,167 +1148,167 @@
           "_type": "Set",
           "elements": [
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ADV_ARC",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ADV_FSP",
               "level": 4
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ADV_IMP",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ADV_INT",
               "level": 3
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ADV_SPM",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ADV_TDS",
               "level": 3
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "AGD_OPE",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "AGD_PRE",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ALC_CMC",
               "level": 4
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ALC_CMS",
               "level": 4
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ALC_DEL",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ALC_DVS",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ALC_FLR",
               "level": 3
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ALC_LCD",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ALC_TAT",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "APE_CCL",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "APE_ECD",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "APE_INT",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "APE_OBJ",
               "level": 2
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "APE_REQ",
               "level": 2
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "APE_SPD",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_CCL",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_ECD",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_INT",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_OBJ",
               "level": 2
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_REQ",
               "level": 2
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_SPD",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_TSS",
               "level": 2
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ATE_COV",
               "level": 2
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ATE_DPT",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ATE_FUN",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ATE_IND",
               "level": 2
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "AVA_VAN",
               "level": 3
             }
@@ -1329,7 +1329,7 @@
       }
     },
     {
-      "_type": "CommonCriteriaCert",
+      "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert",
       "dgst": "011796336c7b94de",
       "status": "archived",
       "category": "Operating Systems",
@@ -1358,7 +1358,7 @@
         "elements": []
       },
       "state": {
-        "_type": "InternalState",
+        "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert.InternalState",
         "st_download_ok": true,
         "report_download_ok": true,
         "st_convert_ok": true,
@@ -1372,7 +1372,7 @@
         "report_txt_hash": "dd120ba7667c2385839c96ee70c56f2a4d464fc95e3ea2818d31b3347d06fd4f"
       },
       "pdf_data": {
-        "_type": "PdfData",
+        "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert.PdfData",
         "report_metadata": {
           "pdf_file_size_bytes": 1178202,
           "pdf_is_encrypted": false,
@@ -2015,7 +2015,7 @@
         }
       },
       "heuristics": {
-        "_type": "CCHeuristics",
+        "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert.Heuristics",
         "extracted_versions": {
           "_type": "Set",
           "elements": [
@@ -2041,14 +2041,14 @@
         ],
         "cert_id": "BSI-DSZ-CC-0875-2015",
         "st_references": {
-          "_type": "References",
+          "_type": "sec_certs.sample.certificate.References",
           "directly_referenced_by": null,
           "indirectly_referenced_by": null,
           "directly_referencing": null,
           "indirectly_referencing": null
         },
         "report_references": {
-          "_type": "References",
+          "_type": "sec_certs.sample.certificate.References",
           "directly_referenced_by": {
             "_type": "Set",
             "elements": [
@@ -2089,167 +2089,167 @@
           "_type": "Set",
           "elements": [
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ADV_ARC",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ADV_FSP",
               "level": 5
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ADV_IMP",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ADV_INT",
               "level": 2
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ADV_SPM",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ADV_TDS",
               "level": 4
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "AGD_OPE",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "AGD_PRE",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ALC_CMC",
               "level": 4
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ALC_CMS",
               "level": 5
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ALC_DEL",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ALC_DVS",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ALC_FLR",
               "level": 3
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ALC_LCD",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ALC_TAT",
               "level": 2
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "APE_CCL",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "APE_ECD",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "APE_INT",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "APE_OBJ",
               "level": 2
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "APE_REQ",
               "level": 2
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "APE_SPD",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_CCL",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_ECD",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_INT",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_OBJ",
               "level": 2
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_REQ",
               "level": 2
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_SPD",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_TSS",
               "level": 2
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ATE_COV",
               "level": 2
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ATE_DPT",
               "level": 3
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ATE_FUN",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ATE_IND",
               "level": 2
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "AVA_VAN",
               "level": 4
             }
@@ -2270,7 +2270,7 @@
       }
     },
     {
-      "_type": "CommonCriteriaCert",
+      "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert",
       "dgst": "ebc77980250ee68f",
       "status": "active",
       "category": "Operating Systems",
@@ -2294,7 +2294,7 @@
         "_type": "Set",
         "elements": [
           {
-            "_type": "ProtectionProfile",
+            "_type": "sec_certs.sample.protection_profile.ProtectionProfile",
             "pp_name": "Operating System Protection Profile, Version 2.0",
             "pp_link": "https://www.commoncriteriaportal.org/files/ppfiles/pp0067b_pdf.pdf",
             "pp_ids": [
@@ -2308,7 +2308,7 @@
         "elements": []
       },
       "state": {
-        "_type": "InternalState",
+        "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert.InternalState",
         "st_download_ok": true,
         "report_download_ok": true,
         "st_convert_ok": true,
@@ -2322,7 +2322,7 @@
         "report_txt_hash": "0a7c65e3d11f082c8f75aba7de0079c0b1aa5e67bb28d4635cbcaa4cd200d1c2"
       },
       "pdf_data": {
-        "_type": "PdfData",
+        "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert.PdfData",
         "report_metadata": {
           "pdf_file_size_bytes": 1932018,
           "pdf_is_encrypted": false,
@@ -3381,7 +3381,7 @@
         }
       },
       "heuristics": {
-        "_type": "CCHeuristics",
+        "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert.Heuristics",
         "extracted_versions": {
           "_type": "Set",
           "elements": [
@@ -3406,14 +3406,14 @@
         ],
         "cert_id": "BSI-DSZ-CC-0948-2017",
         "st_references": {
-          "_type": "References",
+          "_type": "sec_certs.sample.certificate.References",
           "directly_referenced_by": null,
           "indirectly_referenced_by": null,
           "directly_referencing": null,
           "indirectly_referencing": null
         },
         "report_references": {
-          "_type": "References",
+          "_type": "sec_certs.sample.certificate.References",
           "directly_referenced_by": null,
           "indirectly_referenced_by": null,
           "directly_referencing": {
@@ -3441,167 +3441,167 @@
           "_type": "Set",
           "elements": [
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ADV_ARC",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ADV_FSP",
               "level": 4
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ADV_IMP",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ADV_INT",
               "level": 3
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ADV_SPM",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ADV_TDS",
               "level": 3
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "AGD_OPE",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "AGD_PRE",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ALC_CMC",
               "level": 4
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ALC_CMS",
               "level": 4
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ALC_DEL",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ALC_DVS",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ALC_FLR",
               "level": 3
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ALC_LCD",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ALC_TAT",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "APE_CCL",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "APE_ECD",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "APE_INT",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "APE_OBJ",
               "level": 2
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "APE_REQ",
               "level": 2
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "APE_SPD",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_CCL",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_ECD",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_INT",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_OBJ",
               "level": 2
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_REQ",
               "level": 2
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_SPD",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ASE_TSS",
               "level": 2
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ATE_COV",
               "level": 2
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ATE_DPT",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ATE_FUN",
               "level": 1
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "ATE_IND",
               "level": 2
             },
             {
-              "_type": "SAR",
+              "_type": "sec_certs.sample.sar.SAR",
               "family": "AVA_VAN",
               "level": 3
             }

--- a/tests/data/test_cc_heuristics/vulnerable_dataset.json
+++ b/tests/data/test_cc_heuristics/vulnerable_dataset.json
@@ -1,7 +1,7 @@
 {
-    "_type": "CCDataset",
+    "_type": "sec_certs.dataset.common_criteria.CCDataset",
     "state": {
-        "_type": "DatasetInternalState",
+        "_type": "sec_certs.dataset.common_criteria.CCDataset.DatasetInternalState",
         "meta_sources_parsed": true,
         "pdfs_downloaded": false,
         "pdfs_converted": false,
@@ -13,7 +13,7 @@
     "description": "sample dataset description",
     "n_certs": 1,
     "certs": [{
-        "_type": "CommonCriteriaCert",
+        "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert",
         "dgst": "c01e5375331b25dc",
         "status": "active",
         "category": "Access Control Devices and Systems",
@@ -36,7 +36,7 @@
         "protection_profiles": [],
         "maintenance_updates": [],
         "state": {
-            "_type": "InternalState",
+            "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert.InternalState",
             "st_download_ok": true,
             "report_download_ok": true,
             "st_convert_ok": true,
@@ -46,7 +46,7 @@
             "errors": []
         },
         "pdf_data": {
-            "_type": "PdfData",
+            "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert.PdfData",
             "report_metadata": null,
             "st_metadata": null,
             "report_frontpage": null,
@@ -55,7 +55,7 @@
             "st_keywords": null
         },
         "heuristics": {
-            "_type": "CCHeuristics",
+            "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert.Heuristics",
             "extracted_versions": [
                 "8.2"
             ],

--- a/tests/data/test_cc_oop/fictional_cert.json
+++ b/tests/data/test_cc_oop/fictional_cert.json
@@ -1,5 +1,5 @@
 {
-    "_type": "CommonCriteriaCert",
+    "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert",
     "dgst": "a9ccb81a92e547dc",
     "status": "archived",
     "category": "Sample category",
@@ -18,7 +18,7 @@
     "protection_profiles": {
         "_type": "Set",
         "elements": [{
-            "_type": "ProtectionProfile",
+            "_type": "sec_certs.sample.protection_profile.ProtectionProfile",
             "pp_name": "sample_pp",
             "pp_link": "https://sample.pp",
             "pp_ids": null
@@ -27,7 +27,7 @@
     "maintenance_updates": {
         "_type": "Set",
         "elements": [{
-            "_type": "MaintenanceReport",
+            "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert.MaintenanceReport",
             "maintenance_date": "1900-01-01",
             "maintenance_title": "Sample maintenance",
             "maintenance_report_link": "https://maintenance.up",
@@ -35,7 +35,7 @@
         }]
     },
     "state": {
-        "_type": "InternalState",
+        "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert.InternalState",
         "st_download_ok": true,
         "report_download_ok": true,
         "st_convert_ok": true,
@@ -49,7 +49,7 @@
         "report_txt_hash": null
     },
     "pdf_data": {
-        "_type": "PdfData",
+        "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert.PdfData",
         "report_metadata": null,
         "st_metadata": null,
         "report_frontpage": null,
@@ -58,7 +58,7 @@
         "st_keywords": null
     },
     "heuristics": {
-        "_type": "CCHeuristics",
+        "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert.Heuristics",
         "extracted_versions": null,
         "cpe_matches": null,
         "verified_cpe_matches": null,
@@ -69,14 +69,14 @@
         "direct_dependency_cves": null,
         "indirect_dependency_cves": null,
         "report_references": {
-            "_type": "References",
+            "_type": "sec_certs.sample.certificate.References",
             "directly_referenced_by": null,
             "directly_referencing": null,
             "indirectly_referenced_by": null,
             "indirectly_referencing": null
         },
         "st_references": {
-            "_type": "References",
+            "_type": "sec_certs.sample.certificate.References",
             "directly_referenced_by": null,
             "directly_referencing": null,
             "indirectly_referenced_by": null,

--- a/tests/data/test_cc_oop/toy_dataset.json
+++ b/tests/data/test_cc_oop/toy_dataset.json
@@ -1,7 +1,7 @@
 {
-    "_type": "CCDataset",
+    "_type": "sec_certs.dataset.common_criteria.CCDataset",
     "state": {
-        "_type": "DatasetInternalState",
+        "_type": "sec_certs.dataset.common_criteria.CCDataset.DatasetInternalState",
         "meta_sources_parsed": true,
         "pdfs_downloaded": false,
         "pdfs_converted": false,
@@ -13,7 +13,7 @@
     "description": "toy dataset description",
     "n_certs": 2,
     "certs": [{
-            "_type": "CommonCriteriaCert",
+            "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert",
             "dgst": "309ac2fd7f2dcf17",
             "status": "active",
             "category": "Access Control Devices and Systems",
@@ -42,7 +42,7 @@
                 "elements": []
             },
             "state": {
-                "_type": "InternalState",
+                "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert.InternalState",
                 "st_download_ok": true,
                 "report_download_ok": true,
                 "st_convert_ok": true,
@@ -56,7 +56,7 @@
                 "report_txt_hash": null
             },
             "pdf_data": {
-                "_type": "PdfData",
+                "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert.PdfData",
                 "report_metadata": null,
                 "st_metadata": null,
                 "report_frontpage": null,
@@ -65,7 +65,7 @@
                 "st_keywords": null
             },
             "heuristics": {
-                "_type": "CCHeuristics",
+                "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert.Heuristics",
                 "extracted_versions": null,
                 "cpe_matches": null,
                 "verified_cpe_matches": null,
@@ -76,14 +76,14 @@
                 "direct_dependency_cves": null,
                 "indirect_dependency_cves": null,
                 "report_references": {
-                    "_type": "References",
+                    "_type": "sec_certs.sample.certificate.References",
                     "directly_referenced_by": null,
                     "directly_referencing": null,
                     "indirectly_referenced_by": null,
                     "indirectly_referencing": null
                 },
                 "st_references": {
-                    "_type": "References",
+                    "_type": "sec_certs.sample.certificate.References",
                     "directly_referenced_by": null,
                     "directly_referencing": null,
                     "indirectly_referenced_by": null,
@@ -92,7 +92,7 @@
             }
         },
         {
-            "_type": "CommonCriteriaCert",
+            "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert",
             "dgst": "8cf86948f02f047d",
             "status": "active",
             "category": "Access Control Devices and Systems",
@@ -112,7 +112,7 @@
             "protection_profiles": {
                 "_type": "Set",
                 "elements": [{
-                    "_type": "ProtectionProfile",
+                    "_type": "sec_certs.sample.protection_profile.ProtectionProfile",
                     "pp_name": "Korean National Protection Profile for Single Sign On V1.0",
                     "pp_link": "https://www.commoncriteriaportal.org/files/ppfiles/KECS-PP-0822-2017%20Korean%20National%20PP%20for%20Single%20Sign%20On%20V1.0(eng).pdf",
                     "pp_ids": null
@@ -123,7 +123,7 @@
                 "elements": []
             },
             "state": {
-                "_type": "InternalState",
+                "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert.InternalState",
                 "st_download_ok": true,
                 "report_download_ok": true,
                 "st_convert_ok": true,
@@ -137,7 +137,7 @@
                 "report_txt_hash": null
             },
             "pdf_data": {
-                "_type": "PdfData",
+                "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert.PdfData",
                 "report_metadata": null,
                 "st_metadata": null,
                 "report_frontpage": null,
@@ -146,7 +146,7 @@
                 "st_keywords": null
             },
             "heuristics": {
-                "_type": "CCHeuristics",
+                "_type": "sec_certs.sample.common_criteria.CommonCriteriaCert.Heuristics",
                 "extracted_versions": null,
                 "cpe_matches": null,
                 "verified_cpe_matches": null,
@@ -157,14 +157,14 @@
                 "direct_dependency_cves": null,
                 "indirect_dependency_cves": null,
                 "report_references": {
-                    "_type": "References",
+                    "_type": "sec_certs.sample.certificate.References",
                     "directly_referenced_by": null,
                     "directly_referencing": null,
                     "indirectly_referenced_by": null,
                     "indirectly_referencing": null
                 },
                 "st_references": {
-                    "_type": "References",
+                    "_type": "sec_certs.sample.certificate.References",
                     "directly_referenced_by": null,
                     "directly_referencing": null,
                     "indirectly_referenced_by": null,

--- a/tests/data/test_fips_oop/algorithms.json
+++ b/tests/data/test_fips_oop/algorithms.json
@@ -1,9 +1,9 @@
 {
-    "_type": "FIPSAlgorithmDataset",
+    "_type": "sec_certs.dataset.fips_algorithm.FIPSAlgorithmDataset",
     "certs": {
         "2351": [
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2351",
                 "date": "9/21/2018",
                 "implementation": "Apple CoreCrypto Kernel Module v9.0 for ARM (iOS12, A11 Bionic, Assembler_VNG)",
@@ -11,7 +11,7 @@
                 "vendor": "Apple Inc."
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2351",
                 "date": "11/27/2015",
                 "implementation": "Apple iOS CoreCrypto Kernel Module (Optimized SHA, A6)",
@@ -19,7 +19,7 @@
                 "vendor": "Apple Inc."
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2351",
                 "date": "1/27/2017",
                 "implementation": "OpenSSL using assembler for AES and SHA",
@@ -27,7 +27,7 @@
                 "vendor": "Canonical Ltd."
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2351",
                 "date": "1/19/2017",
                 "implementation": "Junos FIPS Version Junos 15.1 X49 - Dataplane_CN7020",
@@ -35,7 +35,7 @@
                 "vendor": "Juniper Networks, Inc."
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2351",
                 "date": "3/8/2013",
                 "implementation": "Samsung OpenSSL Cryptographic Module",
@@ -43,7 +43,7 @@
                 "vendor": "Samsung Electronics Co., Ltd"
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2351",
                 "date": "3/7/2014",
                 "implementation": "Symantec PGP Cryptographic Engine",
@@ -53,7 +53,7 @@
         ],
         "2352": [
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2352",
                 "date": "9/21/2018",
                 "implementation": "Apple CoreCrypto Kernel Module v9.0 for ARM (iOS12, A10X Fusion, Assembler_VNG)",
@@ -61,7 +61,7 @@
                 "vendor": "Apple Inc."
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2352",
                 "date": "3/8/2013",
                 "implementation": "AES-256 Core",
@@ -69,7 +69,7 @@
                 "vendor": "Altera Canada"
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2352",
                 "date": "11/27/2015",
                 "implementation": "Apple iOS CoreCrypto Kernel Module (Optimized SHA, A6X)",
@@ -77,7 +77,7 @@
                 "vendor": "Apple Inc."
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2352",
                 "date": "1/27/2017",
                 "implementation": "OpenSSL using support from Power ISA 2.07 for AES and SHA",
@@ -85,7 +85,7 @@
                 "vendor": "Canonical Ltd."
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2352",
                 "date": "1/19/2017",
                 "implementation": "Junos FIPS Version Junos 15.1 X49 - Dataplane_CN7130",
@@ -93,7 +93,7 @@
                 "vendor": "Juniper Networks, Inc."
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2352",
                 "date": "3/21/2014",
                 "implementation": "Karnak SHA in Hardware",
@@ -103,7 +103,7 @@
         ],
         "2600": [
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2600",
                 "date": "12/15/2017",
                 "implementation": "Apple iOS CoreCrypto v8 Kernel Module (Generic Software Implementation)",
@@ -111,7 +111,7 @@
                 "vendor": "Apple Inc."
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2600",
                 "date": "6/10/2016",
                 "implementation": "IOS Common Cryptographic Module (IC2M) Algorithm Module",
@@ -119,7 +119,7 @@
                 "vendor": "Cisco Systems, Inc."
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2600",
                 "date": "8/16/2013",
                 "implementation": "Blade System Virtual Connect",
@@ -127,7 +127,7 @@
                 "vendor": "Hewlett-Packard Development Company, L.P."
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2600",
                 "date": "12/5/2014",
                 "implementation": "Cryptographic Security Kernel",
@@ -135,7 +135,7 @@
                 "vendor": "IBM Corporation"
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2600",
                 "date": "9/1/2017",
                 "implementation": "IBM z/OS(R) Cryptographic Services System SSL - 31bit",
@@ -145,7 +145,7 @@
         ],
         "2601": [
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2601",
                 "date": "12/5/2014",
                 "implementation": "SHA256 Library on Canon MFP Security Chip",
@@ -153,7 +153,7 @@
                 "vendor": "Canon Inc."
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2601",
                 "date": "8/16/2013",
                 "implementation": "Dell AppAssure Crypto Library",
@@ -161,7 +161,7 @@
                 "vendor": "Dell, Inc."
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2601",
                 "date": "6/10/2016",
                 "implementation": "EFJ Communication Cryptographic Library",
@@ -169,7 +169,7 @@
                 "vendor": "EFJohnson Technologies"
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2601",
                 "date": "9/1/2017",
                 "implementation": "IBM z/OS(R) Cryptographic Services System SSL - 64bit",
@@ -177,7 +177,7 @@
                 "vendor": "IBM Corporation"
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2601",
                 "date": "12/22/2017",
                 "implementation": "Oracle Linux 7 GnuTLS C Implementation",
@@ -187,7 +187,7 @@
         ],
         "2602": [
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2602",
                 "date": "12/22/2017",
                 "implementation": "Apple tvOS CoreCrypto Kernel Module v8.0 (Generic Software Implementation)",
@@ -195,7 +195,7 @@
                 "vendor": "Apple Inc."
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2602",
                 "date": "6/10/2016",
                 "implementation": "FIPS-ALGORITHMS.1.5.0v",
@@ -203,7 +203,7 @@
                 "vendor": "Mercury Systems"
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2602",
                 "date": "8/16/2013",
                 "implementation": "RSA BSAFE\u00ae Crypto-J Software Module",
@@ -211,7 +211,7 @@
                 "vendor": "RSA Security, Inc."
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2602",
                 "date": "12/5/2014",
                 "implementation": "SHA Library",
@@ -219,7 +219,7 @@
                 "vendor": "Sage Microelectronics Corp"
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2602",
                 "date": "9/1/2017",
                 "implementation": "Bouncy Castle FIPS Java API",
@@ -229,7 +229,7 @@
         ],
         "2700": [
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2700",
                 "date": "3/13/2015",
                 "implementation": "Apple OSX CoreCrypto Module (Generic, Xeon)",
@@ -237,7 +237,7 @@
                 "vendor": "Apple Inc."
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2700",
                 "date": "10/21/2016",
                 "implementation": "Axway OpenSSL",
@@ -245,7 +245,7 @@
                 "vendor": "Axway Inc."
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2700",
                 "date": "11/30/2017",
                 "implementation": "Brocade Fabric OS FIPS Cryptographic Module",
@@ -253,7 +253,7 @@
                 "vendor": "Brocade Communications Systems LLC"
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2700",
                 "date": "3/30/2018",
                 "implementation": "Junos OS 17.4R1-S1 - Dataplane",
@@ -261,7 +261,7 @@
                 "vendor": "Juniper Networks, Inc."
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2700",
                 "date": "11/29/2013",
                 "implementation": "VMware NSS Cryptographic Module",
@@ -271,7 +271,7 @@
         ],
         "2701": [
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2701",
                 "date": "3/30/2018",
                 "implementation": "Security Builder GSE-J Crypto Core",
@@ -279,7 +279,7 @@
                 "vendor": "BlackBerry Certicom"
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2701",
                 "date": "11/30/2017",
                 "implementation": "ngfips_rsa",
@@ -287,7 +287,7 @@
                 "vendor": "Cavium, Inc."
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2701",
                 "date": "10/28/2016",
                 "implementation": "Cisco_SSL_Implementation-1",
@@ -295,7 +295,7 @@
                 "vendor": "Cisco Systems, Inc."
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2701",
                 "date": "3/13/2015",
                 "implementation": "RSA BSAFE\u00ae Crypto-J JSAFE and JCE Software Module",
@@ -303,7 +303,7 @@
                 "vendor": "RSA, The Security Division of EMC"
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2701",
                 "date": "11/29/2013",
                 "implementation": "VMware Cryptographic Module",
@@ -313,7 +313,7 @@
         ],
         "2702": [
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2702",
                 "date": "3/30/2018",
                 "implementation": "Security Builder GSE-J Crypto Core",
@@ -321,7 +321,7 @@
                 "vendor": "BlackBerry Certicom"
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2702",
                 "date": "11/30/2017",
                 "implementation": "DELPHI RSA2048 Signature Verification Algorithm Implementation",
@@ -329,7 +329,7 @@
                 "vendor": "DELPHI"
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2702",
                 "date": "12/6/2013",
                 "implementation": "RSA BSAFE Crypto-J",
@@ -337,7 +337,7 @@
                 "vendor": "McAfee, Inc."
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2702",
                 "date": "10/28/2016",
                 "implementation": "OpenSSL Crypto Library",
@@ -345,7 +345,7 @@
                 "vendor": "MikroM GmbH"
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "2702",
                 "date": "3/13/2015",
                 "implementation": "OpenSSL FIPS Object Module",
@@ -355,7 +355,7 @@
         ],
         "3415": [
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "3415",
                 "date": "1/26/2018",
                 "implementation": "Apple Secure Key Store CoreCrypto Module (Generic Software Implementation)",
@@ -363,7 +363,7 @@
                 "vendor": "Apple Inc."
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "3415",
                 "date": "6/5/2015",
                 "implementation": "Motorola Solutions Subscriber \u00b5Mace AES256",
@@ -371,7 +371,7 @@
                 "vendor": "Motorola Solutions Inc"
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "3415",
                 "date": "11/18/2016",
                 "implementation": "Secure Parser Library",
@@ -381,7 +381,7 @@
         ],
         "3426": [
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "3426",
                 "date": "6/11/2015",
                 "implementation": "Apple iOS CoreCrypto Module (KeyWrap A8 32 bit)",
@@ -389,7 +389,7 @@
                 "vendor": "Apple Inc."
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "3426",
                 "date": "12/2/2016",
                 "implementation": "Apple iOS CoreCrypto Module (Generic)",
@@ -397,7 +397,7 @@
                 "vendor": "Apple Inc."
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "3426",
                 "date": "1/26/2018",
                 "implementation": "Apple Secure Key Store CoreCrypto Module (VNG)",
@@ -407,7 +407,7 @@
         ],
         "3427": [
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "3427",
                 "date": "12/2/2016",
                 "implementation": "Apple iOS CoreCrypto Module (Generic)",
@@ -415,7 +415,7 @@
                 "vendor": "Apple Inc."
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "3427",
                 "date": "1/26/2018",
                 "implementation": "Forcepoint NGFW FIPS Java API",
@@ -423,7 +423,7 @@
                 "vendor": "Forcepoint"
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "3427",
                 "date": "6/11/2015",
                 "implementation": "HP ESKM OpenSSL",
@@ -433,7 +433,7 @@
         ],
         "3447": [
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "3447",
                 "date": "12/2/2016",
                 "implementation": "Apple OSX CoreCrypto Module (Optimized SHA nosse)",
@@ -441,7 +441,7 @@
                 "vendor": "Apple Inc."
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "3447",
                 "date": "7/2/2015",
                 "implementation": "FireEye Algorithms Implementation",
@@ -449,7 +449,7 @@
                 "vendor": "FireEye, Inc."
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "3447",
                 "date": "2/9/2018",
                 "implementation": "OpenSSL (no AVX2/AVX/AESNI/SSSE3, x86_64, 64-bit library)",
@@ -459,7 +459,7 @@
         ],
         "3451": [
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "3451",
                 "date": "12/2/2016",
                 "implementation": "Apple OSX CoreCrypto Module (Optimized SHA nosse)",
@@ -467,7 +467,7 @@
                 "vendor": "Apple Inc."
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "3451",
                 "date": "7/2/2015",
                 "implementation": "OpenSSL FIPS Object Module",
@@ -475,7 +475,7 @@
                 "vendor": "OpenSSL Software Foundation, Inc."
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "3451",
                 "date": "2/9/2018",
                 "implementation": "OpenSSL (no AVX2/AVX/AESNI, x86_64, 64-bit library)",
@@ -485,7 +485,7 @@
         ],
         "3464": [
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "3464",
                 "date": "12/9/2016",
                 "implementation": "Apple OSX CoreCrypto Module (Generic)",
@@ -493,7 +493,7 @@
                 "vendor": "Apple Inc."
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "3464",
                 "date": "7/10/2015",
                 "implementation": "Security Builder Linux Kernel Crypto Core",
@@ -501,7 +501,7 @@
                 "vendor": "Certicom Corp."
             },
             {
-                "_type": "Algorithm",
+                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
                 "cert_id": "3464",
                 "date": "2/9/2018",
                 "implementation": "HPE Secure Encryption Engine v1.1",

--- a/tests/data/test_fips_oop/algorithms.json
+++ b/tests/data/test_fips_oop/algorithms.json
@@ -1,513 +1,490 @@
 {
     "_type": "sec_certs.dataset.fips_algorithm.FIPSAlgorithmDataset",
-    "certs": {
-        "2351": [
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2351",
-                "date": "9/21/2018",
-                "implementation": "Apple CoreCrypto Kernel Module v9.0 for ARM (iOS12, A11 Bionic, Assembler_VNG)",
-                "algorithm_type": "DRBG",
-                "vendor": "Apple Inc."
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2351",
-                "date": "11/27/2015",
-                "implementation": "Apple iOS CoreCrypto Kernel Module (Optimized SHA, A6)",
-                "algorithm_type": "HMAC",
-                "vendor": "Apple Inc."
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2351",
-                "date": "1/27/2017",
-                "implementation": "OpenSSL using assembler for AES and SHA",
-                "algorithm_type": "RSA",
-                "vendor": "Canonical Ltd."
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2351",
-                "date": "1/19/2017",
-                "implementation": "Junos FIPS Version Junos 15.1 X49 - Dataplane_CN7020",
-                "algorithm_type": "TDES",
-                "vendor": "Juniper Networks, Inc."
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2351",
-                "date": "3/8/2013",
-                "implementation": "Samsung OpenSSL Cryptographic Module",
-                "algorithm_type": "AES",
-                "vendor": "Samsung Electronics Co., Ltd"
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2351",
-                "date": "3/7/2014",
-                "implementation": "Symantec PGP Cryptographic Engine",
-                "algorithm_type": "SHS",
-                "vendor": "Symantec Corporation"
-            }
-        ],
-        "2352": [
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2352",
-                "date": "9/21/2018",
-                "implementation": "Apple CoreCrypto Kernel Module v9.0 for ARM (iOS12, A10X Fusion, Assembler_VNG)",
-                "algorithm_type": "DRBG",
-                "vendor": "Apple Inc."
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2352",
-                "date": "3/8/2013",
-                "implementation": "AES-256 Core",
-                "algorithm_type": "AES",
-                "vendor": "Altera Canada"
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2352",
-                "date": "11/27/2015",
-                "implementation": "Apple iOS CoreCrypto Kernel Module (Optimized SHA, A6X)",
-                "algorithm_type": "HMAC",
-                "vendor": "Apple Inc."
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2352",
-                "date": "1/27/2017",
-                "implementation": "OpenSSL using support from Power ISA 2.07 for AES and SHA",
-                "algorithm_type": "RSA",
-                "vendor": "Canonical Ltd."
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2352",
-                "date": "1/19/2017",
-                "implementation": "Junos FIPS Version Junos 15.1 X49 - Dataplane_CN7130",
-                "algorithm_type": "TDES",
-                "vendor": "Juniper Networks, Inc."
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2352",
-                "date": "3/21/2014",
-                "implementation": "Karnak SHA in Hardware",
-                "algorithm_type": "SHS",
-                "vendor": "Seagate Technology, LLC."
-            }
-        ],
-        "2600": [
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2600",
-                "date": "12/15/2017",
-                "implementation": "Apple iOS CoreCrypto v8 Kernel Module (Generic Software Implementation)",
-                "algorithm_type": "TDES",
-                "vendor": "Apple Inc."
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2600",
-                "date": "6/10/2016",
-                "implementation": "IOS Common Cryptographic Module (IC2M) Algorithm Module",
-                "algorithm_type": "HMAC",
-                "vendor": "Cisco Systems, Inc."
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2600",
-                "date": "8/16/2013",
-                "implementation": "Blade System Virtual Connect",
-                "algorithm_type": "AES",
-                "vendor": "Hewlett-Packard Development Company, L.P."
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2600",
-                "date": "12/5/2014",
-                "implementation": "Cryptographic Security Kernel",
-                "algorithm_type": "SHS",
-                "vendor": "IBM Corporation"
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2600",
-                "date": "9/1/2017",
-                "implementation": "IBM z/OS(R) Cryptographic Services System SSL - 31bit",
-                "algorithm_type": "RSA",
-                "vendor": "IBM Corporation"
-            }
-        ],
-        "2601": [
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2601",
-                "date": "12/5/2014",
-                "implementation": "SHA256 Library on Canon MFP Security Chip",
-                "algorithm_type": "SHS",
-                "vendor": "Canon Inc."
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2601",
-                "date": "8/16/2013",
-                "implementation": "Dell AppAssure Crypto Library",
-                "algorithm_type": "AES",
-                "vendor": "Dell, Inc."
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2601",
-                "date": "6/10/2016",
-                "implementation": "EFJ Communication Cryptographic Library",
-                "algorithm_type": "HMAC",
-                "vendor": "EFJohnson Technologies"
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2601",
-                "date": "9/1/2017",
-                "implementation": "IBM z/OS(R) Cryptographic Services System SSL - 64bit",
-                "algorithm_type": "RSA",
-                "vendor": "IBM Corporation"
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2601",
-                "date": "12/22/2017",
-                "implementation": "Oracle Linux 7 GnuTLS C Implementation",
-                "algorithm_type": "TDES",
-                "vendor": "Oracle Corporation"
-            }
-        ],
-        "2602": [
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2602",
-                "date": "12/22/2017",
-                "implementation": "Apple tvOS CoreCrypto Kernel Module v8.0 (Generic Software Implementation)",
-                "algorithm_type": "TDES",
-                "vendor": "Apple Inc."
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2602",
-                "date": "6/10/2016",
-                "implementation": "FIPS-ALGORITHMS.1.5.0v",
-                "algorithm_type": "HMAC",
-                "vendor": "Mercury Systems"
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2602",
-                "date": "8/16/2013",
-                "implementation": "RSA BSAFE\u00ae Crypto-J Software Module",
-                "algorithm_type": "AES",
-                "vendor": "RSA Security, Inc."
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2602",
-                "date": "12/5/2014",
-                "implementation": "SHA Library",
-                "algorithm_type": "SHS",
-                "vendor": "Sage Microelectronics Corp"
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2602",
-                "date": "9/1/2017",
-                "implementation": "Bouncy Castle FIPS Java API",
-                "algorithm_type": "RSA",
-                "vendor": "Legion of the Bouncy Castle Inc."
-            }
-        ],
-        "2700": [
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2700",
-                "date": "3/13/2015",
-                "implementation": "Apple OSX CoreCrypto Module (Generic, Xeon)",
-                "algorithm_type": "SHS",
-                "vendor": "Apple Inc."
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2700",
-                "date": "10/21/2016",
-                "implementation": "Axway OpenSSL",
-                "algorithm_type": "HMAC",
-                "vendor": "Axway Inc."
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2700",
-                "date": "11/30/2017",
-                "implementation": "Brocade Fabric OS FIPS Cryptographic Module",
-                "algorithm_type": "RSA",
-                "vendor": "Brocade Communications Systems LLC"
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2700",
-                "date": "3/30/2018",
-                "implementation": "Junos OS 17.4R1-S1 - Dataplane",
-                "algorithm_type": "TDES",
-                "vendor": "Juniper Networks, Inc."
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2700",
-                "date": "11/29/2013",
-                "implementation": "VMware NSS Cryptographic Module",
-                "algorithm_type": "AES",
-                "vendor": "VMware, Inc."
-            }
-        ],
-        "2701": [
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2701",
-                "date": "3/30/2018",
-                "implementation": "Security Builder GSE-J Crypto Core",
-                "algorithm_type": "TDES",
-                "vendor": "BlackBerry Certicom"
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2701",
-                "date": "11/30/2017",
-                "implementation": "ngfips_rsa",
-                "algorithm_type": "RSA",
-                "vendor": "Cavium, Inc."
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2701",
-                "date": "10/28/2016",
-                "implementation": "Cisco_SSL_Implementation-1",
-                "algorithm_type": "HMAC",
-                "vendor": "Cisco Systems, Inc."
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2701",
-                "date": "3/13/2015",
-                "implementation": "RSA BSAFE\u00ae Crypto-J JSAFE and JCE Software Module",
-                "algorithm_type": "SHS",
-                "vendor": "RSA, The Security Division of EMC"
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2701",
-                "date": "11/29/2013",
-                "implementation": "VMware Cryptographic Module",
-                "algorithm_type": "AES",
-                "vendor": "VMware, Inc."
-            }
-        ],
-        "2702": [
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2702",
-                "date": "3/30/2018",
-                "implementation": "Security Builder GSE-J Crypto Core",
-                "algorithm_type": "TDES",
-                "vendor": "BlackBerry Certicom"
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2702",
-                "date": "11/30/2017",
-                "implementation": "DELPHI RSA2048 Signature Verification Algorithm Implementation",
-                "algorithm_type": "RSA",
-                "vendor": "DELPHI"
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2702",
-                "date": "12/6/2013",
-                "implementation": "RSA BSAFE Crypto-J",
-                "algorithm_type": "AES",
-                "vendor": "McAfee, Inc."
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2702",
-                "date": "10/28/2016",
-                "implementation": "OpenSSL Crypto Library",
-                "algorithm_type": "HMAC",
-                "vendor": "MikroM GmbH"
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "2702",
-                "date": "3/13/2015",
-                "implementation": "OpenSSL FIPS Object Module",
-                "algorithm_type": "SHS",
-                "vendor": "OpenSSL Validation Services, Inc."
-            }
-        ],
-        "3415": [
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "3415",
-                "date": "1/26/2018",
-                "implementation": "Apple Secure Key Store CoreCrypto Module (Generic Software Implementation)",
-                "algorithm_type": "HMAC",
-                "vendor": "Apple Inc."
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "3415",
-                "date": "6/5/2015",
-                "implementation": "Motorola Solutions Subscriber \u00b5Mace AES256",
-                "algorithm_type": "AES",
-                "vendor": "Motorola Solutions Inc"
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "3415",
-                "date": "11/18/2016",
-                "implementation": "Secure Parser Library",
-                "algorithm_type": "SHS",
-                "vendor": "Security First Corp."
-            }
-        ],
-        "3426": [
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "3426",
-                "date": "6/11/2015",
-                "implementation": "Apple iOS CoreCrypto Module (KeyWrap A8 32 bit)",
-                "algorithm_type": "AES",
-                "vendor": "Apple Inc."
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "3426",
-                "date": "12/2/2016",
-                "implementation": "Apple iOS CoreCrypto Module (Generic)",
-                "algorithm_type": "SHS",
-                "vendor": "Apple Inc."
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "3426",
-                "date": "1/26/2018",
-                "implementation": "Apple Secure Key Store CoreCrypto Module (VNG)",
-                "algorithm_type": "HMAC",
-                "vendor": "Apple Inc."
-            }
-        ],
-        "3427": [
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "3427",
-                "date": "12/2/2016",
-                "implementation": "Apple iOS CoreCrypto Module (Generic)",
-                "algorithm_type": "SHS",
-                "vendor": "Apple Inc."
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "3427",
-                "date": "1/26/2018",
-                "implementation": "Forcepoint NGFW FIPS Java API",
-                "algorithm_type": "HMAC",
-                "vendor": "Forcepoint"
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "3427",
-                "date": "6/11/2015",
-                "implementation": "HP ESKM OpenSSL",
-                "algorithm_type": "AES",
-                "vendor": "Hewlett Packard Enterprise"
-            }
-        ],
-        "3447": [
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "3447",
-                "date": "12/2/2016",
-                "implementation": "Apple OSX CoreCrypto Module (Optimized SHA nosse)",
-                "algorithm_type": "SHS",
-                "vendor": "Apple Inc."
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "3447",
-                "date": "7/2/2015",
-                "implementation": "FireEye Algorithms Implementation",
-                "algorithm_type": "AES",
-                "vendor": "FireEye, Inc."
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "3447",
-                "date": "2/9/2018",
-                "implementation": "OpenSSL (no AVX2/AVX/AESNI/SSSE3, x86_64, 64-bit library)",
-                "algorithm_type": "HMAC",
-                "vendor": "Red Hat, Inc."
-            }
-        ],
-        "3451": [
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "3451",
-                "date": "12/2/2016",
-                "implementation": "Apple OSX CoreCrypto Module (Optimized SHA nosse)",
-                "algorithm_type": "SHS",
-                "vendor": "Apple Inc."
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "3451",
-                "date": "7/2/2015",
-                "implementation": "OpenSSL FIPS Object Module",
-                "algorithm_type": "AES",
-                "vendor": "OpenSSL Software Foundation, Inc."
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "3451",
-                "date": "2/9/2018",
-                "implementation": "OpenSSL (no AVX2/AVX/AESNI, x86_64, 64-bit library)",
-                "algorithm_type": "HMAC",
-                "vendor": "Red Hat, Inc."
-            }
-        ],
-        "3464": [
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "3464",
-                "date": "12/9/2016",
-                "implementation": "Apple OSX CoreCrypto Module (Generic)",
-                "algorithm_type": "SHS",
-                "vendor": "Apple Inc."
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "3464",
-                "date": "7/10/2015",
-                "implementation": "Security Builder Linux Kernel Crypto Core",
-                "algorithm_type": "AES",
-                "vendor": "Certicom Corp."
-            },
-            {
-                "_type": "sec_certs.sample.fips.FIPSCertificate.Algorithm",
-                "cert_id": "3464",
-                "date": "2/9/2018",
-                "implementation": "HPE Secure Encryption Engine v1.1",
-                "algorithm_type": "HMAC",
-                "vendor": "Hewlett-Packard Development Company, L.P."
-            }
-        ]
-    }
+    "timestamp": "2022-07-11 17:17:38.998647",
+    "sha256_digest": "not implemented",
+    "name": "",
+    "description": "",
+    "n_certs": 60,
+    "certs": [
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "3415",
+            "vendor": "Apple Inc.",
+            "implementation": "Apple Secure Key Store CoreCrypto Module (Generic Software Implementation)",
+            "algorithm_type": "HMAC",
+            "date": "1/26/2018"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2702",
+            "vendor": "MikroM GmbH",
+            "implementation": "OpenSSL Crypto Library",
+            "algorithm_type": "HMAC",
+            "date": "10/28/2016"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2602",
+            "vendor": "Sage Microelectronics Corp",
+            "implementation": "SHA Library",
+            "algorithm_type": "SHS",
+            "date": "12/5/2014"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2701",
+            "vendor": "Cisco Systems, Inc.",
+            "implementation": "Cisco_SSL_Implementation-1",
+            "algorithm_type": "HMAC",
+            "date": "10/28/2016"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2352",
+            "vendor": "Altera Canada",
+            "implementation": "AES-256 Core",
+            "algorithm_type": "AES",
+            "date": "3/8/2013"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2600",
+            "vendor": "IBM Corporation",
+            "implementation": "Cryptographic Security Kernel",
+            "algorithm_type": "SHS",
+            "date": "12/5/2014"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2352",
+            "vendor": "Apple Inc.",
+            "implementation": "Apple iOS CoreCrypto Kernel Module (Optimized SHA, A6X)",
+            "algorithm_type": "HMAC",
+            "date": "11/27/2015"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2700",
+            "vendor": "VMware, Inc.",
+            "implementation": "VMware NSS Cryptographic Module",
+            "algorithm_type": "AES",
+            "date": "11/29/2013"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "3415",
+            "vendor": "Security First Corp.",
+            "implementation": "Secure Parser Library",
+            "algorithm_type": "SHS",
+            "date": "11/18/2016"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2600",
+            "vendor": "Hewlett-Packard Development Company, L.P.",
+            "implementation": "Blade System Virtual Connect",
+            "algorithm_type": "AES",
+            "date": "8/16/2013"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2352",
+            "vendor": "Seagate Technology, LLC.",
+            "implementation": "Karnak SHA in Hardware",
+            "algorithm_type": "SHS",
+            "date": "3/21/2014"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2602",
+            "vendor": "Apple Inc.",
+            "implementation": "Apple tvOS CoreCrypto Kernel Module v8.0 (Generic Software Implementation)",
+            "algorithm_type": "TDES",
+            "date": "12/22/2017"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2702",
+            "vendor": "McAfee, Inc.",
+            "implementation": "RSA BSAFE Crypto-J",
+            "algorithm_type": "AES",
+            "date": "12/6/2013"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2351",
+            "vendor": "Apple Inc.",
+            "implementation": "Apple iOS CoreCrypto Kernel Module (Optimized SHA, A6)",
+            "algorithm_type": "HMAC",
+            "date": "11/27/2015"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2600",
+            "vendor": "IBM Corporation",
+            "implementation": "IBM z/OS(R) Cryptographic Services System SSL - 31bit",
+            "algorithm_type": "RSA",
+            "date": "9/1/2017"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2701",
+            "vendor": "RSA, The Security Division of EMC",
+            "implementation": "RSA BSAFE® Crypto-J JSAFE and JCE Software Module",
+            "algorithm_type": "SHS",
+            "date": "3/13/2015"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "3427",
+            "vendor": "Hewlett Packard Enterprise",
+            "implementation": "HP ESKM OpenSSL",
+            "algorithm_type": "AES",
+            "date": "6/11/2015"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2700",
+            "vendor": "Axway Inc.",
+            "implementation": "Axway OpenSSL",
+            "algorithm_type": "HMAC",
+            "date": "10/21/2016"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2701",
+            "vendor": "BlackBerry Certicom",
+            "implementation": "Security Builder GSE-J Crypto Core",
+            "algorithm_type": "TDES",
+            "date": "3/30/2018"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2701",
+            "vendor": "Cavium, Inc.",
+            "implementation": "ngfips_rsa",
+            "algorithm_type": "RSA",
+            "date": "11/30/2017"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "3426",
+            "vendor": "Apple Inc.",
+            "implementation": "Apple iOS CoreCrypto Module (KeyWrap A8 32 bit)",
+            "algorithm_type": "AES",
+            "date": "6/11/2015"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "3451",
+            "vendor": "OpenSSL Software Foundation, Inc.",
+            "implementation": "OpenSSL FIPS Object Module",
+            "algorithm_type": "AES",
+            "date": "7/2/2015"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2702",
+            "vendor": "BlackBerry Certicom",
+            "implementation": "Security Builder GSE-J Crypto Core",
+            "algorithm_type": "TDES",
+            "date": "3/30/2018"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2602",
+            "vendor": "RSA Security, Inc.",
+            "implementation": "RSA BSAFE® Crypto-J Software Module",
+            "algorithm_type": "AES",
+            "date": "8/16/2013"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2601",
+            "vendor": "EFJohnson Technologies",
+            "implementation": "EFJ Communication Cryptographic Library",
+            "algorithm_type": "HMAC",
+            "date": "6/10/2016"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2601",
+            "vendor": "Dell, Inc.",
+            "implementation": "Dell AppAssure Crypto Library",
+            "algorithm_type": "AES",
+            "date": "8/16/2013"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2600",
+            "vendor": "Cisco Systems, Inc.",
+            "implementation": "IOS Common Cryptographic Module (IC2M) Algorithm Module",
+            "algorithm_type": "HMAC",
+            "date": "6/10/2016"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2700",
+            "vendor": "Juniper Networks, Inc.",
+            "implementation": "Junos OS 17.4R1-S1 - Dataplane",
+            "algorithm_type": "TDES",
+            "date": "3/30/2018"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "3447",
+            "vendor": "Apple Inc.",
+            "implementation": "Apple OSX CoreCrypto Module (Optimized SHA nosse)",
+            "algorithm_type": "SHS",
+            "date": "12/2/2016"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "3447",
+            "vendor": "FireEye, Inc.",
+            "implementation": "FireEye Algorithms Implementation",
+            "algorithm_type": "AES",
+            "date": "7/2/2015"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "3426",
+            "vendor": "Apple Inc.",
+            "implementation": "Apple Secure Key Store CoreCrypto Module (VNG)",
+            "algorithm_type": "HMAC",
+            "date": "1/26/2018"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2351",
+            "vendor": "Apple Inc.",
+            "implementation": "Apple CoreCrypto Kernel Module v9.0 for ARM (iOS12, A11 Bionic, Assembler_VNG)",
+            "algorithm_type": "DRBG",
+            "date": "9/21/2018"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "3447",
+            "vendor": "Red Hat, Inc.",
+            "implementation": "OpenSSL (no AVX2/AVX/AESNI/SSSE3, x86_64, 64-bit library)",
+            "algorithm_type": "HMAC",
+            "date": "2/9/2018"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2351",
+            "vendor": "Canonical Ltd.",
+            "implementation": "OpenSSL using assembler for AES and SHA",
+            "algorithm_type": "RSA",
+            "date": "1/27/2017"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2700",
+            "vendor": "Apple Inc.",
+            "implementation": "Apple OSX CoreCrypto Module (Generic, Xeon)",
+            "algorithm_type": "SHS",
+            "date": "3/13/2015"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2602",
+            "vendor": "Mercury Systems",
+            "implementation": "FIPS-ALGORITHMS.1.5.0v",
+            "algorithm_type": "HMAC",
+            "date": "6/10/2016"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "3451",
+            "vendor": "Apple Inc.",
+            "implementation": "Apple OSX CoreCrypto Module (Optimized SHA nosse)",
+            "algorithm_type": "SHS",
+            "date": "12/2/2016"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "3464",
+            "vendor": "Hewlett-Packard Development Company, L.P.",
+            "implementation": "HPE Secure Encryption Engine v1.1",
+            "algorithm_type": "HMAC",
+            "date": "2/9/2018"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2351",
+            "vendor": "Symantec Corporation",
+            "implementation": "Symantec PGP Cryptographic Engine",
+            "algorithm_type": "SHS",
+            "date": "3/7/2014"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "3427",
+            "vendor": "Apple Inc.",
+            "implementation": "Apple iOS CoreCrypto Module (Generic)",
+            "algorithm_type": "SHS",
+            "date": "12/2/2016"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "3427",
+            "vendor": "Forcepoint",
+            "implementation": "Forcepoint NGFW FIPS Java API",
+            "algorithm_type": "HMAC",
+            "date": "1/26/2018"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2700",
+            "vendor": "Brocade Communications Systems LLC",
+            "implementation": "Brocade Fabric OS FIPS Cryptographic Module",
+            "algorithm_type": "RSA",
+            "date": "11/30/2017"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2702",
+            "vendor": "DELPHI",
+            "implementation": "DELPHI RSA2048 Signature Verification Algorithm Implementation",
+            "algorithm_type": "RSA",
+            "date": "11/30/2017"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2601",
+            "vendor": "Oracle Corporation",
+            "implementation": "Oracle Linux 7 GnuTLS C Implementation",
+            "algorithm_type": "TDES",
+            "date": "12/22/2017"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2352",
+            "vendor": "Apple Inc.",
+            "implementation": "Apple CoreCrypto Kernel Module v9.0 for ARM (iOS12, A10X Fusion, Assembler_VNG)",
+            "algorithm_type": "DRBG",
+            "date": "9/21/2018"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2600",
+            "vendor": "Apple Inc.",
+            "implementation": "Apple iOS CoreCrypto v8 Kernel Module (Generic Software Implementation)",
+            "algorithm_type": "TDES",
+            "date": "12/15/2017"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2352",
+            "vendor": "Canonical Ltd.",
+            "implementation": "OpenSSL using support from Power ISA 2.07 for AES and SHA",
+            "algorithm_type": "RSA",
+            "date": "1/27/2017"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "3426",
+            "vendor": "Apple Inc.",
+            "implementation": "Apple iOS CoreCrypto Module (Generic)",
+            "algorithm_type": "SHS",
+            "date": "12/2/2016"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2702",
+            "vendor": "OpenSSL Validation Services, Inc.",
+            "implementation": "OpenSSL FIPS Object Module",
+            "algorithm_type": "SHS",
+            "date": "3/13/2015"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2601",
+            "vendor": "Canon Inc.",
+            "implementation": "SHA256 Library on Canon MFP Security Chip",
+            "algorithm_type": "SHS",
+            "date": "12/5/2014"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2701",
+            "vendor": "VMware, Inc.",
+            "implementation": "VMware Cryptographic Module",
+            "algorithm_type": "AES",
+            "date": "11/29/2013"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2352",
+            "vendor": "Juniper Networks, Inc.",
+            "implementation": "Junos FIPS Version Junos 15.1 X49 - Dataplane_CN7130",
+            "algorithm_type": "TDES",
+            "date": "1/19/2017"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2351",
+            "vendor": "Juniper Networks, Inc.",
+            "implementation": "Junos FIPS Version Junos 15.1 X49 - Dataplane_CN7020",
+            "algorithm_type": "TDES",
+            "date": "1/19/2017"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2601",
+            "vendor": "IBM Corporation",
+            "implementation": "IBM z/OS(R) Cryptographic Services System SSL - 64bit",
+            "algorithm_type": "RSA",
+            "date": "9/1/2017"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2602",
+            "vendor": "Legion of the Bouncy Castle Inc.",
+            "implementation": "Bouncy Castle FIPS Java API",
+            "algorithm_type": "RSA",
+            "date": "9/1/2017"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "2351",
+            "vendor": "Samsung Electronics Co., Ltd",
+            "implementation": "Samsung OpenSSL Cryptographic Module",
+            "algorithm_type": "AES",
+            "date": "3/8/2013"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "3464",
+            "vendor": "Apple Inc.",
+            "implementation": "Apple OSX CoreCrypto Module (Generic)",
+            "algorithm_type": "SHS",
+            "date": "12/9/2016"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "3451",
+            "vendor": "Red Hat, Inc.",
+            "implementation": "OpenSSL (no AVX2/AVX/AESNI, x86_64, 64-bit library)",
+            "algorithm_type": "HMAC",
+            "date": "2/9/2018"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "3464",
+            "vendor": "Certicom Corp.",
+            "implementation": "Security Builder Linux Kernel Crypto Core",
+            "algorithm_type": "AES",
+            "date": "7/10/2015"
+        },
+        {
+            "_type": "sec_certs.sample.fips_algorithm.FIPSAlgorithm",
+            "cert_id": "3415",
+            "vendor": "Motorola Solutions Inc",
+            "implementation": "Motorola Solutions Subscriber µMace AES256",
+            "algorithm_type": "AES",
+            "date": "6/5/2015"
+        }
+    ]
 }

--- a/tests/test_fips_oop.py
+++ b/tests/test_fips_oop.py
@@ -16,7 +16,7 @@ from tests.fips_test_utils import generate_html
 def _set_up_dataset(td, certs):
     dataset = FIPSDataset({}, Path(td), "test_dataset", "fips_test_dataset")
     generate_html(certs, td + "/test_search.html")
-    dataset.get_certs_from_web(test=td + "/test_search.html", no_download_algorithms=True)
+    dataset.get_certs_from_web(test=td + "/test_search.html")
     return dataset
 
 

--- a/tests/test_fips_oop.py
+++ b/tests/test_fips_oop.py
@@ -116,6 +116,11 @@ class TestFipsOOP(TestCase):
                 dataset = _set_up_dataset(tmp_dir, certs)
                 self.assertEqual(len(dataset.certs), len(certs), "Wrong number of parsed certs")
 
+    def test_metadata_extraction(self):
+        with TemporaryDirectory() as tmp_dir:
+            dst = _set_up_dataset_for_full(tmp_dir, ["3493"], self.cpe_dset_path, self.cve_dset_path)
+            self.assertIsNotNone(dst.certs[fips_dgst("3493")].pdf_data.st_metadata)
+
     def test_connections_microsoft(self):
         certs = self.certs_to_parse["microsoft"]
         with TemporaryDirectory() as tmp_dir:

--- a/tests/test_fips_oop.py
+++ b/tests/test_fips_oop.py
@@ -4,6 +4,8 @@ from tempfile import TemporaryDirectory
 from typing import Dict, Final, List
 from unittest import TestCase
 
+import pytest
+
 import tests.data.test_fips_oop
 from sec_certs.config.configuration import config
 from sec_certs.dataset import FIPSAlgorithmDataset, FIPSDataset
@@ -335,3 +337,13 @@ class TestFipsOOP(TestCase):
             self.assertEqual(
                 set(dataset.certs[fips_dgst("3158")].heuristics.web_references.directly_referencing), {"2398"}
             )
+
+
+class TestFIPSAlgo(TestCase):
+    @pytest.mark.slow
+    def test_get_certs_from_web(self):
+        with TemporaryDirectory() as tmp_dir:
+            web_path = Path(tmp_dir) / "web"
+            web_path.mkdir()
+            aset = FIPSAlgorithmDataset({}, web_path / "algorithms", "algorithms", "sample algs")
+            aset.get_certs_from_web()


### PR DESCRIPTION
This will be an overall FIPS improvement drive to get it to be more similar to CC code.

- [x] Add TODOs.
- [x] Make JSON serialization include full path to class instead of only classname.
- [x] Rename internal FIPSCertificate classes to match CC.
- [x] Remove unused methods.
- [x] Add PDF metadata extraction.
- [x] Make algorithm extraction (and serialization) deterministic.
- [x] #210
- [x] #213
- [x] #211
- [x] Split cert_id match cleaning to separate data structures, do not touch the keywords matches directly.

Possible future work:

- [ ] Also parse the detailed algorithm pages, such as [this one](https://csrc.nist.gov/projects/Cryptographic-Algorithm-Validation-Program/details?source=C&number=423). This is currently not done and only the search results page is scraped for the `FIPSAlgorithm` dataset. This significantly lowers the amount of data we collect.