### PR TITLE
Fix dockerhub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: Release (PyPi, DockerHub)
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   pypi_release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v7.0.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,6 @@ name: Release (PyPi, DockerHub)
 on:
   release:
     types: [published]
-  workflow_dispatch:
 
 jobs:
   pypi_release:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@
     "setuptools-scm",
     "ipykernel",
     "ipywidgets",
-    "spacy",
+    "spacy<3.8.0",
     "pkgconfig",
     "seaborn",
     "pySankeyBeta",

--- a/requirements/all_requirements.txt
+++ b/requirements/all_requirements.txt
@@ -2,9 +2,9 @@ accelerate==1.3.0
     # via sentence-transformers
 accessible-pygments==0.0.5
     # via pydata-sphinx-theme
-aiohappyeyeballs==2.4.4
+aiohappyeyeballs==2.4.6
     # via aiohttp
-aiohttp==3.11.11
+aiohttp==3.11.12
     # via
     #   datasets
     #   fsspec
@@ -26,19 +26,19 @@ attrs==25.1.0
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.16.0
+babel==2.17.0
     # via
     #   pydata-sphinx-theme
     #   sphinx
-beautifulsoup4==4.12.3
+beautifulsoup4==4.13.3
     # via
     #   pydata-sphinx-theme
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
 bleach==6.2.0
     # via panel
-blis==1.2.0
+blis==0.7.11
     # via thinc
-bokeh==3.6.2
+bokeh==3.6.3
     # via
     #   holoviews
     #   panel
@@ -51,8 +51,8 @@ catalogue==2.0.10
     #   srsly
     #   thinc
 catboost==1.2.7
-    # via sec-certs (./../pyproject.toml)
-certifi==2024.12.14
+    # via sec-certs (../pyproject.toml)
+certifi==2025.1.31
     # via requests
 cffi==1.17.1
     # via cryptography
@@ -62,15 +62,12 @@ charset-normalizer==3.4.1
     # via requests
 click==8.1.8
     # via
-    #   dask
     #   jupyter-cache
     #   pip-tools
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   typer
 cloudpathlib==0.20.0
     # via weasel
-cloudpickle==3.1.1
-    # via dask
 colorcet==3.1.0
     # via
     #   datashader
@@ -90,11 +87,11 @@ contourpy==1.3.1
     # via
     #   bokeh
     #   matplotlib
-coverage[toml]==7.6.10
+coverage[toml]==7.6.12
     # via
     #   pytest-cov
-    #   sec-certs (./../pyproject.toml)
-cryptography==44.0.0
+    #   sec-certs (../pyproject.toml)
+cryptography==44.0.1
     # via pypdf
 cycler==0.12.1
     # via matplotlib
@@ -103,18 +100,16 @@ cymem==2.0.11
     #   preshed
     #   spacy
     #   thinc
-dask==2025.1.0
-    # via datashader
 datasets==3.2.0
     # via
     #   evaluate
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   sentence-transformers
     #   setfit
-datashader==0.16.3
+datashader==0.17.0
     # via umap-learn
-dateparser==1.2.0
-    # via sec-certs (./../pyproject.toml)
+dateparser==1.2.1
+    # via sec-certs (../pyproject.toml)
 debugpy==1.8.12
     # via ipykernel
 decorator==5.1.1
@@ -148,7 +143,7 @@ filelock==3.17.0
     #   torch
     #   transformers
     #   virtualenv
-fonttools==4.55.6
+fonttools==4.56.0
     # via matplotlib
 frozenlist==1.5.0
     # via
@@ -156,10 +151,8 @@ frozenlist==1.5.0
     #   aiosignal
 fsspec[http]==2024.9.0
     # via
-    #   dask
     #   datasets
     #   evaluate
-    #   fsspec
     #   huggingface-hub
     #   torch
 gprof2dot==2024.6.6
@@ -169,8 +162,8 @@ graphviz==0.20.3
 holoviews==1.20.0
     # via umap-learn
 html5lib==1.1
-    # via sec-certs (./../pyproject.toml)
-huggingface-hub==0.27.1
+    # via sec-certs (../pyproject.toml)
+huggingface-hub==0.28.1
     # via
     #   accelerate
     #   datasets
@@ -179,7 +172,7 @@ huggingface-hub==0.27.1
     #   setfit
     #   tokenizers
     #   transformers
-identify==2.6.6
+identify==2.6.7
     # via pre-commit
 idna==3.10
     # via
@@ -191,7 +184,6 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==8.6.1
     # via
-    #   dask
     #   jupyter-cache
     #   myst-nb
 iniconfig==2.0.0
@@ -199,15 +191,15 @@ iniconfig==2.0.0
 ipykernel==6.29.5
     # via
     #   myst-nb
-    #   sec-certs (./../pyproject.toml)
-ipython==8.31.0
+    #   sec-certs (../pyproject.toml)
+ipython==8.32.0
     # via
     #   ipykernel
     #   ipywidgets
     #   myst-nb
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
 ipywidgets==8.1.5
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 jedi==0.19.2
     # via ipython
 jinja2==3.1.5
@@ -224,7 +216,7 @@ joblib==1.4.2
 jsonschema==4.23.0
     # via
     #   nbformat
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
 jsonschema-specifications==2024.10.1
     # via jsonschema
 jupyter-cache==1.0.1
@@ -255,13 +247,11 @@ llvmlite==0.44.0
     # via
     #   numba
     #   pynndescent
-locket==1.0.0
-    # via partd
-lxml==5.3.0
+lxml==5.3.1
     # via
     #   pikepdf
-    #   sec-certs (./../pyproject.toml)
-mako==1.3.8
+    #   sec-certs (../pyproject.toml)
+mako==1.3.9
     # via alembic
 marisa-trie==1.2.1
     # via language-data
@@ -282,7 +272,7 @@ matplotlib==3.10.0
     #   catboost
     #   pysankeybeta
     #   seaborn
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   umap-learn
 matplotlib-inline==0.1.7
     # via
@@ -314,13 +304,15 @@ murmurhash==1.0.12
     #   spacy
     #   thinc
 mypy==1.13.0
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 mypy-extensions==1.0.0
     # via mypy
-myst-nb==1.1.2
-    # via sec-certs (./../pyproject.toml)
-myst-parser==4.0.0
+myst-nb==1.2.0
+    # via sec-certs (../pyproject.toml)
+myst-parser==4.0.1
     # via myst-nb
+narwhals==1.26.0
+    # via plotly
 nbclient==0.10.2
     # via
     #   jupyter-cache
@@ -335,7 +327,7 @@ nest-asyncio==1.6.0
 networkx==3.4.2
     # via
     #   scikit-image
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   torch
 nodeenv==1.9.1
     # via pre-commit
@@ -365,7 +357,7 @@ numpy==1.26.4
     #   scikit-learn
     #   scipy
     #   seaborn
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   spacy
     #   tabula-py
     #   thinc
