### PR TITLE
Cleanup cert-id rules

### DIFF
--- a/src/sec_certs/rules.yaml
+++ b/src/sec_certs/rules.yaml
@@ -79,7 +79,10 @@ cc_cert_id:
     - "[0-9\\.]+?/TSE-CCCS-[0-9]+"  # Turkish CCCS (21.0.0sc/TSE-CCCS-75)
     - "(?:[0-9]{1,2}\\.){2}[0-9]{1,2}/[0-9]{1,4}-[0-9]{3}"   # 21.0.01/13-028
   SE:
-    - "CSEC ?[0-9]{6,7}"  # Sweden (CSEC2019015)
+    - "CSEC ?(?P<year>[0-9]{4})(?P<counter>[0-9]{2,3})"
+    # Examples:
+    # CSEC2019015
+    # CSEC 2019012
   IN:
     # India (IC3S/DEL01/VALIANT/EAL1/0317/0007/CR  STQC/CC/14-15/12/ETR/0017 IC3S/MUM01/CISCO/cPP/0119/0016/CR)
     # will miss STQC/CC/14-15/12/ETR/0017

--- a/src/sec_certs/rules.yaml
+++ b/src/sec_certs/rules.yaml
@@ -77,8 +77,12 @@ cc_cert_id:
     # ISCB-5-RPT-C075-CR-v2
     # ISCB-5-RPT-C046-CR-V1a
   IT:
-    - "OCSI/CERT/.+?"  # Italy
-    - "OCSI/CERT/.+?/20[0-9]+(?:\\w|/RC)"  # Italy  (OCSI/CERT/ATS/01/2018/RC)
+    - "OCSI/CERT/(?:(?P<lab>[A-Z]{3})/)?(?P<counter>[0-9]{2,3})/(?P<year>[0-9]{4})/RC"
+    # Examples:
+    # OCSI/CERT/SYS/04/2018/RC
+    # OCSI/CERT/CCL/10/2022/RC
+    # OCSI/CERT/TEC/09/2017/RC
+    # OCSI/CERT/ATS/06/2020/RC
   TR:
     - "[0-9\\.]+?/TSE-CCCS-[0-9]+"  # Turkish CCCS (21.0.0sc/TSE-CCCS-75)
     - "(?:[0-9]{1,2}\\.){2}[0-9]{1,2}/[0-9]{1,4}-[0-9]{3}"   # 21.0.01/13-028

--- a/src/sec_certs/rules.yaml
+++ b/src/sec_certs/rules.yaml
@@ -5,17 +5,17 @@
 #####
 cc_cert_id:
   DE:
-    - "BSI-DSZ-CC-[0-9]+?-[0-9]+"
-    - "BSI-DSZ-CC-[0-9]+?-(?:V|v)[0-9]+-[0-9]+"
-    - "BSI-DSZ-CC-[0-9]+?-(?:V|v)[0-9]+"
-    - "BSI-DSZ-CC-[0-9]+-(?:V|v)[0-9]+(-[0-9]{4})*"  # German BSI (number + version + year or without year)
-    - "BSI-DSZ-CC-[0-9]+-[0-9]{4}"  # German BSI (number + year, no version)
-    - "BSI-DSZ-CC-[0-9]+-(?:V|v)[0-9]+(?!-)"  # German BSI (number + version but no year => no - after version)
-    # - "BSI-DSZ-CC-[0-9]+"  # Maybe?
+    - "BSI-DSZ-CC-(?:(?P<s>S)-)?(?P<counter>[0-9]{3,5})-(?:(?P<version>[vV][0-9])-)?(?P<year>[0-9]{4})?(?:-(?P<doc>(?:RA|MA)(?:-[0-9]+)?))?"
+    # Examples:
+    # BSI-DSZ-CC-1004
+    # BSI-DSZ-CC-0973-2016
+    # BSI-DSZ-CC-0831-V4-2021
+    # BSI-DSZ-CC-0837-V2-2014-MA-01
+    # BSI-DSZ-CC-S-0192-2021
   FR:
     - "DCSS[Ii]-(?P<year>[0-9]{2,4})/(?P<counter>[0-9]+)([vV](?P<version>[0-9]))?"
-    - "Certification Report (?P<year>[0-9]{2,4})/(?P<counter>[0-9]+)([vV](?P<version>[0-9]))?"
     - "Rapport de certification (?P<year>[0-9]{2,4})/(?P<counter>[0-9]+)([vV](?P<version>[0-9]))?"
+    - "Certification Report (?P<year>[0-9]{2,4})/(?P<counter>[0-9]+)([vV](?P<version>[0-9]))?"
     - "ANSS[Ii](?:-CC)?[ -](?P<year>[0-9]{2,4})[/_-](?P<counter>[0-9]+)(?:-(?P<doc>(?:[MSR][0-9]+)))?([vV](?P<version>[0-9]))?"
     # Examples:
     # DCSSI-2009/07
@@ -30,7 +30,9 @@ cc_cert_id:
     # CC-16-31801-CR4  (no NSCIB)
     # NSCIB-CC-98209   (no year, no CR)
   "NO":
-    - "SERTIT-(?P<counter>[0-9]+)"  # Norway
+    - "SERTIT-(?P<counter>[0-9]+)"
+    # Examples:
+    # SERTIT-101
   US:
     - "CCEVS-VR-(?:CC-|VID)?[0-9]+-[0-9]+[a-z]?(?:-[0-9]+)?"  # US NSA (CCEVS-VR-10884-2018 CCEVS-VR-VID10877-2018)
   CA:

--- a/src/sec_certs/rules.yaml
+++ b/src/sec_certs/rules.yaml
@@ -46,8 +46,11 @@ cc_cert_id:
     - "[0-9][0-9][0-9][ -](?:EWA|LSS|CCS)(?:[ -]20[0-9][0-9])?"  # Canada (522-EWA-2020, 524 LSS 2020, 503-LSS)
     - "[0-9][0-9][0-9](?:%20|-)(?:EWA|LSS|CCS)(?:%20|-)(?:20[0-9][0-9]%20|)CR%20v[0-9]\\.[0-9]" # Canada filename with space (518-LSS%20CR%20v1.0)
   UK:
-    - "CRP[0-9]+[A-Z]?"  # UK CESG
-    - "CERTIFICATION REPORT No. P[0-9]+[A-Z]?"  # UK CESG
+    - "CRP(?P<counter>[0-9]+[A-Z]?)"
+    - "CERTIFICATION REPORT No. P(?P<counter>[0-9]+[A-Z]?)"
+    # Examples:
+    # CRP208
+    # CERTIFICATION REPORT No. P123A
   ES:
     - "20[0-9][0-9][-‐][0-9]+[-‐]INF[-‐][0-9]+([-‐]?[ -‐](?:V|v)[0-9]+)?"  # Spain ("2006-4-INF-98 v2" or "2006-4-INF-98-v2" or "2020-34-INF-3784- v1")
   KR:

--- a/src/sec_certs/rules.yaml
+++ b/src/sec_certs/rules.yaml
@@ -34,7 +34,12 @@ cc_cert_id:
     # Examples:
     # SERTIT-101
   US:
