### PR TITLE
Use tmpdir with enough free space.

### DIFF
--- a/src/sec_certs/dataset/cpe.py
+++ b/src/sec_certs/dataset/cpe.py
@@ -71,7 +71,7 @@ class CPEDataset(JSONPathDataset, ComplexSerializableType):
         return cls(**dct)
 
     @classmethod
-    def from_web(cls, json_path: str | Path = constants.DUMMY_NONEXISTING_PATH) -> CPEDataset:
+    def from_web(cls, json_path: str | Path | None = None) -> CPEDataset:
         """
         Creates CPEDataset from NIST resources published on-line
 
@@ -91,8 +91,11 @@ class CPEDataset(JSONPathDataset, ComplexSerializableType):
                 raise RuntimeError(f"Could not download CPEDataset from {config.cpe_latest_snapshot}.")
             dset = cls.from_json(dset_path, is_compressed=True)
 
-        dset.json_path = json_path
-        dset.to_json()
+        if json_path:
+            dset.json_path = json_path
+            dset.to_json()
+        else:
+            dset.json_path = constants.DUMMY_NONEXISTING_PATH
         return dset
 
     def enhance_with_nvd_data(self, nvd_data: dict[Any, Any]) -> None:

--- a/src/sec_certs/dataset/cve.py
+++ b/src/sec_certs/dataset/cve.py
@@ -67,7 +67,7 @@ class CVEDataset(JSONPathDataset, ComplexSerializableType):
         return bool(self._cpe_uri_to_cve_ids_lookup)
 
     @classmethod
-    def from_web(cls, json_path: str | Path = constants.DUMMY_NONEXISTING_PATH) -> CVEDataset:
+    def from_web(cls, json_path: str | Path | None = None) -> CVEDataset:
         """
         Creates CVEDataset from NIST resources published on-line
 
@@ -87,8 +87,11 @@ class CVEDataset(JSONPathDataset, ComplexSerializableType):
                 raise RuntimeError(f"Could not download CVEDataset from {config_module.config.cve_latest_snapshot}.")
             dset = cls.from_json(dset_path, is_compressed=True)
 
-        dset.json_path = json_path
-        dset.to_json()
+        if json_path:
+            dset.json_path = json_path
+            dset.to_json()
+        else:
+            dset.json_path = constants.DUMMY_NONEXISTING_PATH
         return dset
 
     def _get_cves_with_criteria_configurations(self) -> None:

--- a/src/sec_certs/dataset/dataset.py
+++ b/src/sec_certs/dataset/dataset.py
@@ -182,10 +182,12 @@ class Dataset(Generic[CertSubType], ComplexSerializableType, ABC):
             if not path.is_dir():
                 raise ValueError("Path needs to be a directory.")
         if artifacts:
-            with tempfile.TemporaryDirectory() as tmp_dir:
+            fsize = helpers.query_file_size(str(archive_url))
+            base_tmpdir = tempfile.gettempdir() if fsize is None else helpers.tempdir_for(fsize)
+            with tempfile.TemporaryDirectory(dir=base_tmpdir) as tmp_dir:
                 dset_path = Path(tmp_dir) / "dataset.tar.gz"
                 res = helpers.download_file(
-                    archive_url,
+                    str(archive_url),
                     dset_path,
                     show_progress_bar=True,
                     progress_bar_desc=progress_bar_desc,
@@ -201,7 +203,7 @@ class Dataset(Generic[CertSubType], ComplexSerializableType, ABC):
             with tempfile.TemporaryDirectory() as tmp_dir:
                 dset_path = Path(tmp_dir) / "dataset.json"
                 helpers.download_file(
-                    snapshot_url,
+                    str(snapshot_url),
                     dset_path,
                     show_progress_bar=True,
                     progress_bar_desc=progress_bar_desc,

--- a/src/sec_certs/heuristics/__init__.py
+++ b/src/sec_certs/heuristics/__init__.py
@@ -1,0 +1,1 @@
+"""This package provides heuristics for extracting information from certificates."""

--- a/src/sec_certs/utils/__init__.py
+++ b/src/sec_certs/utils/__init__.py
@@ -1,1 +1,1 @@
-"""This package provides utilities used throught the framework."""
+"""This package provides utilities used throughout the framework."""

--- a/tests/cc/test_cc_dataset.py
+++ b/tests/cc/test_cc_dataset.py
@@ -12,8 +12,6 @@ from sec_certs.sample.cc import CCCertificate
 
 
 def test_download_and_convert_pdfs(toy_dataset: CCDataset, data_dir: Path):
-    for cert in toy_dataset:
-        print(cert.dgst, cert.old_dgst, cert.older_dgst)
     template_report_pdf_hashes = {
         "e3dcf91ef38ddbf0": "774c41fbba980191ca40ae610b2f61484c5997417b3325b6fd68b345173bde52",
         "ed7611868f0f9d97": "533a5995ef8b736cc48cfda30e8aafec77d285511471e0e5a9e8007c8750203a",

--- a/tests/cc/test_cc_dataset.py
+++ b/tests/cc/test_cc_dataset.py
@@ -78,6 +78,12 @@ def test_download_and_convert_pdfs(toy_dataset: CCDataset, data_dir: Path):
         )
 
 
+@pytest.mark.slow
+def test_from_web():
+    dset = CCDataset.from_web()
+    assert len(dset) > 6000
+
+
 def test_dataset_to_json(toy_dataset: CCDataset, data_dir: Path, tmp_path: Path):
     toy_dataset.to_json(tmp_path / "dset.json")
 

--- a/tests/cc/test_cc_dataset.py
+++ b/tests/cc/test_cc_dataset.py
@@ -6,8 +6,10 @@ from tempfile import TemporaryDirectory
 import pytest
 
 from sec_certs import constants
+from sec_certs.configuration import config
 from sec_certs.dataset.cc import CCDataset
 from sec_certs.sample.cc import CCCertificate
+from sec_certs.utils import helpers
 
 
 def test_download_and_convert_pdfs(toy_dataset: CCDataset, data_dir: Path):
@@ -79,6 +81,12 @@ def test_download_and_convert_pdfs(toy_dataset: CCDataset, data_dir: Path):
 def test_from_web():
     dset = CCDataset.from_web()
     assert len(dset) > 6000
+
+
+def test_archive_fits():
+    fsize = helpers.query_file_size(config.cc_latest_full_archive)
+    tmpdir = helpers.tempdir_for(fsize)
+    assert tmpdir is not None
 
 
 def test_dataset_to_json(toy_dataset: CCDataset, data_dir: Path, tmp_path: Path):

--- a/tests/cc/test_cc_dataset.py
+++ b/tests/cc/test_cc_dataset.py
@@ -6,7 +6,6 @@ from tempfile import TemporaryDirectory
 import pytest
 
 from sec_certs import constants
-from sec_certs.dataset import ProtectionProfileDataset
 from sec_certs.dataset.cc import CCDataset
 from sec_certs.sample.cc import CCCertificate
 
@@ -136,22 +135,19 @@ def test_build_dataset(data_dir: Path, cert_one: CCCertificate, toy_dataset: CCD
 
 
 @pytest.mark.xfail(reason="May fail due to error on CC server")
-@pytest.mark.parametrize("dataset_class", ["CCDataset", "ProtectionProfileDataset"])
-def test_download_csv_html_files(dataset_class):
+def test_download_csv_html_files():
     with TemporaryDirectory() as tmp_dir:
-        constructor = CCDataset if dataset_class == "CCDataset" else ProtectionProfileDataset
-        min_html_size = constants.MIN_CC_HTML_SIZE if dataset_class == "CCDataset" else constants.MIN_PP_HTML_SIZE
-        dset = constructor(root_dir=Path(tmp_dir))
-        dset._download_html_resources(get_active=True, get_archived=False)
+        min_html_size = constants.MIN_CC_HTML_SIZE
+        dset = CCDataset(root_dir=Path(tmp_dir))
+        dset._download_csv_html_resources(get_active=True, get_archived=False)
 
         for x in dset.active_html_tuples:
             assert x[1].exists()
             assert x[1].stat().st_size >= min_html_size
 
-        if dataset_class == "CCDataset":
-            for x in dset.active_csv_tuples:
-                assert x[1].exists()
-                assert x[1].stat().st_size >= constants.MIN_CC_CSV_SIZE
+        for x in dset.active_csv_tuples:
+            assert x[1].exists()
+            assert x[1].stat().st_size >= constants.MIN_CC_CSV_SIZE
 
 
 def test_to_pandas(toy_dataset: CCDataset):

--- a/tests/cc/test_cc_maintenance_updates.py
+++ b/tests/cc/test_cc_maintenance_updates.py
@@ -77,9 +77,8 @@ def test_to_pandas(mu_dset: CCDatasetMaintenanceUpdates):
     assert set(df.columns) == set(CCMaintenanceUpdate.pandas_columns) - {"dgst"}
 
 
-@pytest.mark.skip(reason="Will work only with fresh snapshot on sec-certs.org")
+@pytest.mark.slow
 def test_from_web():
     dset = CCDatasetMaintenanceUpdates.from_web()
     assert dset is not None
     assert len(dset) >= 492  # Contents as of November 2022, maintenances should not disappear
-    assert "cert_8f08cacb49a742fb_update_559ed93dd80320b5" in dset  # random cert verified to be present

--- a/tests/cc/test_cc_protection_profiles.py
+++ b/tests/cc/test_cc_protection_profiles.py
@@ -5,6 +5,7 @@ from tempfile import TemporaryDirectory
 
 import pytest
 
+from sec_certs import constants
 from sec_certs.dataset.protection_profile import ProtectionProfileDataset
 
 
@@ -68,6 +69,23 @@ def test_get_certs_from_web(pp_data_dir: Path, toy_pp_dataset: ProtectionProfile
         assert isinstance(cert.web_data.status, str)
         assert isinstance(cert.web_data.category, str)
         assert isinstance(cert.web_data.version, str)
+
+
+@pytest.mark.slow
+def test_from_web():
+    dset = ProtectionProfileDataset.from_web()
+    assert len(dset) > 400
+
+
+@pytest.mark.xfail(reason="May fail due to error on CC server")
+def test_download_html_files():
+    with TemporaryDirectory() as tmp_dir:
+        dset = ProtectionProfileDataset(root_dir=Path(tmp_dir))
+        dset._download_html_resources(get_active=True, get_archived=False)
+
+        for x in dset.active_html_tuples:
+            assert x[1].exists()
+            assert x[1].stat().st_size >= constants.MIN_PP_HTML_SIZE
 
 
 def test_download_and_convert_artifacts(toy_pp_dataset: ProtectionProfileDataset, tmpdir, pp_data_dir):

--- a/tests/fips/test_fips_dataset.py
+++ b/tests/fips/test_fips_dataset.py
@@ -35,6 +35,12 @@ def test_dataset_to_json(toy_dataset: FIPSDataset, data_dir: Path, tmp_path: Pat
     assert data == template_data
 
 
+@pytest.mark.slow
+def test_from_web():
+    dset = FIPSDataset.from_web()
+    assert len(dset) > 4000
+
+
 def test_dataset_from_json(toy_dataset: FIPSDataset, data_dir: Path, tmp_path: Path):
     assert toy_dataset == FIPSDataset.from_json(data_dir / "toy_dataset.json")
 

--- a/tests/fips/test_fips_dataset.py
+++ b/tests/fips/test_fips_dataset.py
@@ -11,8 +11,10 @@ import pytest
 import tests.data.fips.dataset
 
 from sec_certs import constants
+from sec_certs.configuration import config
 from sec_certs.dataset.fips import FIPSDataset
 from sec_certs.sample.fips import FIPSCertificate
+from sec_certs.utils import helpers
 
 
 @pytest.fixture(scope="module")
@@ -39,6 +41,12 @@ def test_dataset_to_json(toy_dataset: FIPSDataset, data_dir: Path, tmp_path: Pat
 def test_from_web():
     dset = FIPSDataset.from_web()
     assert len(dset) > 4000
+
+
+def test_archive_fits():
+    fsize = helpers.query_file_size(config.fips_latest_full_archive)
+    tmpdir = helpers.tempdir_for(fsize)
+    assert tmpdir is not None
 
 
 def test_dataset_from_json(toy_dataset: FIPSDataset, data_dir: Path, tmp_path: Path):

--- a/tests/test_nvd_dataset_builder.py
+++ b/tests/test_nvd_dataset_builder.py
@@ -5,7 +5,7 @@ from typing import Any
 import pytest
 
 from sec_certs.configuration import config
-from sec_certs.dataset import CCDataset, CPEDataset, CVEDataset
+from sec_certs.dataset import CPEDataset, CVEDataset
 from sec_certs.utils.nvd_dataset_builder import (
     CpeMatchNvdDatasetBuilder,
     CpeNvdDatasetBuilder,
@@ -20,25 +20,18 @@ def load_test_config():
         config.load_from_yaml(path)
 
 
-@pytest.mark.skip(reason="not yet implemented on the web")
+@pytest.mark.slow
 def test_cpe_download_from_seccerts():
     cpe_dataset = CPEDataset.from_web()
     assert len(cpe_dataset) > 100000
     assert cpe_dataset.last_update_timestamp > datetime.now() - timedelta(days=28)
 
 
-@pytest.mark.skip(reason="not yet implemented on the web")
+@pytest.mark.slow
 def test_cve_download_from_seccerts():
     cve_dataset = CVEDataset.from_web()
     assert len(cve_dataset) > 100000
     assert cve_dataset.last_update_timestamp > datetime.now() - timedelta(days=28)
-
-
-@pytest.mark.skip(reason="not yet implemented on the web")
-def test_cpe_match_download_from_seccerts():
-    cpe_match_dict = CCDataset._prepare_cpe_match_dict()
-    assert len(cpe_match_dict["match_strings"]) > 100000
-    assert datetime.fromisoformat(cpe_match_dict["timestamp"]) > datetime.now() - timedelta(days=28)
 
 
 @pytest.mark.xfail(reason="May fail due to NVD server errors.")


### PR DESCRIPTION
The full CC archive is now about 9GB. Quite often, `/tmp` is actually `tmpfs` and thus in memory and thus not that large. If the temp directory we download in is in there, we will get "No space left on device" while downloading. So lets try more tempdirs (like Python does itself: https://github.com/python/cpython/blob/main/Lib/tempfile.py#L156) and hope for the best.