@@ -373,14 +365,13 @@ numpy==1.26.4
     #   transformers
     #   umap-learn
     #   xarray
-optuna==4.2.0
-    # via sec-certs (./../pyproject.toml)
+optuna==4.2.1
+    # via sec-certs (../pyproject.toml)
 packaging==24.2
     # via
     #   accelerate
     #   bokeh
     #   build
-    #   dask
     #   datasets
     #   datashader
     #   evaluate
@@ -415,7 +406,7 @@ pandas==2.2.3
     #   panel
     #   pysankeybeta
     #   seaborn
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   tabula-py
     #   umap-learn
     #   xarray
@@ -430,41 +421,38 @@ param==2.2.0
     #   pyviz-comms
 parso==0.8.4
     # via jedi
-partd==1.4.2
-    # via dask
 pdftotext==3.0.0
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 pexpect==4.9.0
     # via ipython
-pikepdf==9.5.1
-    # via sec-certs (./../pyproject.toml)
+pikepdf==9.5.2
+    # via sec-certs (../pyproject.toml)
 pillow==11.1.0
     # via
     #   bokeh
-    #   datashader
     #   imageio
     #   matplotlib
     #   pikepdf
     #   pytesseract
     #   scikit-image
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   sentence-transformers
 pip-tools==7.4.1
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 pkgconfig==1.5.5
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 platformdirs==4.3.6
     # via
     #   jupyter-core
     #   virtualenv
-plotly==5.24.1
+plotly==6.0.0
     # via
     #   catboost
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
 pluggy==1.5.0
     # via pytest
 pre-commit==4.1.0
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 preshed==3.0.9
     # via
     #   spacy
@@ -475,13 +463,13 @@ propcache==0.2.1
     # via
     #   aiohttp
     #   yarl
-psutil==6.1.1
+psutil==7.0.0
     # via
     #   accelerate
     #   ipykernel
     #   memory-profiler
     #   pytest-monitor
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
@@ -496,14 +484,14 @@ pydantic==2.10.6
     # via
     #   confection
     #   pydantic-settings
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   spacy
     #   thinc
     #   weasel
 pydantic-core==2.27.2
     # via pydantic
 pydantic-settings==2.7.1
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 pydata-sphinx-theme==0.16.1
     # via sphinx-book-theme
 pygments==2.19.1
@@ -517,40 +505,38 @@ pynndescent==0.5.13
     # via umap-learn
 pyparsing==3.2.1
     # via matplotlib
-pypdf[crypto]==5.2.0
-    # via
-    #   pypdf
-    #   sec-certs (./../pyproject.toml)
+pypdf[crypto]==5.3.0
+    # via sec-certs (../pyproject.toml)
 pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
 pysankeybeta==1.4.2
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 pytesseract==0.3.13
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 pytest==8.3.4
     # via
     #   pytest-cov
     #   pytest-monitor
     #   pytest-profiling
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
 pytest-cov==6.0.0
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 pytest-monitor==1.6.6
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 pytest-profiling==1.8.1
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 python-dateutil==2.9.0.post0
     # via
     #   dateparser
     #   jupyter-client
     #   matplotlib
     #   pandas
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
 python-dotenv==1.0.1
     # via pydantic-settings
-pytz==2024.2
+pytz==2025.1
     # via
     #   dateparser
     #   pandas
@@ -562,7 +548,6 @@ pyyaml==6.0.2
     # via
     #   accelerate
     #   bokeh
-    #   dask
     #   datasets
     #   huggingface-hub
     #   jupyter-cache
@@ -570,14 +555,14 @@ pyyaml==6.0.2
     #   myst-parser
     #   optuna
     #   pre-commit
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   transformers
-pyzmq==26.2.0
+pyzmq==26.2.1
     # via
     #   ipykernel
     #   jupyter-client
-rapidfuzz==3.11.0
-    # via sec-certs (./../pyproject.toml)
+rapidfuzz==3.12.1
+    # via sec-certs (../pyproject.toml)
 referencing==0.36.2
     # via
     #   jsonschema
@@ -594,7 +579,7 @@ requests==2.32.3
     #   huggingface-hub
     #   panel
     #   pytest-monitor
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   spacy
     #   sphinx
     #   transformers
@@ -606,7 +591,7 @@ rpds-py==0.22.3
     #   jsonschema
     #   referencing
 ruff==0.7.4
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 safetensors==0.5.2
     # via
     #   accelerate
@@ -616,7 +601,7 @@ scikit-image==0.25.1
 scikit-learn==1.6.1
     # via
     #   pynndescent
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   sentence-transformers
     #   setfit
     #   umap-learn
@@ -627,22 +612,20 @@ scipy==1.15.1
     #   pynndescent
     #   scikit-image
     #   scikit-learn
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   sentence-transformers
     #   umap-learn
 seaborn==0.13.2
     # via
     #   pysankeybeta
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   umap-learn
-sentence-transformers[train]==3.4.0
-    # via
-    #   sentence-transformers
-    #   setfit
+sentence-transformers[train]==3.4.1
+    # via setfit
 setfit==1.1.1
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 setuptools-scm==8.1.0
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 shellingham==1.5.4
     # via typer
 six==1.17.0
@@ -657,8 +640,8 @@ snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.6
     # via beautifulsoup4
-spacy==3.8.4
-    # via sec-certs (./../pyproject.toml)
+spacy==3.7.5
+    # via sec-certs (../pyproject.toml)
 spacy-legacy==3.0.12
     # via spacy
 spacy-loggers==1.0.5
@@ -668,16 +651,16 @@ sphinx==8.1.3
     #   myst-nb
     #   myst-parser
     #   pydata-sphinx-theme
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   sphinx-book-theme
     #   sphinx-copybutton
     #   sphinx-design
 sphinx-book-theme==1.1.3
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 sphinx-copybutton==0.5.2
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 sphinx-design==0.6.1
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==2.0.0
@@ -690,7 +673,7 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.37
+sqlalchemy==2.0.38
     # via
     #   alembic
     #   jupyter-cache
@@ -706,12 +689,10 @@ stack-data==0.6.3
 sympy==1.13.1
     # via torch
 tabula-py==2.10.0
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 tabulate==0.9.0
     # via jupyter-cache
-tenacity==9.0.0
-    # via plotly
-thinc==8.3.4
+thinc==8.2.5
     # via spacy
 threadpoolctl==3.5.0
     # via scikit-learn
@@ -720,11 +701,8 @@ tifffile==2025.1.10
 tokenizers==0.21.0
     # via transformers
 toolz==1.0.0
-    # via
-    #   dask
-    #   datashader
-    #   partd
-torch==2.5.1
+    # via datashader
+torch==2.6.0
     # via
     #   accelerate
     #   sentence-transformers
@@ -740,7 +718,7 @@ tqdm==4.67.1
     #   huggingface-hub
     #   optuna
     #   panel
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   sentence-transformers
     #   spacy
     #   transformers