-    - "CCEVS-VR-(?:CC-|VID)?[0-9]+-[0-9]+[a-z]?(?:-[0-9]+)?"  # US NSA (CCEVS-VR-10884-2018 CCEVS-VR-VID10877-2018)
+    - "CCEVS-VR-(?:(?P<cc>CC)-)?(?:(?P<VID>VID)-?)?(?P<year>[0-9]{2})-(?P<counter>[0-9]+)"
+    - "CCEVS-VR-(?:(?P<cc>CC)-)?(?:(?P<VID>VID)-?)?(?P<counter>[0-9]{4,5})-(?P<year>[0-9]{4})?"
+    # Examples:
+    # CCEVS-VR-VID10015-2008
+    # CCEVS-VR-10880-2018
+    # CCEVS-VR-04-0082
   CA:
     # '[0-9][0-9\-]+?-CR', # Canada
     - "[0-9][0-9][0-9]-[347]-[0-9][0-9][0-9]?(?:-CR|P)?"  # Canada xxx-{347}-xxx (383-4-438, 383-4-82-CR, 383-4-422P)

--- a/src/sec_certs/rules.yaml
+++ b/src/sec_certs/rules.yaml
@@ -86,8 +86,11 @@ cc_cert_id:
     # OCSI/CERT/TEC/09/2017/RC
     # OCSI/CERT/ATS/06/2020/RC
   TR:
-    - "[0-9\\.]+?/TSE-CCCS-[0-9]+"  # Turkish CCCS (21.0.0sc/TSE-CCCS-75)
-    - "(?:[0-9]{1,2}\\.){2}[0-9]{1,2}/[0-9]{1,4}-[0-9]{3}"   # 21.0.01/13-028
+    - "(?P<prefix>[0-9\\.]+)/TSE-CCCS-(?P<number>[0-9]+)"
+    # XXX: The report numbers are like "21.0.01/13-028"
+    # Examples:
+    # 21.0.03.0.00.00/TSE-CCCS-85
+    # 21.0.03/TSE-CCCS-33
   SE:
     - "CSEC ?(?P<year>[0-9]{4})(?P<counter>[0-9]{2,3})"
     # Examples:

--- a/src/sec_certs/rules.yaml
+++ b/src/sec_certs/rules.yaml
@@ -52,7 +52,11 @@ cc_cert_id:
     # CRP208
     # CERTIFICATION REPORT No. P123A
   ES:
-    - "20[0-9][0-9][-‐][0-9]+[-‐]INF[-‐][0-9]+([-‐]?[ -‐](?:V|v)[0-9]+)?"  # Spain ("2006-4-INF-98 v2" or "2006-4-INF-98-v2" or "2020-34-INF-3784- v1")
+    - "(?P<year>[0-9]{4})[-‐](?P<project>[0-9]+)[-‐]INF[-‐](?P<counter>[0-9]+)[ -‐]{1,2}[vV](?P<version>[0-9])"
+    # Examples:
+    # 2006-4-INF-98 v2
+    # 2020-34-INF-3784- v1
+    # 2019-20-INF-3379-v1
   KR:
     # Korea
     # XXX: Do not use KECS-CR as those refer to the certificate report and do not represent the certificate id.

--- a/src/sec_certs/rules.yaml
+++ b/src/sec_certs/rules.yaml
@@ -92,13 +92,17 @@ cc_cert_id:
     # will miss STQC/CC/14-15/12/ETR/0017
     - "(?:IC3S|STQC/CC)/[^ ]+? ?/CR"
   SG:
-    - "CSA_CC_[0-9]+"  # Singapore (CSA_CC_19001)
+    - "CSA_CC_(?P<year>[0-9]{2})(?P<counter>[0-9]{3})"
+    # Examples:
+    # CSA_CC_19001
   AU:
-    # Australia (EFS-T048 ETR 1.0, EFS-T056-ETR 1.0, DXC-EFC-T092-ETR 1.0)
+    - "(?:Certificate Number:|Certification Report) (?P<year>[0-9]{2,4})/(?P<counter>[0-9]+)"
     # XXX: Do not use Australian ETR numbers, they are not certificate id.
-    # - "(?:EFS|EFT|DXC-EFC)-T[0-9]+(?: |-)ETR [0-9]+.[0-9]+"
-    - "Certificate Number: [0-9]{1,4}/[0-9]{1,4}"
-    - "Certification Report [0-9]+/[0-9]+"
+    # Examples:
+    # Certification Report 2007/06
+    # Certificate Number: 2010/67
+    # Certificate Number: 37/2006    !mistake
+    # Certification Report 97/76     !short year
 
 #####
 # Common Criteria protection profile IDs, grouped by certification body (e.g. BSI)

--- a/src/sec_certs/rules.yaml
+++ b/src/sec_certs/rules.yaml
@@ -21,14 +21,12 @@ cc_cert_id:
     - "Certification Report [0-9]+/[0-9]+" # French or Australia! Solved because we limit ourselves to scheme when doing heuristics.
     - "Rapport de certification [0-9]+/[0-9]+"  # French
   NL:
-    - "NSCIB-CC-[0-9]{4}.+?"  # Netherlands
-    - "NSCIB-CC-[0-9]{4}[0-9]*-CR"  # Netherlands
-    - "NSCIB-CC-[0-9][0-9]-[0-9]+?-CR[0-9]+?"  # Netherlands
-    - "NSCIB-CC-[0-9][0-9]-[0-9]+(-CR[0-9]+)*"  # Netherlands (old number NSCIB-CC-05-6609 or NSCIB-CC-05-6609-CR)
-    - "NSCIB-CC-[0-9]+-CR[0-9]*"  # Netherlands (new number NSCIB-CC-111441-CR NSCIB-CC-111441-CR1)
-    - "NSCIB-CC-[0-9]+-MA[0-9]*"  # Netherlands (new number NSCIB-CC-222073-MA NSCIB-CC-200716-MA2)
-    - "NSCIB-CC-[0-9][0-9]-[0-9]+"  # Netherlands   (old number NSCIB-CC-05-6609)
-    - "NSCIB-CC-[0-9][0-9]-[0-9]+-CR[0-9]+"  # Netherlands (NSCIB-CC-year2digits-number-CR)
+    - "(?:NSCIB-|CC-|NSCIB-CC-)(?P<core>((?P<year>[0-9]{2})-)?(?:-?[0-9]+)+)(?:-?(?P<doc>(?:CR|MA|MR)[0-9]*))?"
+    # Examples:
+    # NSCIB-CC-22-0428888-CR2  (with year=22 and CR2)
+    # NSCIB-CC-228723-CR  (no year)
+    # CC-16-31801-CR4  (no NSCIB)
+    # NSCIB-CC-98209   (no year, no CR)
   "NO":
     - "SERTIT-[0-9]+"  # Norway
   US:

--- a/src/sec_certs/rules.yaml
+++ b/src/sec_certs/rules.yaml
@@ -58,10 +58,12 @@ cc_cert_id:
     # 2020-34-INF-3784- v1
     # 2019-20-INF-3379-v1
   KR:
-    # Korea
+    - "KECS[-‐](?P<word>ISIS|NISS|CISS)[-‐](?P<counter>[0-9]{2,4})[-‐](?P<year>[0-9]{4})"
     # XXX: Do not use KECS-CR as those refer to the certificate report and do not represent the certificate id.
-    # - "KECS[-‐]CR[-‐][0-9]+[-‐][0-9]+"  # Korea KECS-CR-20-61
-    - "KECS[-‐](?:ISIS|NISS|CISS)[-‐][0-9]+[-‐][0-9]{4}"  # Korea KECS-ISIS-1234-2011
+    # Examples:
+    # KECS-ISIS-0579-2015
+    # KECS-NISS-0792-2017
+    # KECS-CISS-1210-2023
   JP:
     - "(?:CRP|ACR)-C(?P<counter>[0-9]+)-(?P<digit>[0-9]+)"
     - "JISEC-CC-CRP-C(?P<counter>[0-9]+)-(?P<digit>[0-9]+)-(?P<year>[0-9]{4})"

