### PR TITLE
Add version warning for dataset compatibility

### DIFF
--- a/src/sec_certs/dataset/dataset.py
+++ b/src/sec_certs/dataset/dataset.py
@@ -277,7 +277,7 @@ class Dataset(Generic[CertSubType], ComplexSerializableType, ABC):
             from sec_certs._version import __version__ as current_version
         except ImportError:
             current_version = "unknown"
-        dset_version = getattr(getattr(dset, 'state', None), 'sec_certs_version', None)
+        dset_version = getattr(getattr(dset, "state", None), "sec_certs_version", None)
         if dset_version and current_version != "unknown" and dset_version != current_version:
             try:
                 dset_v = parse_version(dset_version)
@@ -288,9 +288,13 @@ class Dataset(Generic[CertSubType], ComplexSerializableType, ABC):
                     which = "older than"
                 else:
                     which = "equal to"
-                logger.warning(f"Dataset was created with sec-certs version {dset_version} ({which} your version {current_version}). To install the matching version: pip install sec-certs=={dset_version}")
+                logger.warning(
+                    f"Dataset was created with sec-certs version {dset_version} ({which} your version {current_version}). To install the matching version: pip install sec-certs=={dset_version}"
+                )
             except Exception:
-                logger.warning(f"Dataset was created with sec-certs version {dset_version}, but you are running version {current_version}. To install the matching version: pip install sec-certs=={dset_version}")
+                logger.warning(
+                    f"Dataset was created with sec-certs version {dset_version}, but you are running version {current_version}. To install the matching version: pip install sec-certs=={dset_version}"
+                )
         return dset
 
     @classmethod

--- a/src/sec_certs/dataset/dataset.py
+++ b/src/sec_certs/dataset/dataset.py
@@ -13,8 +13,10 @@ from typing import Any, ClassVar, Generic, TypeVar, cast
 
 import pandas as pd
 import requests
+from packaging.version import parse as parse_version
 from pydantic import AnyHttpUrl
 
