### PR TITLE
Introduce-reference-bool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,9 @@ virt/
 # mypy
 .mypy_cache/
 
+# ruff
+.ruff_cache
+
 # log
 cert_processing_log.txt
 ./cc_processing_log.txt

--- a/src/sec_certs/dataset/dataset.py
+++ b/src/sec_certs/dataset/dataset.py
@@ -53,9 +53,6 @@ class Dataset(Generic[CertSubType, AuxiliaryDatasetsSubType], ComplexSerializabl
         auxiliary_datasets_processed: bool = False
         certs_analyzed: bool = False
 
-        def __bool__(self):
-            return any(vars(self))
-
     def __init__(
         self,
         certs: dict[str, CertSubType] = {},

--- a/src/sec_certs/sample/certificate.py
+++ b/src/sec_certs/sample/certificate.py
@@ -25,6 +25,9 @@ class References(ComplexSerializableType):
     directly_referencing: set[str] | None = field(default=None)
     indirectly_referencing: set[str] | None = field(default=None)
 
+    def __bool__(self):
+        return any(getattr(self, x) for x in vars(self))
+
 
 class Heuristics:
     cpe_matches: set[str] | None


### PR DESCRIPTION
Minor fixes and introduces `__bool__()` method on `Reference` object so that one can select reference-rich certificates with `[x for x in dset if x.heuristics.policy_processed_references]`