--- a/src/sec_certs/rules.yaml
+++ b/src/sec_certs/rules.yaml
@@ -56,9 +56,13 @@ cc_cert_id:
     # - "KECS[-‐]CR[-‐][0-9]+[-‐][0-9]+"  # Korea KECS-CR-20-61
     - "KECS[-‐](?:ISIS|NISS|CISS)[-‐][0-9]+[-‐][0-9]{4}"  # Korea KECS-ISIS-1234-2011
   JP:
-    - "(?:CRP|ACR)-C[0-9]+-[0-9]+"  # Japan (CRP-C0595-01 ACR-C0417-03)
-    - "JISEC-CC-CRP-C[0-9]+-[0-9]+-[0-9]+"  # Japan (JISEC-CC-CRP-C0689-01-2020)
-    - "Certification No. [cC][0-9]+" # Japan (Certification No. C0090)
+    - "(?:CRP|ACR)-C(?P<counter>[0-9]+)-(?P<digit>[0-9]+)"
+    - "JISEC-CC-CRP-C(?P<counter>[0-9]+)-(?P<digit>[0-9]+)-(?P<year>[0-9]{4})"
+    - "Certification No. [cC](?P<counter>[0-9]+)"
+    # Examples:
+    # CRP-C0595-01
+    # JISEC-CC-CRP-C0689-01-2020
+    # Certification No. C0090
   MY:
     - "ISCB-(?P<digit>[0-9])-RPT-C(?P<counter>[0-9]{3})-CR(?:-[0-9])?-(?P<version>[vV][0-9][a-z]?)"
     # Examples:

--- a/src/sec_certs/rules.yaml
+++ b/src/sec_certs/rules.yaml
@@ -94,9 +94,13 @@ cc_cert_id:
     # CSEC2019015
     # CSEC 2019012
   IN:
-    # India (IC3S/DEL01/VALIANT/EAL1/0317/0007/CR  STQC/CC/14-15/12/ETR/0017 IC3S/MUM01/CISCO/cPP/0119/0016/CR)
-    # will miss STQC/CC/14-15/12/ETR/0017
-    - "(?:IC3S|STQC/CC)/[^ ]+? ?/CR"
+    - "IC3S/(?P<lab>[A-Z]+[0-9]+)/(?P<vendor>[a-zA-Z_]+)/(?P<level>[a-zA-Z0-9]+)/(?P<number1>[0-9]+)/(?P<number2>[0-9]+) ?(?:/CR)?"
+    # XXX: The cert IDs are often present only in the certificate and not in the report.
+    #      The report often only has the report id, of the format "STQC/CC/1617/18/CR"
+    # Examples:
+    # IC3S/BG01/HALTDOS/EAL2/0317/0008/CR
+    # IC3S/KOL01/ADVA/EAL2/0520/0021/CR
+    # IC3S/MUM01/Symantec/NDcPP/0722/0032/CR
   SG:
     - "CSA_CC_(?P<year>[0-9]{2})(?P<counter>[0-9]{3})"
     # Examples:

--- a/src/sec_certs/rules.yaml
+++ b/src/sec_certs/rules.yaml
@@ -13,13 +13,15 @@ cc_cert_id:
     - "BSI-DSZ-CC-[0-9]+-(?:V|v)[0-9]+(?!-)"  # German BSI (number + version but no year => no - after version)
     # - "BSI-DSZ-CC-[0-9]+"  # Maybe?
   FR:
-    - "ANSS[Ii](?:-|-CC-|-CC )[0-9]{4}/[0-9]+(v[1-9])?"  # French
-    - "ANSS[Ii]-CC[ -][0-9]{4}[/-_][0-9][0-9]+(?!-M|-S|-R)"  # French (/two or more digits then NOT -M or -S)
-    - "ANSS[Ii]-CC[ -][0-9]{4}[/-_][0-9]+(?:v[0-9])?[_/-][MSR][0-9]+"  # French, maintenance or surveillance report (ANSSI-CC-2014_46_M01)
-    # 'ANSSI-CC-CER-F-.+?', # French
-    - "DCSS[Ii]-[0-9]+/[0-9]+"  # French (DCSSI-2009/07)
-    - "Certification Report [0-9]+/[0-9]+" # French or Australia! Solved because we limit ourselves to scheme when doing heuristics.
-    - "Rapport de certification [0-9]+/[0-9]+"  # French
+    - "DCSS[Ii]-(?P<year>[0-9]{2,4})/(?P<counter>[0-9]+)([vV](?P<version>[0-9]))?"
+    - "Certification Report (?P<year>[0-9]{2,4})/(?P<counter>[0-9]+)([vV](?P<version>[0-9]))?"
+    - "Rapport de certification (?P<year>[0-9]{2,4})/(?P<counter>[0-9]+)([vV](?P<version>[0-9]))?"
+    - "ANSS[Ii](?:-CC)?[ -](?P<year>[0-9]{2,4})[/_-](?P<counter>[0-9]+)(?:-(?P<doc>(?:[MSR][0-9]+)))?([vV](?P<version>[0-9]))?"
+    # Examples:
+    # DCSSI-2009/07
+    # ANSSI-CC 2001/02-R01
+    # Rapport de certification 2001/02v2
+    # Certification Report 2003/20
   NL:
     - "(?:NSCIB-|CC-|NSCIB-CC-)(?P<core>((?P<year>[0-9]{2})-)?(?:-?[0-9]+)+)(?:-?(?P<doc>(?:CR|MA|MR)[0-9]*))?"
     # Examples:
@@ -28,7 +30,7 @@ cc_cert_id:
     # CC-16-31801-CR4  (no NSCIB)
     # NSCIB-CC-98209   (no year, no CR)
   "NO":
-    - "SERTIT-[0-9]+"  # Norway
+    - "SERTIT-(?P<counter>[0-9]+)"  # Norway
   US:
     - "CCEVS-VR-(?:CC-|VID)?[0-9]+-[0-9]+[a-z]?(?:-[0-9]+)?"  # US NSA (CCEVS-VR-10884-2018 CCEVS-VR-VID10877-2018)
   CA:

--- a/src/sec_certs/rules.yaml
+++ b/src/sec_certs/rules.yaml
@@ -126,11 +126,11 @@ cc_cert_id:
 #####
 cc_filename_cert_id:
   DE:
-    - "(?P<counter>[0-9]{3,5})(?:(?P<version>[vV][0-9]))?a?(?:_pdf)?"
+    #- "(?P<counter>[0-9]{3,5})(?:(?P<version>[vV][0-9]))?a?(?:_pdf)?"
     - "(?P<year>[0-9]{4})(?P<month>[0-9]{2})(?P<day>[0-9]{2})_(?P<counter>[0-9]{3,5})(?:(?P<version>[vV][0-9]))?a?(?:_pdf)?"
   FR:
     - "(?P<year>[0-9]{4})[_-](?P<counter>[0-9]{2})([vV](?P<version>[0-9]))?"