@@ -756,7 +734,7 @@ traitlets==5.14.3
     #   matplotlib-inline
     #   nbclient
     #   nbformat
-transformers==4.48.1
+transformers==4.48.3
     # via
     #   sentence-transformers
     #   setfit
@@ -765,14 +743,15 @@ typer==0.15.1
     #   spacy
     #   weasel
 types-python-dateutil==2.9.0.20241206
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 types-pyyaml==6.0.12.20241230
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 types-requests==2.32.0.20241016
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 typing-extensions==4.12.2
     # via
     #   alembic
+    #   beautifulsoup4
     #   huggingface-hub
     #   ipython
     #   mypy
@@ -787,17 +766,17 @@ typing-extensions==4.12.2
     #   typer
 tzdata==2025.1
     # via pandas
-tzlocal==5.2
+tzlocal==5.3
     # via dateparser
 uc-micro-py==1.0.3
     # via linkify-it-py
 umap-learn[plot]==0.5.7
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 urllib3==2.3.0
     # via
     #   requests
     #   types-requests
-virtualenv==20.29.1
+virtualenv==20.29.2
     # via pre-commit
 wasabi==1.1.3
     # via
@@ -822,7 +801,7 @@ wrapt==1.17.2
     # via
     #   deprecated
     #   smart-open
-xarray==2025.1.1
+xarray==2025.1.2
     # via datashader
 xxhash==3.5.0
     # via

--- a/requirements/dev_requirements.txt
+++ b/requirements/dev_requirements.txt
@@ -1,8 +1,8 @@
 accessible-pygments==0.0.5
     # via pydata-sphinx-theme
-aiohappyeyeballs==2.4.4
+aiohappyeyeballs==2.4.6
     # via aiohttp
-aiohttp==3.11.11
+aiohttp==3.11.12
     # via
     #   datasets
     #   fsspec
@@ -22,15 +22,15 @@ attrs==25.1.0
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.16.0
+babel==2.17.0
     # via
     #   pydata-sphinx-theme
     #   sphinx
-beautifulsoup4==4.12.3
+beautifulsoup4==4.13.3
     # via
     #   pydata-sphinx-theme
-    #   sec-certs (./../pyproject.toml)
-blis==1.2.0
+    #   sec-certs (../pyproject.toml)
+blis==0.7.11
     # via thinc
 build==1.2.2.post1
     # via pip-tools
@@ -39,7 +39,7 @@ catalogue==2.0.10
     #   spacy
     #   srsly
     #   thinc
-certifi==2024.12.14
+certifi==2025.1.31
     # via requests
 cffi==1.17.1
     # via cryptography
@@ -51,7 +51,7 @@ click==8.1.8
     # via
     #   jupyter-cache
     #   pip-tools
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   typer
 cloudpathlib==0.20.0
     # via weasel
@@ -65,11 +65,9 @@ confection==0.1.5
     #   weasel
 contourpy==1.3.1
     # via matplotlib
-coverage[toml]==7.6.10
-    # via
-    #   coverage
-    #   pytest-cov
-cryptography==44.0.0
+coverage[toml]==7.6.12
+    # via pytest-cov
+cryptography==44.0.1
     # via pypdf
 cycler==0.12.1
     # via matplotlib
@@ -79,9 +77,9 @@ cymem==2.0.11
     #   spacy
     #   thinc
 datasets==3.2.0
-    # via sec-certs (./../pyproject.toml)
-dateparser==1.2.0
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
+dateparser==1.2.1
+    # via sec-certs (../pyproject.toml)
 debugpy==1.8.12
     # via ipykernel
 decorator==5.1.1
@@ -110,7 +108,7 @@ filelock==3.17.0
     #   datasets
     #   huggingface-hub
     #   virtualenv
-fonttools==4.55.6
+fonttools==4.56.0
     # via matplotlib
 frozenlist==1.5.0
     # via
@@ -119,15 +117,14 @@ frozenlist==1.5.0
 fsspec[http]==2024.9.0
     # via
     #   datasets
-    #   fsspec
     #   huggingface-hub
 gprof2dot==2024.6.6
     # via pytest-profiling
 html5lib==1.1
-    # via sec-certs (./../pyproject.toml)
-huggingface-hub==0.27.1
+    # via sec-certs (../pyproject.toml)
+huggingface-hub==0.28.1
     # via datasets
-identify==2.6.6
+identify==2.6.7
     # via pre-commit
 idna==3.10
     # via
@@ -144,15 +141,15 @@ iniconfig==2.0.0
 ipykernel==6.29.5
     # via
     #   myst-nb
-    #   sec-certs (./../pyproject.toml)
-ipython==8.31.0
+    #   sec-certs (../pyproject.toml)
+ipython==8.32.0
     # via
     #   ipykernel
     #   ipywidgets
     #   myst-nb
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
 ipywidgets==8.1.5
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 jedi==0.19.2
     # via ipython
 jinja2==3.1.5
@@ -165,7 +162,7 @@ joblib==1.4.2
 jsonschema==4.23.0
     # via
     #   nbformat
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
 jsonschema-specifications==2024.10.1
     # via jsonschema
 jupyter-cache==1.0.1
@@ -188,10 +185,10 @@ langcodes==3.5.0
     # via spacy
 language-data==1.3.0
     # via langcodes
-lxml==5.3.0
+lxml==5.3.1
     # via
     #   pikepdf
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
 marisa-trie==1.2.1
     # via language-data
 markdown-it-py==3.0.0
@@ -205,7 +202,7 @@ matplotlib==3.10.0
     # via
     #   pysankeybeta
     #   seaborn
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
 matplotlib-inline==0.1.7
     # via
     #   ipykernel
@@ -228,12 +225,12 @@ murmurhash==1.0.12
     #   spacy
     #   thinc
 mypy==1.13.0
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 mypy-extensions==1.0.0
     # via mypy
-myst-nb==1.1.2
-    # via sec-certs (./../pyproject.toml)
-myst-parser==4.0.0
+myst-nb==1.2.0
+    # via sec-certs (../pyproject.toml)
+myst-parser==4.0.1
     # via myst-nb
 nbclient==0.10.2
     # via
@@ -247,10 +244,10 @@ nbformat==5.10.4
 nest-asyncio==1.6.0
     # via ipykernel
 networkx==3.4.2
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 nodeenv==1.9.1
     # via pre-commit
-numpy==2.2.2
+numpy==1.26.4
     # via
     #   blis
     #   contourpy
@@ -261,7 +258,7 @@ numpy==2.2.2
     #   scikit-learn
     #   scipy
     #   seaborn
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   spacy
     #   tabula-py
     #   thinc
@@ -285,26 +282,26 @@ pandas==2.2.3
     #   datasets
     #   pysankeybeta
     #   seaborn
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   tabula-py
 parso==0.8.4
     # via jedi
 pdftotext==3.0.0
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 pexpect==4.9.0
     # via ipython
