### PR TITLE
switch wide to long/tidy format in temp notebook

### DIFF
--- a/sec_certs/dataset/common_criteria.py
+++ b/sec_certs/dataset/common_criteria.py
@@ -82,7 +82,9 @@ class CCDataset(Dataset[CommonCriteriaCert], ComplexSerializableType):
 
         df.not_valid_before = pd.to_datetime(df.not_valid_before, infer_datetime_format=True)
         df.not_valid_after = pd.to_datetime(df.not_valid_after, infer_datetime_format=True)
-        df = df.astype({"category": "category", "status": "category", "scheme": "category"}).fillna(value=np.nan)
+        df = df.astype(
+            {"category": "category", "status": "category", "scheme": "category", "cert_lab": "category"}
+        ).fillna(value=np.nan)
         df = df.loc[
             ~df.manufacturer.isnull()
         ]  # Manually delete one certificate with None manufacturer (seems to have many blank fields)


### PR DESCRIPTION
Just switch from wide-format to long format before plotting for consistency. For more description see: https://vita.had.co.nz/papers/tidy-data.pdf