-    - "(?P<year>[0-9]{2})(?P<counter>[0-9]{2})([vV](?P<version>[0-9]))?"
+    #- "(?P<year>[0-9]{2})(?P<counter>[0-9]{2})([vV](?P<version>[0-9]))?"
   NL:
     - "(?:NSCIB-|CC-|NSCIB-CC-)(?P<core>((?P<year>[0-9]{2})-)?(?:-?[0-9]+)+)(?:-?(?P<doc>(?:CR|MA|MR)[0-9]*))?"
   "NO":

--- a/src/sec_certs/rules.yaml
+++ b/src/sec_certs/rules.yaml
@@ -41,10 +41,14 @@ cc_cert_id:
     # CCEVS-VR-10880-2018
     # CCEVS-VR-04-0082
   CA:
-    # '[0-9][0-9\-]+?-CR', # Canada
-    - "[0-9][0-9][0-9]-[347]-[0-9][0-9][0-9]?(?:-CR|P)?"  # Canada xxx-{347}-xxx (383-4-438, 383-4-82-CR, 383-4-422P)
-    - "[0-9][0-9][0-9][ -](?:EWA|LSS|CCS)(?:[ -]20[0-9][0-9])?"  # Canada (522-EWA-2020, 524 LSS 2020, 503-LSS)
-    - "[0-9][0-9][0-9](?:%20|-)(?:EWA|LSS|CCS)(?:%20|-)(?:20[0-9][0-9]%20|)CR%20v[0-9]\\.[0-9]" # Canada filename with space (518-LSS%20CR%20v1.0)
+    - "(?P<number1>[0-9]+)[ -](?P<digit>[0-9])[ -](?P<number2>[0-9]+)(?:-CR|P)?"
+    - "(?P<number>[0-9]+)[ -](?P<lab>EWA|LSS|CCS)(?:[ -](?P<year>[0-9]+))?"
+    # Examples:
+    # 383-4-123-CR
+    # 383-4-123P
+    # 522 EWA 2020
+    # Filename rule:
+    #- "[0-9][0-9][0-9](?:%20|-)(?:EWA|LSS|CCS)(?:%20|-)(?:20[0-9][0-9]%20|)CR%20v[0-9]\\.[0-9]" # Canada filename with space (518-LSS%20CR%20v1.0)
   UK:
     - "CRP(?P<counter>[0-9]+[A-Z]?)"
     - "CERTIFICATION REPORT No. P(?P<counter>[0-9]+[A-Z]?)"

--- a/src/sec_certs/rules.yaml
+++ b/src/sec_certs/rules.yaml
@@ -60,7 +60,11 @@ cc_cert_id:
     - "JISEC-CC-CRP-C[0-9]+-[0-9]+-[0-9]+"  # Japan (JISEC-CC-CRP-C0689-01-2020)
     - "Certification No. [cC][0-9]+" # Japan (Certification No. C0090)
   MY:
-    - "ISCB-[0-9]+-(?:RPT|FRM)-[CM][0-9]+[A-Z]?-(?:CR|AMR)(?:-[0-9])?-[vV][0-9](?:\\.[0-9])?[a-z]?" # Malaysia (ISCB-3-RPT-C092-CR-v1, ISCB-3-RPT-C068-CR-1-v1)
+    - "ISCB-(?P<digit>[0-9])-RPT-C(?P<counter>[0-9]{3})-CR(?:-[0-9])?-(?P<version>[vV][0-9][a-z]?)"
+    # Examples:
+    # ISCB-3-RPT-C068-CR-1-v1
+    # ISCB-5-RPT-C075-CR-v2
+    # ISCB-5-RPT-C046-CR-V1a
   IT:
     - "OCSI/CERT/.+?"  # Italy
     - "OCSI/CERT/.+?/20[0-9]+(?:\\w|/RC)"  # Italy  (OCSI/CERT/ATS/01/2018/RC)

--- a/src/sec_certs/rules.yaml
+++ b/src/sec_certs/rules.yaml
@@ -5,7 +5,7 @@
 #####
 cc_cert_id:
   DE:
-    - "BSI-DSZ-CC-(?:(?P<s>S)-)?(?P<counter>[0-9]{3,5})-(?:(?P<version>[vV][0-9])-)?(?P<year>[0-9]{4})?(?:-(?P<doc>(?:RA|MA)(?:-[0-9]+)?))?"
+    - "BSI-DSZ-CC-(?:(?P<s>S)-)?(?P<counter>[0-9]{3,5})-?(?:(?P<version>[vV][0-9])-)?(?P<year>[0-9]{4})?(?:-(?P<doc>(?:RA|MA)(?:-[0-9]+)?))?"
     # Examples:
     # BSI-DSZ-CC-1004
     # BSI-DSZ-CC-0973-2016

--- a/src/sec_certs/rules.yaml
+++ b/src/sec_certs/rules.yaml
@@ -122,6 +122,43 @@ cc_cert_id:
     # Certification Report 97/76     !short year
 
 #####
+# Common Criteria certificate IDs as they appear in report filenames, grouped by scheme (Alpha-2 ISO country code).
+#####
+cc_filename_cert_id:
+  DE:
+    - "(?P<counter>[0-9]{3,5})(?:(?P<version>[vV][0-9]))?a?(?:_pdf)?"
+    - "(?P<year>[0-9]{4})(?P<month>[0-9]{2})(?P<day>[0-9]{2})_(?P<counter>[0-9]{3,5})(?:(?P<version>[vV][0-9]))?a?(?:_pdf)?"
+  FR:
+    - "(?P<year>[0-9]{4})[_-](?P<counter>[0-9]{2})([vV](?P<version>[0-9]))?"
+    - "(?P<year>[0-9]{2})(?P<counter>[0-9]{2})([vV](?P<version>[0-9]))?"
+  NL:
+    - "(?:NSCIB-|CC-|NSCIB-CC-)(?P<core>((?P<year>[0-9]{2})-)?(?:-?[0-9]+)+)(?:-?(?P<doc>(?:CR|MA|MR)[0-9]*))?"
+  "NO":
+    - "SERTIT-(?P<counter>[0-9]+)"
+  US:
+  CA:
+    - "(?P<number1>[0-9]+)[ -](?P<digit>[0-9])[ -](?P<number2>[0-9]+)(?:-CR|P)?"
+    - "(?P<number>[0-9]+)[ -](?P<lab>EWA|LSS|CCS)(?:[ -](?P<year>[0-9]+))?"
+  UK:
+    - "CRP(?P<counter>[0-9]+[A-Z]?)"
+  ES:
+    - "(?P<year>[0-9]{4})[-‐](?P<project>[0-9]+)[-‐]INF[-‐](?P<counter>[0-9]+)[ -‐_]{1,2}[vV](?P<version>[0-9])"
+  KR:
+    - "(?P<word>ISIS|NISS|CISS)[-‐](?P<counter>[0-9]{2,4})(?:[-‐](?P<year>[0-9]{4}))?"
+  JP:
+    - "[cC](?P<counter>[0-9]+)"
+  MY:
+    - "ISCB-(?P<digit>[0-9])-RPT-C(?P<counter>[0-9]{3})-CR(?:-[0-9])?-(?P<version>[vV][0-9][a-z]?)"
+  IT:
+  TR:
+  SE:
+    - "CR(?P<year>[0-9]{4})(?P<counter>[0-9]{2,3})"
+  IN:
+  SG:
+  AU:
+    - "(?P<year>[0-9]{2,4})_(?P<counter>[0-9]+)"
+
+#####
 # Common Criteria protection profile IDs, grouped by certification body (e.g. BSI)
 #####
 cc_protection_profile_id:

