### PR TITLE
Try to fix FIPS alg search.

### DIFF
--- a/src/sec_certs/constants.py
+++ b/src/sec_certs/constants.py
@@ -32,7 +32,7 @@ FIPS_BASE_URL = "https://csrc.nist.gov"
 FIPS_CMVP_URL = FIPS_BASE_URL + "/projects/cryptographic-module-validation-program"
 FIPS_CAVP_URL = FIPS_BASE_URL + "/projects/Cryptographic-Algorithm-Validation-Program"
 FIPS_MODULE_URL = FIPS_CMVP_URL + "/certificate/{}"
-FIPS_ALG_SEARCH_URL = FIPS_CAVP_URL + "/validation-search?searchMode=implementation&page="
+FIPS_ALG_SEARCH_URL = FIPS_CAVP_URL + "/validation-search?searchMode=validation&page="
 FIPS_SP_URL = "https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp{}.pdf"
 FIPS_ACTIVE_MODULES_URL = (
     FIPS_CMVP_URL + "/validated-modules/search?SearchMode=Advanced&CertificateStatus=Active&ValidationYear=0"


### PR DESCRIPTION
The link:
https://csrc.nist.gov/projects/Cryptographic-Algorithm-Validation-Program/validation-search?searchMode=implementation&page=1&ipp=250 does not work, gives 408. Their search on the site which queries this also does not work.

However, when one searches by "validation" it does work. There is no difference to us, as we do not have any queries and simply want all the data.