-pikepdf==9.5.1
-    # via sec-certs (./../pyproject.toml)
+pikepdf==9.5.2
+    # via sec-certs (../pyproject.toml)
 pillow==11.1.0
     # via
     #   matplotlib
     #   pikepdf
     #   pytesseract
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
 pip-tools==7.4.1
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 pkgconfig==1.5.5
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 platformdirs==4.3.6
     # via
     #   jupyter-core
@@ -312,7 +309,7 @@ platformdirs==4.3.6
 pluggy==1.5.0
     # via pytest
 pre-commit==4.1.0
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 preshed==3.0.9
     # via
     #   spacy
@@ -323,12 +320,12 @@ propcache==0.2.1
     # via
     #   aiohttp
     #   yarl
-psutil==6.1.1
+psutil==7.0.0
     # via
     #   ipykernel
     #   memory-profiler
     #   pytest-monitor
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
@@ -341,14 +338,14 @@ pydantic==2.10.6
     # via
     #   confection
     #   pydantic-settings
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   spacy
     #   thinc
     #   weasel
 pydantic-core==2.27.2
     # via pydantic
 pydantic-settings==2.7.1
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 pydata-sphinx-theme==0.16.1
     # via sphinx-book-theme
 pygments==2.19.1
@@ -360,40 +357,38 @@ pygments==2.19.1
     #   sphinx
 pyparsing==3.2.1
     # via matplotlib
-pypdf[crypto]==5.2.0
-    # via
-    #   pypdf
-    #   sec-certs (./../pyproject.toml)
+pypdf[crypto]==5.3.0
+    # via sec-certs (../pyproject.toml)
 pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
 pysankeybeta==1.4.2
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 pytesseract==0.3.13
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 pytest==8.3.4
     # via
     #   pytest-cov
     #   pytest-monitor
     #   pytest-profiling
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
 pytest-cov==6.0.0
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 pytest-monitor==1.6.6
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 pytest-profiling==1.8.1
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 python-dateutil==2.9.0.post0
     # via
     #   dateparser
     #   jupyter-client
     #   matplotlib
     #   pandas
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
 python-dotenv==1.0.1
     # via pydantic-settings
-pytz==2024.2
+pytz==2025.1
     # via
     #   dateparser
     #   pandas
@@ -405,13 +400,13 @@ pyyaml==6.0.2
     #   myst-nb
     #   myst-parser
     #   pre-commit
-    #   sec-certs (./../pyproject.toml)
-pyzmq==26.2.0
+    #   sec-certs (../pyproject.toml)
+pyzmq==26.2.1
     # via
     #   ipykernel
     #   jupyter-client
-rapidfuzz==3.11.0
-    # via sec-certs (./../pyproject.toml)
+rapidfuzz==3.12.1
+    # via sec-certs (../pyproject.toml)
 referencing==0.36.2
     # via
     #   jsonschema
@@ -423,7 +418,7 @@ requests==2.32.3
     #   datasets
     #   huggingface-hub
     #   pytest-monitor
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   spacy
     #   sphinx
     #   weasel
@@ -434,19 +429,19 @@ rpds-py==0.22.3
     #   jsonschema
     #   referencing
 ruff==0.7.4
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 scikit-learn==1.6.1
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 scipy==1.15.1
     # via
     #   scikit-learn
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
 seaborn==0.13.2
     # via
     #   pysankeybeta
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
 setuptools-scm==8.1.0
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 shellingham==1.5.4
     # via typer
 six==1.17.0
@@ -460,8 +455,8 @@ snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.6
     # via beautifulsoup4
-spacy==3.8.4
-    # via sec-certs (./../pyproject.toml)
+spacy==3.7.5
+    # via sec-certs (../pyproject.toml)
 spacy-legacy==3.0.12
     # via spacy
 spacy-loggers==1.0.5
@@ -471,16 +466,16 @@ sphinx==8.1.3
     #   myst-nb
     #   myst-parser
     #   pydata-sphinx-theme
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   sphinx-book-theme
     #   sphinx-copybutton
     #   sphinx-design
 sphinx-book-theme==1.1.3
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 sphinx-copybutton==0.5.2
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 sphinx-design==0.6.1
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==2.0.0
@@ -493,7 +488,7 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.37
+sqlalchemy==2.0.38
     # via jupyter-cache
 srsly==2.5.1
     # via
@@ -504,10 +499,10 @@ srsly==2.5.1
 stack-data==0.6.3
     # via ipython
 tabula-py==2.10.0
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 tabulate==0.9.0
     # via jupyter-cache
-thinc==8.3.4
+thinc==8.2.5
     # via spacy
 threadpoolctl==3.5.0
     # via scikit-learn
@@ -519,7 +514,7 @@ tqdm==4.67.1
     # via
     #   datasets
     #   huggingface-hub
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   spacy
 traitlets==5.14.3
     # via
@@ -537,13 +532,14 @@ typer==0.15.1
     #   spacy
     #   weasel
 types-python-dateutil==2.9.0.20241206
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 types-pyyaml==6.0.12.20241230
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 types-requests==2.32.0.20241016
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 typing-extensions==4.12.2
     # via
+    #   beautifulsoup4
     #   huggingface-hub
     #   ipython
     #   mypy
@@ -556,13 +552,13 @@ typing-extensions==4.12.2
     #   typer
 tzdata==2025.1
     # via pandas
-tzlocal==5.2
+tzlocal==5.3
     # via dateparser
 urllib3==2.3.0
     # via
     #   requests
     #   types-requests
-virtualenv==20.29.1
+virtualenv==20.29.2
     # via pre-commit
 wasabi==1.1.3
     # via

--- a/requirements/nlp_requirements.txt
+++ b/requirements/nlp_requirements.txt
@@ -1,8 +1,8 @@
 accelerate==1.3.0
     # via sentence-transformers
-aiohappyeyeballs==2.4.4
+aiohappyeyeballs==2.4.6
     # via aiohttp
-aiohttp==3.11.11
+aiohttp==3.11.12
     # via
     #   datasets
     #   fsspec
@@ -21,13 +21,13 @@ attrs==25.1.0
     #   aiohttp
     #   jsonschema
     #   referencing
-beautifulsoup4==4.12.3
-    # via sec-certs (./../pyproject.toml)
+beautifulsoup4==4.13.3
+    # via sec-certs (../pyproject.toml)
 bleach==6.2.0
     # via panel
-blis==1.2.0
+blis==0.7.11
     # via thinc
-bokeh==3.6.2
+bokeh==3.6.3
     # via
     #   holoviews
     #   panel
@@ -38,8 +38,8 @@ catalogue==2.0.10
     #   srsly
     #   thinc
 catboost==1.2.7
-    # via sec-certs (./../pyproject.toml)
-certifi==2024.12.14
+    # via sec-certs (../pyproject.toml)
+certifi==2025.1.31
     # via requests
 cffi==1.17.1
     # via cryptography