--- a/src/sec_certs/sample/cc.py
+++ b/src/sec_certs/sample/cc.py
@@ -338,13 +338,16 @@ class CCCertificate(
             if not self.report_filename:
                 return {}
             scheme_filename_rules = rules["cc_filename_cert_id"][scheme]
+            if not scheme_filename_rules:
+                return {}
             scheme_meta = schemes[scheme]
             matches: Counter = Counter()
             for rule in scheme_filename_rules:
                 match = re.search(rule, self.report_filename)
                 if match:
                     try:
-                        cert_id = scheme_meta(match.groupdict())
+                        meta = match.groupdict()
+                        cert_id = scheme_meta(meta)
                         matches[cert_id] += 1
                     except Exception:
                         continue

--- a/src/sec_certs/sample/cc_certificate_id.py
+++ b/src/sec_certs/sample/cc_certificate_id.py
@@ -89,6 +89,19 @@ class CertificateId:
 
         return new_cert_id
 
+    def _canonical_my(self) -> str:
+        new_cert_id = self.clean
+        for rule in rules["cc_cert_id"]["MY"]:
+            if match := re.match(rule, new_cert_id):
+                groups = match.groupdict()
+                digit = groups["digit"]
+                counter = groups["counter"]
+                version = groups["version"]
+                new_cert_id = f"ISCB-{digit}-RPT-C{counter}-CR-{version.lower()}"
+                break
+
+        return new_cert_id
+
     def _canonical_es(self) -> str:
         cert_id = self.clean
         spain_parts = cert_id.split("-")
@@ -170,6 +183,7 @@ class CertificateId:
             "FR": self._canonical_fr,
             "DE": self._canonical_de,
             "US": self._canonical_us,
+            "MY": self._canonical_my,
             "ES": self._canonical_es,
             "IT": self._canonical_it,
             "IN": self._canonical_in,

--- a/src/sec_certs/sample/cc_certificate_id.py
+++ b/src/sec_certs/sample/cc_certificate_id.py
@@ -117,7 +117,17 @@ class CertificateId:
         return new_cert_id
 
     def _canonical_in(self):
-        return self.clean.replace(" ", "")
+        new_cert_id = self.clean
+        for rule in rules["cc_cert_id"]["IN"]:
+            if match := re.match(rule, new_cert_id):
+                groups = match.groupdict()
+                lab = groups["lab"]
+                vendor = groups["vendor"]
+                level = groups["level"]
+                number1, number2 = groups["number1"], groups["number2"]
+                new_cert_id = f"IC3S/{lab}/{vendor}/{level}/{number1}/{number2}"
+                break
+        return new_cert_id
 
     def _canonical_se(self):
         new_cert_id = self.clean
@@ -232,7 +242,7 @@ class CertificateId:
             "AU": self._canonical_au,
             "KR": self._canonical_kr,
             # SG is canonical by default
-            # IT is canonucal by default
+            # IT is canonical by default
         }
 
         if self.scheme in schemes:

--- a/src/sec_certs/sample/cc_certificate_id.py
+++ b/src/sec_certs/sample/cc_certificate_id.py
@@ -19,7 +19,7 @@ def _parse_year(year: str | None) -> int | None:
         return y
 
 
-@dataclass(eq=True, frozen=True)
+@dataclass(frozen=True)
 class CertificateId:
     """
     A Common Criteria certificate id.

--- a/src/sec_certs/sample/cc_certificate_id.py
+++ b/src/sec_certs/sample/cc_certificate_id.py
@@ -103,19 +103,17 @@ class CertificateId:
         return new_cert_id
 
     def _canonical_es(self) -> str:
-        cert_id = self.clean
-        spain_parts = cert_id.split("-")
-        cert_year = spain_parts[0]
-        cert_batch = spain_parts[1].lstrip("0")
-        cert_num = spain_parts[3].lstrip("0")
-
-        if "v" in cert_num:
-            cert_num = cert_num[: cert_num.find("v")]
-        if "V" in cert_num:
-            cert_num = cert_num[: cert_num.find("V")]
-
-        new_cert_id = f"{cert_year}-{cert_batch}-INF-{cert_num.strip()}"  # drop version # TODO: Maybe do not drop?
-
+        new_cert_id = self.clean
+        for rule in rules["cc_cert_id"]["ES"]:
+            if match := re.match(rule, new_cert_id):
+                groups = match.groupdict()
+                year = _parse_year(groups["year"])
+                project = groups["project"]
+                counter = groups["counter"]
+                # Version is intentionally cut here, as it seems to refer to an internal version of the report.
+                # version = groups["version"]
+                new_cert_id = f"{year}-{project}-INF-{counter}"
+                break
         return new_cert_id
 
     def _canonical_it(self):

--- a/src/sec_certs/sample/cc_certificate_id.py
+++ b/src/sec_certs/sample/cc_certificate_id.py
@@ -182,6 +182,28 @@ def IT(meta) -> str:
     return cert_id
 
 
+# We have rules for some schemes to make canonical cert_ids.
+schemes = {
+    "FR": FR,
+    "DE": DE,
+    "US": US,
+    "MY": MY,
+    "ES": ES,
+    "IN": IN,
+    "SE": SE,
+    "UK": UK,
+    "CA": CA,
+    "JP": JP,
+    "NO": NO,
+    "NL": NL,
+    "AU": AU,
+    "KR": KR,
+    "TR": TR,
+    "SG": SG,
+    "IT": IT,
+}
+
+
 @dataclass(frozen=True)
 class CertificateId:
     """
@@ -210,26 +232,6 @@ class CertificateId:
         """
         The canonical version of this certificate id.
         """
-        # We have rules for some schemes to make canonical cert_ids.
-        schemes = {
-            "FR": FR,
-            "DE": DE,
-            "US": US,
-            "MY": MY,
-            "ES": ES,
-            "IN": IN,
-            "SE": SE,
-            "UK": UK,
-            "CA": CA,
-            "JP": JP,
-            "NO": NO,
-            "NL": NL,
-            "AU": AU,
-            "KR": KR,
-            "TR": TR,
-            "SG": SG,
-            "IT": IT,
-        }
         clean = self.clean
 
         if self.scheme in schemes:

--- a/src/sec_certs/sample/cc_certificate_id.py
+++ b/src/sec_certs/sample/cc_certificate_id.py
@@ -133,8 +133,12 @@ class CertificateId:
 
     def _canonical_uk(self):
         new_cert_id = self.clean
-        if match := re.match("CERTIFICATION REPORT No. P([0-9]+[A-Z]?)", new_cert_id):
-            new_cert_id = "CRP" + match.group(1)
+        for rule in rules["cc_cert_id"]["UK"]:
+            if match := re.match(rule, new_cert_id):
+                groups = match.groupdict()
+                counter = groups["counter"]
+                new_cert_id = f"CRP{counter}"
+                break
         return new_cert_id
 
     def _canonical_ca(self):

--- a/src/sec_certs/sample/cc_certificate_id.py
+++ b/src/sec_certs/sample/cc_certificate_id.py
@@ -116,13 +116,6 @@ class CertificateId:
                 break
         return new_cert_id
 
-    def _canonical_it(self):
-        new_cert_id = self.clean
-        if not new_cert_id.endswith("/RC"):
-            new_cert_id = new_cert_id + "/RC"
-
-        return new_cert_id
-
     def _canonical_in(self):
         return self.clean.replace(" ", "")
 