+from sec_certs._version import __version__
 from sec_certs.dataset.auxiliary_dataset_handling import AuxiliaryDatasetHandler
 from sec_certs.sample.certificate import Certificate
 from sec_certs.serialization.json import (
@@ -48,6 +50,23 @@ class Dataset(Generic[CertSubType], ComplexSerializableType, ABC):
         pdfs_converted: bool = False
         auxiliary_datasets_processed: bool = False
         certs_analyzed: bool = False
+        sec_certs_version: str | None = None
+
+        def __init__(
+            self,
+            meta_sources_parsed: bool = False,
+            artifacts_downloaded: bool = False,
+            pdfs_converted: bool = False,
+            auxiliary_datasets_processed: bool = False,
+            certs_analyzed: bool = False,
+            sec_certs_version: str | None = None,
+        ):
+            self.meta_sources_parsed = meta_sources_parsed
+            self.artifacts_downloaded = artifacts_downloaded
+            self.pdfs_converted = pdfs_converted
+            self.auxiliary_datasets_processed = auxiliary_datasets_processed
+            self.certs_analyzed = certs_analyzed
+            self.sec_certs_version = sec_certs_version if sec_certs_version is not None else __version__
 
     def __init__(
         self,
@@ -60,7 +79,6 @@ class Dataset(Generic[CertSubType], ComplexSerializableType, ABC):
     ):
         super().__init__()
         self.certs = certs if certs is not None else {}
-
         self.timestamp = datetime.now()
         self.name = name if name else type(self).__name__
         self.description = description if description else datetime.now().strftime("%d/%m/%Y %H:%M:%S")
@@ -254,6 +272,25 @@ class Dataset(Generic[CertSubType], ComplexSerializableType, ABC):
             logger.error(
                 f"The actual number of certs in dataset ({len(dset)}) does not match the claimed number ({claimed})."
             )
+        # Version check and warning
+        try:
+            from sec_certs._version import __version__ as current_version
+        except ImportError:
+            current_version = "unknown"
+        dset_version = getattr(getattr(dset, 'state', None), 'sec_certs_version', None)
+        if dset_version and current_version != "unknown" and dset_version != current_version:
+            try:
+                dset_v = parse_version(dset_version)
+                curr_v = parse_version(current_version)
+                if dset_v > curr_v:
+                    which = "newer than"
+                elif dset_v < curr_v:
+                    which = "older than"
+                else:
+                    which = "equal to"
+                logger.warning(f"Dataset was created with sec-certs version {dset_version} ({which} your version {current_version}). To install the matching version: pip install sec-certs=={dset_version}")
+            except Exception:
+                logger.warning(f"Dataset was created with sec-certs version {dset_version}, but you are running version {current_version}. To install the matching version: pip install sec-certs=={dset_version}")
         return dset
 
     @classmethod

--- a/tests/cc/test_cc_dataset.py
+++ b/tests/cc/test_cc_dataset.py
@@ -101,6 +101,8 @@ def test_dataset_to_json(toy_dataset: CCDataset, data_dir: Path, tmp_path: Path)
 
     del data["timestamp"]
     del template_data["timestamp"]
+    del data["state"]["sec_certs_version"]
+    del template_data["state"]["sec_certs_version"]
     assert data == template_data
 
 

--- a/tests/cc/test_cc_maintenance_updates.py
+++ b/tests/cc/test_cc_maintenance_updates.py
@@ -61,6 +61,8 @@ def test_dataset_to_json(mu_dset: CCDatasetMaintenanceUpdates, data_dir: Path, t
 
     del template_data["timestamp"]
     del data["timestamp"]
+    del template_data["state"]["sec_certs_version"]
+    del data["state"]["sec_certs_version"]
     assert data == template_data
 
 

--- a/tests/cc/test_cc_protection_profiles.py
+++ b/tests/cc/test_cc_protection_profiles.py
@@ -19,6 +19,8 @@ def test_dataset_from_json(toy_pp_dataset: ProtectionProfileDataset, pp_data_dir
 
     del data["timestamp"]
     del template_data["timestamp"]
+    del data["state"]["sec_certs_version"]
+    del template_data["state"]["sec_certs_version"]
     assert data == template_data
 
 

--- a/tests/data/cc/dataset/auxiliary_datasets/maintenances/maintenance_updates.json
+++ b/tests/data/cc/dataset/auxiliary_datasets/maintenances/maintenance_updates.json
@@ -6,7 +6,8 @@
         "artifacts_downloaded": true,
         "pdfs_converted": false,
         "auxiliary_datasets_processed": false,
-        "certs_analyzed": false
+        "certs_analyzed": false,
+        "sec_certs_version": "unknown"
     },
     "timestamp": "2022-11-10 13:44:35.171285",
     "name": "maintenance_updates",

--- a/tests/data/cc/dataset/toy_dataset.json
+++ b/tests/data/cc/dataset/toy_dataset.json
@@ -6,7 +6,8 @@
     "artifacts_downloaded": false,
     "pdfs_converted": false,
     "auxiliary_datasets_processed": false,
-    "certs_analyzed": false
+    "certs_analyzed": false,
+    "sec_certs_version": "unknown"
   },
   "timestamp": "2020-11-16 17:04:14.770153",
   "name": "toy dataset",

--- a/tests/data/fips/dataset/toy_dataset.json
+++ b/tests/data/fips/dataset/toy_dataset.json
@@ -6,7 +6,8 @@
         "artifacts_downloaded": true,
         "pdfs_converted": true,
         "auxiliary_datasets_processed": false,
-        "certs_analyzed": false
+        "certs_analyzed": false,
+        "sec_certs_version": "unknown"
     },
     "timestamp": "2022-11-30 16:38:51.953055",
     "name": "FIPSDataset dataset",

--- a/tests/data/protection_profiles/dataset.json
+++ b/tests/data/protection_profiles/dataset.json
@@ -6,7 +6,8 @@
         "artifacts_downloaded": false,
         "pdfs_converted": false,
         "auxiliary_datasets_processed": false,
-        "certs_analyzed": false
+        "certs_analyzed": false,
+        "sec_certs_version": "unknown"
     },
     "timestamp": "2025-01-25 17:39:26.873380",
     "name": "ProtectionProfileDataset dataset",

--- a/tests/fips/test_fips_dataset.py
+++ b/tests/fips/test_fips_dataset.py
@@ -34,6 +34,8 @@ def test_dataset_to_json(toy_dataset: FIPSDataset, data_dir: Path, tmp_path: Pat
 
     del data["timestamp"]
     del template_data["timestamp"]
+    del data["state"]["secure_certs_version"]
+    del template_data["state"]["secure_certs_version"]
     assert data == template_data
 
 

--- a/tests/fips/test_fips_dataset.py
+++ b/tests/fips/test_fips_dataset.py
@@ -34,8 +34,8 @@ def test_dataset_to_json(toy_dataset: FIPSDataset, data_dir: Path, tmp_path: Pat
 
     del data["timestamp"]
     del template_data["timestamp"]
-    del data["state"]["secure_certs_version"]
-    del template_data["state"]["secure_certs_version"]
+    del data["state"]["sec_certs_version"]
+    del template_data["state"]["sec_certs_version"]
     assert data == template_data
 
 


### PR DESCRIPTION
Introduce a version check for datasets to warn users if the dataset version differs from the current package version. Update tests to accommodate the new version handling.

Fixes #338.

Generated with Github Copilot agent.