@@ -47,13 +47,10 @@ charset-normalizer==3.4.1
     # via requests
 click==8.1.8
     # via
-    #   dask
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   typer
 cloudpathlib==0.20.0
     # via weasel
-cloudpickle==3.1.1
-    # via dask
 colorcet==3.1.0
     # via
     #   datashader
@@ -73,7 +70,7 @@ contourpy==1.3.1
     # via
     #   bokeh
     #   matplotlib
-cryptography==44.0.0
+cryptography==44.0.1
     # via pypdf
 cycler==0.12.1
     # via matplotlib
@@ -82,17 +79,15 @@ cymem==2.0.11
     #   preshed
     #   spacy
     #   thinc
-dask==2025.1.0
-    # via datashader
 datasets==3.2.0
     # via
     #   evaluate
     #   sentence-transformers
     #   setfit
-datashader==0.16.3
+datashader==0.17.0
     # via umap-learn
-dateparser==1.2.0
-    # via sec-certs (./../pyproject.toml)
+dateparser==1.2.1
+    # via sec-certs (../pyproject.toml)
 debugpy==1.8.12
     # via ipykernel
 decorator==5.1.1
@@ -116,7 +111,7 @@ filelock==3.17.0
     #   huggingface-hub
     #   torch
     #   transformers
-fonttools==4.55.6
+fonttools==4.56.0
     # via matplotlib
 frozenlist==1.5.0
     # via
@@ -124,10 +119,8 @@ frozenlist==1.5.0
     #   aiosignal
 fsspec[http]==2024.9.0
     # via
-    #   dask
     #   datasets
     #   evaluate
-    #   fsspec
     #   huggingface-hub
     #   torch
 graphviz==0.20.3
@@ -135,8 +128,8 @@ graphviz==0.20.3
 holoviews==1.20.0
     # via umap-learn
 html5lib==1.1
-    # via sec-certs (./../pyproject.toml)
-huggingface-hub==0.27.1
+    # via sec-certs (../pyproject.toml)
+huggingface-hub==0.28.1
     # via
     #   accelerate
     #   datasets
@@ -151,16 +144,14 @@ idna==3.10
     #   yarl
 imageio==2.37.0
     # via scikit-image
-importlib-metadata==8.6.1
-    # via dask
 ipykernel==6.29.5
-    # via sec-certs (./../pyproject.toml)
-ipython==8.31.0
+    # via sec-certs (../pyproject.toml)
+ipython==8.32.0
     # via
     #   ipykernel
     #   ipywidgets
 ipywidgets==8.1.5
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 jedi==0.19.2
     # via ipython
 jinja2==3.1.5
@@ -173,7 +164,7 @@ joblib==1.4.2
     #   pynndescent
     #   scikit-learn
 jsonschema==4.23.0
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 jsonschema-specifications==2024.10.1
     # via jsonschema
 jupyter-client==8.6.3
@@ -198,13 +189,11 @@ llvmlite==0.44.0
     # via
     #   numba
     #   pynndescent
-locket==1.0.0
-    # via partd
-lxml==5.3.0
+lxml==5.3.1
     # via
     #   pikepdf
-    #   sec-certs (./../pyproject.toml)
-mako==1.3.8
+    #   sec-certs (../pyproject.toml)
+mako==1.3.9
     # via alembic
 marisa-trie==1.2.1
     # via language-data
@@ -224,7 +213,7 @@ matplotlib==3.10.0
     #   catboost
     #   pysankeybeta
     #   seaborn
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   umap-learn
 matplotlib-inline==0.1.7
     # via
@@ -251,12 +240,14 @@ murmurhash==1.0.12
     #   preshed
     #   spacy
     #   thinc
+narwhals==1.26.0
+    # via plotly
 nest-asyncio==1.6.0
     # via ipykernel
 networkx==3.4.2
     # via
     #   scikit-image
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   torch
 numba==0.61.0
     # via
@@ -284,7 +275,7 @@ numpy==1.26.4
     #   scikit-learn
     #   scipy
     #   seaborn
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   spacy
     #   tabula-py
     #   thinc
@@ -292,13 +283,12 @@ numpy==1.26.4
     #   transformers
     #   umap-learn
     #   xarray
-optuna==4.2.0
-    # via sec-certs (./../pyproject.toml)
+optuna==4.2.1
+    # via sec-certs (../pyproject.toml)
 packaging==24.2
     # via
     #   accelerate
     #   bokeh
-    #   dask
     #   datasets
     #   datashader
     #   evaluate
@@ -331,7 +321,7 @@ pandas==2.2.3
     #   panel
     #   pysankeybeta
     #   seaborn
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   tabula-py
     #   umap-learn
     #   xarray
@@ -346,33 +336,30 @@ param==2.2.0
     #   pyviz-comms
 parso==0.8.4
     # via jedi
-partd==1.4.2
-    # via dask
 pdftotext==3.0.0
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 pexpect==4.9.0
     # via ipython
-pikepdf==9.5.1
-    # via sec-certs (./../pyproject.toml)
+pikepdf==9.5.2
+    # via sec-certs (../pyproject.toml)
 pillow==11.1.0
     # via
     #   bokeh
-    #   datashader
     #   imageio
     #   matplotlib
     #   pikepdf
     #   pytesseract
     #   scikit-image
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   sentence-transformers
 pkgconfig==1.5.5
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 platformdirs==4.3.6
     # via jupyter-core
-plotly==5.24.1
+plotly==6.0.0
     # via
     #   catboost
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
 preshed==3.0.9
     # via
     #   spacy
@@ -383,11 +370,11 @@ propcache==0.2.1
     # via
     #   aiohttp
     #   yarl
-psutil==6.1.1
+psutil==7.0.0
     # via
     #   accelerate
     #   ipykernel
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
@@ -402,14 +389,14 @@ pydantic==2.10.6
     # via
     #   confection
     #   pydantic-settings
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   spacy
     #   thinc
     #   weasel
 pydantic-core==2.27.2
     # via pydantic
 pydantic-settings==2.7.1
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 pygments==2.19.1
     # via
     #   ipython
@@ -418,24 +405,22 @@ pynndescent==0.5.13
     # via umap-learn
 pyparsing==3.2.1
     # via matplotlib
-pypdf[crypto]==5.2.0
-    # via
-    #   pypdf
-    #   sec-certs (./../pyproject.toml)
+pypdf[crypto]==5.3.0
+    # via sec-certs (../pyproject.toml)
 pysankeybeta==1.4.2
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 pytesseract==0.3.13
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 python-dateutil==2.9.0.post0
     # via
     #   dateparser
     #   jupyter-client
     #   matplotlib
     #   pandas
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
 python-dotenv==1.0.1
     # via pydantic-settings
-pytz==2024.2
+pytz==2025.1
     # via
     #   dateparser
     #   pandas