@@ -217,7 +210,6 @@ class CertificateId:
             "US": self._canonical_us,
             "MY": self._canonical_my,
             "ES": self._canonical_es,
-            "IT": self._canonical_it,
             "IN": self._canonical_in,
             "SE": self._canonical_se,
             "UK": self._canonical_uk,
@@ -227,6 +219,7 @@ class CertificateId:
             "NL": self._canonical_nl,
             "AU": self._canonical_au,
             # SG is canonical by default
+            # IT is canonucal by default
         }
 
         if self.scheme in schemes:

--- a/src/sec_certs/sample/cc_certificate_id.py
+++ b/src/sec_certs/sample/cc_certificate_id.py
@@ -151,11 +151,23 @@ class CertificateId:
 
     def _canonical_ca(self):
         new_cert_id = self.clean
-        if new_cert_id.endswith("-CR"):
-            new_cert_id = new_cert_id[:-3]
-        if new_cert_id.endswith("P"):
-            new_cert_id = new_cert_id[:-1]
-        return new_cert_id.replace(" ", "-")
+        for rule in rules["cc_cert_id"]["CA"]:
+            if match := re.match(rule, new_cert_id):
+                groups = match.groupdict()
+                if "lab" in groups:
+                    year = _parse_year(groups.get("year"))
+                    number = groups["number"]
+                    lab = groups["lab"]
+                    new_cert_id = f"{number}-{lab}"
+                    if year:
+                        new_cert_id += f"-{year}"
+                else:
+                    number1 = groups["number1"]
+                    digit = groups["digit"]
+                    number2 = groups["number2"]
+                    new_cert_id = f"{number1}-{digit}-{number2}"
+                break
+        return new_cert_id
 
     def _canonical_jp(self):
         new_cert_id = self.clean

--- a/src/sec_certs/sample/cc_certificate_id.py
+++ b/src/sec_certs/sample/cc_certificate_id.py
@@ -163,6 +163,18 @@ class CertificateId:
                 break
         return new_cert_id
 
+    def _canonical_kr(self):
+        new_cert_id = self.clean
+        for rule in rules["cc_cert_id"]["KR"]:
+            if match := re.match(rule, new_cert_id):
+                groups = match.groupdict()
+                word = groups["word"]
+                counter = int(groups["counter"])
+                year = _parse_year(groups["year"])
+                new_cert_id = f"KECS-{word}-{counter:04}-{year}"
+                break
+        return new_cert_id
+
     def _canonical_no(self):
         new_cert_id = self.clean
         cert_num = int(new_cert_id.split("-")[1])
@@ -218,6 +230,7 @@ class CertificateId:
             "NO": self._canonical_no,
             "NL": self._canonical_nl,
             "AU": self._canonical_au,
+            "KR": self._canonical_kr,
             # SG is canonical by default
             # IT is canonucal by default
         }

--- a/src/sec_certs/sample/cc_certificate_id.py
+++ b/src/sec_certs/sample/cc_certificate_id.py
@@ -126,7 +126,7 @@ class CertificateId:
         new_cert_id = self.clean
         if new_cert_id.startswith("CC-"):
             new_cert_id = f"NSCIB-{new_cert_id}"
-        if not new_cert_id.endswith("-CR"):
+        if not re.match(".*-(CR|MA|MR)[0-9]*$", new_cert_id):
             new_cert_id = f"{new_cert_id}-CR"
         return new_cert_id
 

--- a/src/sec_certs/sample/cc_certificate_id.py
+++ b/src/sec_certs/sample/cc_certificate_id.py
@@ -185,6 +185,17 @@ class CertificateId:
                 break
         return new_cert_id
 
+    def _canonical_tr(self):
+        new_cert_id = self.clean
+        for rule in rules["cc_cert_id"]["TR"]:
+            if match := re.match(rule, new_cert_id):
+                groups = match.groupdict()
+                prefix = groups["prefix"]
+                number = groups["number"]
+                new_cert_id = f"{prefix}/TSE-CCCS-{number}"
+                break
+        return new_cert_id
+
     def _canonical_no(self):
         new_cert_id = self.clean
         cert_num = int(new_cert_id.split("-")[1])
@@ -241,6 +252,7 @@ class CertificateId:
             "NL": self._canonical_nl,
             "AU": self._canonical_au,
             "KR": self._canonical_kr,
+            "TR": self._canonical_tr,
             # SG is canonical by default
             # IT is canonical by default
         }

--- a/src/sec_certs/sample/cc_certificate_id.py
+++ b/src/sec_certs/sample/cc_certificate_id.py
@@ -129,7 +129,14 @@ class CertificateId:
         return self.clean.replace(" ", "")
 
     def _canonical_se(self):
-        return self.clean.replace(" ", "")
+        new_cert_id = self.clean
+        for rule in rules["cc_cert_id"]["SE"]:
+            if match := re.match(rule, new_cert_id):
+                groups = match.groupdict()
+                year = _parse_year(groups["year"])
+                counter = int(groups["counter"])
+                new_cert_id = f"CSEC{year}{counter:03}"
+        return new_cert_id
 
     def _canonical_uk(self):
         new_cert_id = self.clean

--- a/src/sec_certs/sample/cc_certificate_id.py
+++ b/src/sec_certs/sample/cc_certificate_id.py
@@ -147,10 +147,18 @@ class CertificateId:
 
     def _canonical_jp(self):
         new_cert_id = self.clean
-        if match := re.match("Certification No. (C[0-9]+)", new_cert_id):
-            return match.group(1)
-        if match := re.search("CRP-(C[0-9]+)-", new_cert_id):
-            return match.group(1)
+        for rule in rules["cc_cert_id"]["JP"]:
+            if match := re.match(rule, new_cert_id):
+                groups = match.groupdict()
+                counter = groups["counter"]
+                digit = groups.get("digit")
+                year = _parse_year(groups.get("year"))
+                new_cert_id = f"JISEC-CC-CRP-C{counter}"
+                if digit:
+                    new_cert_id += f"-{digit}"
+                if year:
+                    new_cert_id += f"-{year}"
+                break
         return new_cert_id
 
     def _canonical_no(self):

--- a/src/sec_certs/sample/cc_certificate_id.py
+++ b/src/sec_certs/sample/cc_certificate_id.py
@@ -183,6 +183,21 @@ class CertificateId:
             new_cert_id = f"{new_cert_id}-CR"
         return new_cert_id
 
