### PR TITLE
Wrap CC scheme download in try-except and continue on fail.

### DIFF
--- a/src/sec_certs/dataset/cc_scheme.py
+++ b/src/sec_certs/dataset/cc_scheme.py
@@ -54,5 +54,8 @@ class CCSchemeDataset(JSONPathDataset, ComplexSerializableType):
         for scheme, sources in CCScheme.methods.items():
             if only_schemes is not None and scheme not in only_schemes:
                 continue
-            schemes[scheme] = CCScheme.from_web(scheme, sources.keys())
+            try:
+                schemes[scheme] = CCScheme.from_web(scheme, sources.keys())
+            except Exception as e:
+                logger.warning(f"Could not download CC scheme: {scheme} due to error {e}.")
         return cls(schemes)


### PR DESCRIPTION
These scheme downloads fail very often, it is better to have just some schemes downloaded rather than to stop the whole download process and throw an exception. This then prevents the updates to go through on the web and means that the data gets stale.