@@ -447,18 +432,17 @@ pyyaml==6.0.2
     # via
     #   accelerate
     #   bokeh
-    #   dask
     #   datasets
     #   huggingface-hub
     #   optuna
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   transformers
-pyzmq==26.2.0
+pyzmq==26.2.1
     # via
     #   ipykernel
     #   jupyter-client
-rapidfuzz==3.11.0
-    # via sec-certs (./../pyproject.toml)
+rapidfuzz==3.12.1
+    # via sec-certs (../pyproject.toml)
 referencing==0.36.2
     # via
     #   jsonschema
@@ -474,7 +458,7 @@ requests==2.32.3
     #   evaluate
     #   huggingface-hub
     #   panel
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   spacy
     #   transformers
     #   weasel
@@ -493,7 +477,7 @@ scikit-image==0.25.1
 scikit-learn==1.6.1
     # via
     #   pynndescent
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   sentence-transformers
     #   setfit
     #   umap-learn
@@ -504,22 +488,20 @@ scipy==1.15.1
     #   pynndescent
     #   scikit-image
     #   scikit-learn
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   sentence-transformers
     #   umap-learn
 seaborn==0.13.2
     # via
     #   pysankeybeta
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   umap-learn
-sentence-transformers[train]==3.4.0
-    # via
-    #   sentence-transformers
-    #   setfit
+sentence-transformers[train]==3.4.1
+    # via setfit
 setfit==1.1.1
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 setuptools-scm==8.1.0
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 shellingham==1.5.4
     # via typer
 six==1.17.0
@@ -531,13 +513,13 @@ smart-open==7.1.0
     # via weasel
 soupsieve==2.6
     # via beautifulsoup4
-spacy==3.8.4
-    # via sec-certs (./../pyproject.toml)
+spacy==3.7.5
+    # via sec-certs (../pyproject.toml)
 spacy-legacy==3.0.12
     # via spacy
 spacy-loggers==1.0.5
     # via spacy
-sqlalchemy==2.0.37
+sqlalchemy==2.0.38
     # via
     #   alembic
     #   optuna
@@ -552,10 +534,8 @@ stack-data==0.6.3
 sympy==1.13.1
     # via torch
 tabula-py==2.10.0
-    # via sec-certs (./../pyproject.toml)
-tenacity==9.0.0
-    # via plotly
-thinc==8.3.4
+    # via sec-certs (../pyproject.toml)
+thinc==8.2.5
     # via spacy
 threadpoolctl==3.5.0
     # via scikit-learn
@@ -564,11 +544,8 @@ tifffile==2025.1.10
 tokenizers==0.21.0
     # via transformers
 toolz==1.0.0
-    # via
-    #   dask
-    #   datashader
-    #   partd
-torch==2.5.1
+    # via datashader
+torch==2.6.0
     # via
     #   accelerate
     #   sentence-transformers
@@ -584,7 +561,7 @@ tqdm==4.67.1
     #   huggingface-hub
     #   optuna
     #   panel
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   sentence-transformers
     #   spacy
     #   transformers
@@ -598,7 +575,7 @@ traitlets==5.14.3
     #   jupyter-client
     #   jupyter-core
     #   matplotlib-inline
-transformers==4.48.1
+transformers==4.48.3
     # via
     #   sentence-transformers
     #   setfit
@@ -609,6 +586,7 @@ typer==0.15.1
 typing-extensions==4.12.2
     # via
     #   alembic
+    #   beautifulsoup4
     #   huggingface-hub
     #   ipython
     #   panel
@@ -620,12 +598,12 @@ typing-extensions==4.12.2
     #   typer
 tzdata==2025.1
     # via pandas
-tzlocal==5.2
+tzlocal==5.3
     # via dateparser
 uc-micro-py==1.0.3
     # via linkify-it-py
 umap-learn[plot]==0.5.7
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 urllib3==2.3.0
     # via requests
 wasabi==1.1.3
@@ -647,7 +625,7 @@ wrapt==1.17.2
     # via
     #   deprecated
     #   smart-open
-xarray==2025.1.1
+xarray==2025.1.2
     # via datashader
 xxhash==3.5.0
     # via
@@ -657,8 +635,6 @@ xyzservices==2025.1.0
     # via bokeh
 yarl==1.18.3
     # via aiohttp
-zipp==3.21.0
-    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -8,16 +8,16 @@ attrs==25.1.0
     # via
     #   jsonschema
     #   referencing
-beautifulsoup4==4.12.3
-    # via sec-certs (./../pyproject.toml)
-blis==1.2.0
+beautifulsoup4==4.13.3
+    # via sec-certs (../pyproject.toml)
+blis==0.7.11
     # via thinc
 catalogue==2.0.10
     # via
     #   spacy
     #   srsly
     #   thinc
-certifi==2024.12.14
+certifi==2025.1.31
     # via requests
 cffi==1.17.1
     # via cryptography
@@ -25,7 +25,7 @@ charset-normalizer==3.4.1
     # via requests
 click==8.1.8
     # via
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   typer
 cloudpathlib==0.20.0
     # via weasel
@@ -39,7 +39,7 @@ confection==0.1.5
     #   weasel
 contourpy==1.3.1
     # via matplotlib
-cryptography==44.0.0
+cryptography==44.0.1
     # via pypdf
 cycler==0.12.1
     # via matplotlib
@@ -48,8 +48,8 @@ cymem==2.0.11
     #   preshed
     #   spacy
     #   thinc
-dateparser==1.2.0
-    # via sec-certs (./../pyproject.toml)
+dateparser==1.2.1
+    # via sec-certs (../pyproject.toml)
 debugpy==1.8.12
     # via ipykernel
 decorator==5.1.1
@@ -60,20 +60,20 @@ distro==1.9.0
     # via tabula-py
 executing==2.2.0
     # via stack-data
-fonttools==4.55.6
+fonttools==4.56.0
     # via matplotlib
 html5lib==1.1
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 idna==3.10
     # via requests
 ipykernel==6.29.5
-    # via sec-certs (./../pyproject.toml)
-ipython==8.31.0
+    # via sec-certs (../pyproject.toml)
+ipython==8.32.0
     # via
     #   ipykernel
     #   ipywidgets
 ipywidgets==8.1.5
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 jedi==0.19.2
     # via ipython
 jinja2==3.1.5
@@ -81,7 +81,7 @@ jinja2==3.1.5
 joblib==1.4.2
     # via scikit-learn
 jsonschema==4.23.0
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 jsonschema-specifications==2024.10.1
     # via jsonschema
 jupyter-client==8.6.3
@@ -98,10 +98,10 @@ langcodes==3.5.0
     # via spacy
 language-data==1.3.0
     # via langcodes
-lxml==5.3.0
+lxml==5.3.1
     # via
     #   pikepdf
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
 marisa-trie==1.2.1
     # via language-data
 markdown-it-py==3.0.0