+    def _canonical_au(self):
+        new_cert_id = self.clean
+        for rule in rules["cc_cert_id"]["AU"]:
+            if match := re.match(rule, new_cert_id):
+                groups = match.groupdict()
+                counter = groups["counter"]
+                year_s = groups["year"]
+                if len(year_s) < len(counter):
+                    # Hack for some mistakes in their ordering
+                    year_s, counter = counter, year_s
+                year = _parse_year(year_s)
+                new_cert_id = f"Certificate Number: {year}/{counter}"
+                break
+        return new_cert_id
+
     @property
     def clean(self) -> str:
         """
@@ -210,6 +225,8 @@ class CertificateId:
             "JP": self._canonical_jp,
             "NO": self._canonical_no,
             "NL": self._canonical_nl,
+            "AU": self._canonical_au,
+            # SG is canonical by default
         }
 
         if self.scheme in schemes:

--- a/src/sec_certs/sample/cc_certificate_id.py
+++ b/src/sec_certs/sample/cc_certificate_id.py
@@ -10,7 +10,9 @@ def _parse_year(year: str | None) -> int | None:
     if year is None:
         return None
     y = int(year)
-    if y < 100:
+    if y < 50:
+        return y + 2000
+    elif y < 100:
         return y + 1900
     else:
         return y
@@ -39,7 +41,7 @@ class CertificateId:
                     new_cert_id += f"-{doc}"
                 if version:
                     new_cert_id += f"v{version}"
-                return new_cert_id
+                break
 
         return new_cert_id
 
@@ -63,7 +65,27 @@ class CertificateId:
                     new_cert_id += f"-{year}"
                 if doc:
                     new_cert_id += f"-{doc}"
-                return new_cert_id
+                break
+
+        return new_cert_id
+
+    def _canonical_us(self) -> str:
+        new_cert_id = self.clean
+        for rule in rules["cc_cert_id"]["US"]:
+            if match := re.match(rule, new_cert_id):
+                groups = match.groupdict()
+                year = _parse_year(groups["year"])
+                counter = groups["counter"]
+                cc = groups.get("cc")
+                vid = groups.get("VID")
+                new_cert_id = "CCEVS-VR"
+                if cc:
+                    new_cert_id += f"-{cc}"
+                if vid:
+                    new_cert_id += f"-{vid}"
+                new_cert_id += f"-{counter}"
+                new_cert_id += f"-{year}"
+                break
 
         return new_cert_id
 
@@ -147,6 +169,7 @@ class CertificateId:
         schemes = {
             "FR": self._canonical_fr,
             "DE": self._canonical_de,
+            "US": self._canonical_us,
             "ES": self._canonical_es,
             "IT": self._canonical_it,
             "IN": self._canonical_in,

--- a/tests/cc/test_cc_misc.py
+++ b/tests/cc/test_cc_misc.py
@@ -1,4 +1,10 @@
-from sec_certs.sample.cc_certificate_id import canonicalize
+from sec_certs.sample.cc_certificate_id import CertificateId, canonicalize
+
+
+def test_meta_parse():
+    i = CertificateId("FR", "Rapport de certification 2001/02v2")
+    assert "year" in i.meta
+    assert i.meta["year"] == "2001"
 
 
 def test_canonicalize_fr():

--- a/tests/cc/test_cc_misc.py
+++ b/tests/cc/test_cc_misc.py
@@ -36,8 +36,16 @@ def test_canonicalize_es():
     assert canonicalize("2011-14-INF-1095-v1", "ES") == "2011-14-INF-1095"
 
 
+def test_canonicalize_sg():
+    assert canonicalize("CSA_CC_21005", "SG") == "CSA_CC_21005"
+
+
 def test_canonicalize_in():
     assert canonicalize("IC3S/KOL01/ADVA/EAL2/0520/0021 /CR", "IN") == "IC3S/KOL01/ADVA/EAL2/0520/0021"
+
+
+def test_canonicalize_it():
+    assert canonicalize("OCSI/CERT/TEC/02/2009/RC", "IT") == "OCSI/CERT/TEC/02/2009/RC"
 
 
 def test_canonicalize_se():

--- a/tests/cc/test_cc_misc.py
+++ b/tests/cc/test_cc_misc.py
@@ -63,6 +63,11 @@ def test_canonicalize_jp():
     assert canonicalize("JISEC-CC-CRP-C0689-01-2020", "JP") == "JISEC-CC-CRP-C0689-01-2020"
 
 
+def test_canonicalize_KR():
+    assert canonicalize("KECS-ISIS-0579-2015", "KR") == "KECS-ISIS-0579-2015"
+    assert canonicalize("KECS-CISS-10-2023", "KR") == "KECS-CISS-0010-2023"
+
+
 def test_canonicalize_no():
     assert canonicalize("SERTIT-12", "NO") == "SERTIT-012"
 

--- a/tests/cc/test_cc_misc.py
+++ b/tests/cc/test_cc_misc.py
@@ -5,6 +5,8 @@ def test_meta_parse():
     i = CertificateId("FR", "Rapport de certification 2001/02v2")
     assert "year" in i.meta
     assert i.meta["year"] == "2001"
+    assert i.meta["counter"] == "02"
+    assert i.meta["version"] == "2"
 
 
 def test_canonicalize_fr():
@@ -96,3 +98,11 @@ def test_canonicalize_nl():
     assert canonicalize("NSCIB-CC-22-0428888-CR2", "NL") == "NSCIB-CC-22-0428888-CR2"
     assert canonicalize("NSCIB-CC-22-0428888", "NL") == "NSCIB-CC-22-0428888-CR"
     assert canonicalize("CC-22-0428888", "NL") == "NSCIB-CC-22-0428888-CR"
+
+
+def test_certid_compare():
+    cid1 = CertificateId("AU", "Certification Report 2007/02")
+    cid2 = CertificateId("AU", "Certificate Number: 02/2007")
+    cid3 = CertificateId("AU", "Certificate Number: 05/2007")
+    assert cid1 == cid2
+    assert cid1 != cid3

--- a/tests/cc/test_cc_misc.py
+++ b/tests/cc/test_cc_misc.py
@@ -4,6 +4,7 @@ from sec_certs.sample.cc_certificate_id import canonicalize
 def test_canonicalize_fr():
     assert canonicalize("Rapport de certification 2001/02v2", "FR") == "ANSSI-CC-2001/02v2"
     assert canonicalize("ANSSI-CC 2001/02-R01", "FR") == "ANSSI-CC-2001/02-R01"
+    assert canonicalize("ANSSI-CC 2001_02-M01", "FR") == "ANSSI-CC-2001/02-M01"
 
 
 def test_canonicalize_de():
@@ -40,6 +41,7 @@ def test_canonicalize_in():
 def test_canonicalize_se():
     assert canonicalize("CSEC2017020", "SE") == "CSEC2017020"
     assert canonicalize("CSEC 2017020", "SE") == "CSEC2017020"
+    assert canonicalize("CSEC201003", "SE") == "CSEC2010003"
 
 
 def test_canonicalize_uk():

--- a/tests/cc/test_cc_misc.py
+++ b/tests/cc/test_cc_misc.py
@@ -45,3 +45,9 @@ def test_canonicalize_jp():
 
 def test_canonicalize_no():
     assert canonicalize("SERTIT-12", "NO") == "SERTIT-012"
+
+
+def test_canonicalize_nl():
+    assert canonicalize("NSCIB-CC-22-0428888-CR2", "NL") == "NSCIB-CC-22-0428888-CR2"
+    assert canonicalize("NSCIB-CC-22-0428888", "NL") == "NSCIB-CC-22-0428888-CR"
+    assert canonicalize("CC-22-0428888", "NL") == "NSCIB-CC-22-0428888-CR"

--- a/tests/cc/test_cc_misc.py
+++ b/tests/cc/test_cc_misc.py
@@ -8,6 +8,9 @@ def test_canonicalize_fr():
 
 def test_canonicalize_de():
     assert canonicalize("BSI-DSZ-CC-0420-2007", "DE") == "BSI-DSZ-CC-0420-2007"
+    assert canonicalize("BSI-DSZ-CC-1004", "DE") == "BSI-DSZ-CC-1004"
+    assert canonicalize("BSI-DSZ-CC-0831-V4-2021", "DE") == "BSI-DSZ-CC-0831-V4-2021"
+    assert canonicalize("BSI-DSZ-CC-0837-V2-2014-MA-01", "DE") == "BSI-DSZ-CC-0837-V2-2014-MA-01"
 
 
 def test_canonicalize_es():

--- a/tests/cc/test_cc_misc.py
+++ b/tests/cc/test_cc_misc.py
@@ -53,9 +53,9 @@ def test_canonicalize_ca():
 
 
 def test_canonicalize_jp():
-    assert canonicalize("Certification No. C01234", "JP") == "C01234"
-    assert canonicalize("CRP-C01234-01", "JP") == "C01234"
-    assert canonicalize("JISEC-CC-CRP-C0689-01-2020", "JP") == "C0689"
+    assert canonicalize("Certification No. C01234", "JP") == "JISEC-CC-CRP-C01234"
+    assert canonicalize("CRP-C01234-01", "JP") == "JISEC-CC-CRP-C01234-01"
+    assert canonicalize("JISEC-CC-CRP-C0689-01-2020", "JP") == "JISEC-CC-CRP-C0689-01-2020"
 
 
 def test_canonicalize_no():

--- a/tests/cc/test_cc_misc.py
+++ b/tests/cc/test_cc_misc.py
@@ -63,13 +63,18 @@ def test_canonicalize_jp():
     assert canonicalize("JISEC-CC-CRP-C0689-01-2020", "JP") == "JISEC-CC-CRP-C0689-01-2020"
 
 
-def test_canonicalize_KR():
+def test_canonicalize_kr():
     assert canonicalize("KECS-ISIS-0579-2015", "KR") == "KECS-ISIS-0579-2015"
     assert canonicalize("KECS-CISS-10-2023", "KR") == "KECS-CISS-0010-2023"
 
 
 def test_canonicalize_no():
     assert canonicalize("SERTIT-12", "NO") == "SERTIT-012"
+
+
+def test_canonicalize_tr():
+    assert canonicalize("21.0.03.0.00.00/TSE-CCCS-85", "TR") == "21.0.03.0.00.00/TSE-CCCS-85"
+    assert canonicalize("21.0.03/TSE-CCCS-33", "TR") == "21.0.03/TSE-CCCS-33"
 
 
 def test_canonicalize_nl():

--- a/tests/cc/test_cc_misc.py
+++ b/tests/cc/test_cc_misc.py
@@ -55,6 +55,7 @@ def test_canonicalize_au():
 def test_canonicalize_ca():
     assert canonicalize("383-4-123-CR", "CA") == "383-4-123"
     assert canonicalize("383-4-123P", "CA") == "383-4-123"
+    assert canonicalize("522 EWA 2020", "CA") == "522-EWA-2020"
 
 
 def test_canonicalize_jp():

--- a/tests/cc/test_cc_misc.py
+++ b/tests/cc/test_cc_misc.py
@@ -13,6 +13,12 @@ def test_canonicalize_de():
     assert canonicalize("BSI-DSZ-CC-0837-V2-2014-MA-01", "DE") == "BSI-DSZ-CC-0837-V2-2014-MA-01"
 
 
+def test_canonicalize_us():
+    assert canonicalize("CCEVS-VR-VID10015-2008", "US") == "CCEVS-VR-VID-10015-2008"
+    assert canonicalize("CCEVS-VR-10880-2018", "US") == "CCEVS-VR-10880-2018"
+    assert canonicalize("CCEVS-VR-04-0082", "US") == "CCEVS-VR-0082-2004"
+
+
 def test_canonicalize_es():
     assert canonicalize("2011-14-INF-1095-v1", "ES") == "2011-14-INF-1095"
 

--- a/tests/cc/test_cc_misc.py
+++ b/tests/cc/test_cc_misc.py
@@ -49,6 +49,13 @@ def test_canonicalize_uk():
     assert canonicalize("CRP123A", "UK") == "CRP123A"
 
 
+def test_canonicalize_au():
+    assert canonicalize("Certification Report 2007/02", "AU") == "Certificate Number: 2007/02"
+    assert canonicalize("Certificate Number: 37/2006", "AU") == "Certificate Number: 2006/37"
+    assert canonicalize("Certificate Number: 2011/73", "AU") == "Certificate Number: 2011/73"
+    assert canonicalize("Certification Report 97/76", "AU") == "Certificate Number: 1997/76"
+
+
 def test_canonicalize_ca():
     assert canonicalize("383-4-123-CR", "CA") == "383-4-123"
     assert canonicalize("383-4-123P", "CA") == "383-4-123"

--- a/tests/cc/test_cc_misc.py
+++ b/tests/cc/test_cc_misc.py
@@ -31,7 +31,7 @@ def test_canonicalize_es():
 
 
 def test_canonicalize_in():
-    assert canonicalize("IC3S/KOL01/ADVA/EAL2/0520/0021 /CR", "IN") == "IC3S/KOL01/ADVA/EAL2/0520/0021/CR"
+    assert canonicalize("IC3S/KOL01/ADVA/EAL2/0520/0021 /CR", "IN") == "IC3S/KOL01/ADVA/EAL2/0520/0021"
 
 
 def test_canonicalize_se():

--- a/tests/cc/test_cc_misc.py
+++ b/tests/cc/test_cc_misc.py
@@ -19,6 +19,12 @@ def test_canonicalize_us():
     assert canonicalize("CCEVS-VR-04-0082", "US") == "CCEVS-VR-0082-2004"
 
 
+def test_canonicalize_my():
+    assert canonicalize("ISCB-5-RPT-C075-CR-v2", "MY") == "ISCB-5-RPT-C075-CR-v2"
+    assert canonicalize("ISCB-5-RPT-C046-CR-V1a", "MY") == "ISCB-5-RPT-C046-CR-v1a"
+    assert canonicalize("ISCB-3-RPT-C068-CR-1-v1", "MY") == "ISCB-3-RPT-C068-CR-v1"
+
+
 def test_canonicalize_es():
     assert canonicalize("2011-14-INF-1095-v1", "ES") == "2011-14-INF-1095"
 

--- a/tests/cc/test_cc_misc.py
+++ b/tests/cc/test_cc_misc.py
@@ -30,10 +30,6 @@ def test_canonicalize_es():
     assert canonicalize("2011-14-INF-1095-v1", "ES") == "2011-14-INF-1095"
 
 
-def test_canonicalize_it():
-    assert canonicalize("OCSI/CERT/SYS/10/2016", "IT") == "OCSI/CERT/SYS/10/2016/RC"
-
-
 def test_canonicalize_in():
     assert canonicalize("IC3S/KOL01/ADVA/EAL2/0520/0021 /CR", "IN") == "IC3S/KOL01/ADVA/EAL2/0520/0021/CR"
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -5,5 +5,5 @@ def test_rules():
     assert "cc_cert_id" in cc_rules
     assert "fips_cert_id" in fips_rules
     for rule_group in rules:
-        if rule_group not in ("cc_rules", "fips_rules"):
+        if rule_group not in ("cc_rules", "fips_rules", "cc_filename_cert_id"):
             assert rule_group in cc_rules or rule_group in fips_rules


### PR DESCRIPTION
The cert-id rules work, but are a mess. This PR will clean them up for presentation in the paper.

Before this, the regular cert_id regexes were used to extract
the cert_id from the report filename. However, the filenames often
do not use the same cert_id format, but contain all of the information
necessary to reconstruct the cert_id, but with different order for example.

This commit along with those before it introduce a new set of regular
expressions that better match the ones in the filenames. To extract
the correctly formatted canonical cert_id, the regexes are used to
obtain the parts of the cert_id (using named groups in regexes) and
those are then reconstructed into a canonical version of the cert_id
via one of the scheme-dependent functions.
