### PR TITLE
Fix mapping of certs to PPs broken due to CC URL change.

### DIFF
--- a/src/sec_certs/sample/cc.py
+++ b/src/sec_certs/sample/cc.py
@@ -684,7 +684,7 @@ class CCCertificate(
     @classmethod
     def from_html_row(cls, row: Tag, status: str, category: str) -> CCCertificate:
         """
-        Creates a CC sample from html row of commoncriteria.org webpage.
+        Creates a CC sample from html row of commoncriteriaportal.org webpage.
         """
 
         cells = list(row.find_all("td"))


### PR DESCRIPTION
The PP links in the CSV/HTML are now slightly different than they were before. Since the PP dataset is static, it still has the old links. We use the links to match the PPs to the certs, hence that matching was broken with the change. This PR tries to fix the issue by mapping links to filenames before the matching is done.