@@ -112,7 +112,7 @@ matplotlib==3.10.0
     # via
     #   pysankeybeta
     #   seaborn
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
 matplotlib-inline==0.1.7
     # via
     #   ipykernel
@@ -127,8 +127,8 @@ murmurhash==1.0.12
 nest-asyncio==1.6.0
     # via ipykernel
 networkx==3.4.2
-    # via sec-certs (./../pyproject.toml)
-numpy==2.2.2
+    # via sec-certs (../pyproject.toml)
+numpy==1.26.4
     # via
     #   blis
     #   contourpy
@@ -138,7 +138,7 @@ numpy==2.2.2
     #   scikit-learn
     #   scipy
     #   seaborn
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   spacy
     #   tabula-py
     #   thinc
@@ -156,24 +156,24 @@ pandas==2.2.3
     # via
     #   pysankeybeta
     #   seaborn
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   tabula-py
 parso==0.8.4
     # via jedi
 pdftotext==3.0.0
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 pexpect==4.9.0
     # via ipython
-pikepdf==9.5.1
-    # via sec-certs (./../pyproject.toml)
+pikepdf==9.5.2
+    # via sec-certs (../pyproject.toml)
 pillow==11.1.0
     # via
     #   matplotlib
     #   pikepdf
     #   pytesseract
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
 pkgconfig==1.5.5
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 platformdirs==4.3.6
     # via jupyter-core
 preshed==3.0.9
@@ -182,10 +182,10 @@ preshed==3.0.9
     #   thinc
 prompt-toolkit==3.0.50
     # via ipython
-psutil==6.1.1
+psutil==7.0.0
     # via
     #   ipykernel
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
@@ -196,49 +196,47 @@ pydantic==2.10.6
     # via
     #   confection
     #   pydantic-settings
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   spacy
     #   thinc
     #   weasel
 pydantic-core==2.27.2
     # via pydantic
 pydantic-settings==2.7.1
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 pygments==2.19.1
     # via
     #   ipython
     #   rich
 pyparsing==3.2.1
     # via matplotlib
-pypdf[crypto]==5.2.0
-    # via
-    #   pypdf
-    #   sec-certs (./../pyproject.toml)
+pypdf[crypto]==5.3.0
+    # via sec-certs (../pyproject.toml)
 pysankeybeta==1.4.2
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 pytesseract==0.3.13
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 python-dateutil==2.9.0.post0
     # via
     #   dateparser
     #   jupyter-client
     #   matplotlib
     #   pandas
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
 python-dotenv==1.0.1
     # via pydantic-settings
-pytz==2024.2
+pytz==2025.1
     # via
     #   dateparser
     #   pandas
 pyyaml==6.0.2
-    # via sec-certs (./../pyproject.toml)
-pyzmq==26.2.0
+    # via sec-certs (../pyproject.toml)
+pyzmq==26.2.1
     # via
     #   ipykernel
     #   jupyter-client
-rapidfuzz==3.11.0
-    # via sec-certs (./../pyproject.toml)
+rapidfuzz==3.12.1
+    # via sec-certs (../pyproject.toml)
 referencing==0.36.2
     # via
     #   jsonschema
@@ -247,7 +245,7 @@ regex==2024.11.6
     # via dateparser
 requests==2.32.3
     # via
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   spacy
     #   weasel
 rich==13.9.4
@@ -257,17 +255,17 @@ rpds-py==0.22.3
     #   jsonschema
     #   referencing
 scikit-learn==1.6.1
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 scipy==1.15.1
     # via
     #   scikit-learn
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
 seaborn==0.13.2
     # via
     #   pysankeybeta
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
 setuptools-scm==8.1.0
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 shellingham==1.5.4
     # via typer
 six==1.17.0
@@ -278,8 +276,8 @@ smart-open==7.1.0
     # via weasel
 soupsieve==2.6
     # via beautifulsoup4
-spacy==3.8.4
-    # via sec-certs (./../pyproject.toml)
+spacy==3.7.5
+    # via sec-certs (../pyproject.toml)
 spacy-legacy==3.0.12
     # via spacy
 spacy-loggers==1.0.5
@@ -293,8 +291,8 @@ srsly==2.5.1
 stack-data==0.6.3
     # via ipython
 tabula-py==2.10.0
-    # via sec-certs (./../pyproject.toml)
-thinc==8.3.4
+    # via sec-certs (../pyproject.toml)
+thinc==8.2.5
     # via spacy
 threadpoolctl==3.5.0
     # via scikit-learn
@@ -304,7 +302,7 @@ tornado==6.4.2
     #   jupyter-client
 tqdm==4.67.1
     # via
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   spacy
 traitlets==5.14.3
     # via
@@ -321,6 +319,7 @@ typer==0.15.1
     #   weasel
 typing-extensions==4.12.2
     # via
+    #   beautifulsoup4
     #   ipython
     #   pydantic
     #   pydantic-core
@@ -328,7 +327,7 @@ typing-extensions==4.12.2
     #   typer
 tzdata==2025.1
     # via pandas
-tzlocal==5.2
+tzlocal==5.3
     # via dateparser
 urllib3==2.3.0
     # via requests

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -8,16 +8,16 @@ attrs==25.1.0
     # via
     #   jsonschema
     #   referencing
-beautifulsoup4==4.12.3
-    # via sec-certs (./../pyproject.toml)
-blis==1.2.0
+beautifulsoup4==4.13.3
+    # via sec-certs (../pyproject.toml)
+blis==0.7.11
     # via thinc
 catalogue==2.0.10
     # via
     #   spacy
     #   srsly
     #   thinc
-certifi==2024.12.14
+certifi==2025.1.31
     # via requests
 cffi==1.17.1
     # via cryptography
@@ -25,7 +25,7 @@ charset-normalizer==3.4.1
     # via requests
 click==8.1.8
     # via
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   typer
 cloudpathlib==0.20.0
     # via weasel
@@ -39,11 +39,11 @@ confection==0.1.5
     #   weasel
 contourpy==1.3.1
     # via matplotlib
-coverage[toml]==7.6.10
+coverage[toml]==7.6.12
     # via
     #   pytest-cov
-    #   sec-certs (./../pyproject.toml)
-cryptography==44.0.0
+    #   sec-certs (../pyproject.toml)
+cryptography==44.0.1
     # via pypdf
 cycler==0.12.1
     # via matplotlib
@@ -52,8 +52,8 @@ cymem==2.0.11
     #   preshed
     #   spacy
     #   thinc
-dateparser==1.2.0
-    # via sec-certs (./../pyproject.toml)
+dateparser==1.2.1
+    # via sec-certs (../pyproject.toml)
 debugpy==1.8.12
     # via ipykernel
 decorator==5.1.1
@@ -64,22 +64,22 @@ distro==1.9.0
     # via tabula-py
 executing==2.2.0
     # via stack-data
-fonttools==4.55.6
+fonttools==4.56.0
     # via matplotlib
 html5lib==1.1
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 idna==3.10
     # via requests
 iniconfig==2.0.0
     # via pytest
 ipykernel==6.29.5
-    # via sec-certs (./../pyproject.toml)
-ipython==8.31.0
+    # via sec-certs (../pyproject.toml)
+ipython==8.32.0
     # via
     #   ipykernel
     #   ipywidgets
 ipywidgets==8.1.5
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 jedi==0.19.2
     # via ipython
 jinja2==3.1.5
@@ -87,7 +87,7 @@ jinja2==3.1.5
 joblib==1.4.2
     # via scikit-learn
 jsonschema==4.23.0
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 jsonschema-specifications==2024.10.1
     # via jsonschema
 jupyter-client==8.6.3
@@ -104,10 +104,10 @@ langcodes==3.5.0
     # via spacy
 language-data==1.3.0
     # via langcodes
-lxml==5.3.0
+lxml==5.3.1
     # via
     #   pikepdf
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
 marisa-trie==1.2.1
     # via language-data
 markdown-it-py==3.0.0
@@ -118,7 +118,7 @@ matplotlib==3.10.0
     # via
     #   pysankeybeta
     #   seaborn
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
 matplotlib-inline==0.1.7
     # via
     #   ipykernel
@@ -133,8 +133,8 @@ murmurhash==1.0.12
 nest-asyncio==1.6.0
     # via ipykernel
 networkx==3.4.2
-    # via sec-certs (./../pyproject.toml)
-numpy==2.2.2
+    # via sec-certs (../pyproject.toml)
+numpy==1.26.4
     # via
     #   blis
     #   contourpy
@@ -144,7 +144,7 @@ numpy==2.2.2
     #   scikit-learn
     #   scipy
     #   seaborn
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   spacy
     #   tabula-py
     #   thinc
@@ -163,24 +163,24 @@ pandas==2.2.3
     # via
     #   pysankeybeta
     #   seaborn
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   tabula-py
 parso==0.8.4
     # via jedi
 pdftotext==3.0.0
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 pexpect==4.9.0
     # via ipython
-pikepdf==9.5.1
-    # via sec-certs (./../pyproject.toml)
+pikepdf==9.5.2
+    # via sec-certs (../pyproject.toml)
 pillow==11.1.0
     # via
     #   matplotlib
     #   pikepdf
     #   pytesseract
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
 pkgconfig==1.5.5
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 platformdirs==4.3.6
     # via jupyter-core
 pluggy==1.5.0
@@ -191,10 +191,10 @@ preshed==3.0.9
     #   thinc
 prompt-toolkit==3.0.50
     # via ipython
-psutil==6.1.1
+psutil==7.0.0
     # via
     #   ipykernel
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
@@ -205,55 +205,53 @@ pydantic==2.10.6
     # via
     #   confection
     #   pydantic-settings
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   spacy
     #   thinc
     #   weasel
 pydantic-core==2.27.2
     # via pydantic
 pydantic-settings==2.7.1
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 pygments==2.19.1
     # via
     #   ipython
     #   rich
 pyparsing==3.2.1
     # via matplotlib
-pypdf[crypto]==5.2.0
-    # via
-    #   pypdf
-    #   sec-certs (./../pyproject.toml)
+pypdf[crypto]==5.3.0
+    # via sec-certs (../pyproject.toml)
 pysankeybeta==1.4.2
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 pytesseract==0.3.13
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 pytest==8.3.4
     # via
     #   pytest-cov
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
 pytest-cov==6.0.0
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 python-dateutil==2.9.0.post0
     # via
     #   dateparser
     #   jupyter-client
     #   matplotlib
     #   pandas
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
 python-dotenv==1.0.1
     # via pydantic-settings
-pytz==2024.2
+pytz==2025.1
     # via
     #   dateparser
     #   pandas
 pyyaml==6.0.2
-    # via sec-certs (./../pyproject.toml)
-pyzmq==26.2.0
+    # via sec-certs (../pyproject.toml)
+pyzmq==26.2.1
     # via
     #   ipykernel
     #   jupyter-client
-rapidfuzz==3.11.0
-    # via sec-certs (./../pyproject.toml)
+rapidfuzz==3.12.1
+    # via sec-certs (../pyproject.toml)
 referencing==0.36.2
     # via
     #   jsonschema
@@ -262,7 +260,7 @@ regex==2024.11.6
     # via dateparser
 requests==2.32.3
     # via
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   spacy
     #   weasel
 rich==13.9.4
@@ -272,17 +270,17 @@ rpds-py==0.22.3
     #   jsonschema
     #   referencing
 scikit-learn==1.6.1
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 scipy==1.15.1
     # via
     #   scikit-learn
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
 seaborn==0.13.2
     # via
     #   pysankeybeta
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
 setuptools-scm==8.1.0
-    # via sec-certs (./../pyproject.toml)
+    # via sec-certs (../pyproject.toml)
 shellingham==1.5.4
     # via typer
 six==1.17.0
@@ -293,8 +291,8 @@ smart-open==7.1.0
     # via weasel
 soupsieve==2.6
     # via beautifulsoup4
-spacy==3.8.4
-    # via sec-certs (./../pyproject.toml)
+spacy==3.7.5
+    # via sec-certs (../pyproject.toml)
 spacy-legacy==3.0.12
     # via spacy
 spacy-loggers==1.0.5
@@ -308,8 +306,8 @@ srsly==2.5.1
 stack-data==0.6.3
     # via ipython
 tabula-py==2.10.0
-    # via sec-certs (./../pyproject.toml)
-thinc==8.3.4
+    # via sec-certs (../pyproject.toml)
+thinc==8.2.5
     # via spacy
 threadpoolctl==3.5.0
     # via scikit-learn
@@ -319,7 +317,7 @@ tornado==6.4.2
     #   jupyter-client
 tqdm==4.67.1
     # via
-    #   sec-certs (./../pyproject.toml)
+    #   sec-certs (../pyproject.toml)
     #   spacy
 traitlets==5.14.3
     # via
@@ -336,6 +334,7 @@ typer==0.15.1
     #   weasel
 typing-extensions==4.12.2
     # via
+    #   beautifulsoup4
     #   ipython
     #   pydantic
     #   pydantic-core
@@ -343,7 +342,7 @@ typing-extensions==4.12.2
     #   typer
 tzdata==2025.1
     # via pandas
-tzlocal==5.2
+tzlocal==5.3
     # via dateparser
 urllib3==2.3.0
     # via requests


### PR DESCRIPTION
Two problems solved:
- Segfaults due to QEMU, pinned at v7.0.0, https://github.com/tonistiigi/binfmt/issues/215
- Broken build of spacy dependency on ARM, spacy capped at <3.8.0, https://github.com/explosion/cython-blis/issues/117

Temporarily added `workflow_dispatch` and deployed from ce4c4df60faa7d9752d1eea2e3dbf9fb30591083, removing this changed and merging later. 