### PR TITLE
Fix failing docling tests due to different outputs

### DIFF
--- a/src/sec_certs/utils/strings.py
+++ b/src/sec_certs/utils/strings.py
@@ -41,3 +41,10 @@ def lemmatize_product_name(nlp, product_name: str) -> str:
     if not product_name:
         return product_name
     return " ".join([token.lemma_ for token in nlp(fully_sanitize_string(product_name))])
+
+
+def normalize_whitespace(text: str) -> str:
+    text = text.strip()
+    text = re.sub(r"[^\S\n]+", " ", text)
+    text = re.sub(r"\n+", "\n", text)
+    return text

--- a/tests/cc/test_cc_dataset.py
+++ b/tests/cc/test_cc_dataset.py
@@ -6,7 +6,7 @@ from tempfile import TemporaryDirectory
 
 import pytest
 import tests.data.cc.dataset
-from tests.conftest import get_converters
+from tests.conftest import compare_to_template, get_converters
 
 from sec_certs import constants
 from sec_certs.configuration import config
@@ -83,8 +83,9 @@ def test_convert_pdfs(downloaded_toy_dataset: CCDataset, data_dir: Path, convert
     test_crt = downloaded_toy_dataset["e3dcf91ef38ddbf0"]
     template_report_path = data_dir / f"templates/{converter.get_name()}/reports/{test_crt.dgst}.txt"
     template_st_path = data_dir / f"templates/{converter.get_name()}/targets/{test_crt.dgst}.txt"
-    assert abs(test_crt.state.st.txt_path.stat().st_size - template_st_path.stat().st_size) < 1000
-    assert abs(test_crt.state.report.txt_path.stat().st_size - template_report_path.stat().st_size) < 1000
+
+    compare_to_template(template_report_path, test_crt.state.report.txt_path)
+    compare_to_template(template_st_path, test_crt.state.st.txt_path)
 
 
 @pytest.mark.remote

--- a/tests/cc/test_cc_protection_profiles.py
+++ b/tests/cc/test_cc_protection_profiles.py
@@ -6,7 +6,7 @@ from tempfile import TemporaryDirectory
 
 import pytest
 import tests.data.protection_profiles
-from tests.conftest import get_converters
+from tests.conftest import compare_to_template, get_converters
 
 from sec_certs import constants
 from sec_certs.converter import PDFConverter
@@ -148,8 +148,9 @@ def test_convert_pdfs(
     test_crt = downloaded_toy_dataset["b02ed76d2545326a"]
     template_report_path = pp_data_dir / f"templates/{converter.get_name()}/reports/{test_crt.dgst}.txt"
     template_pp_path = pp_data_dir / f"templates/{converter.get_name()}/pps/{test_crt.dgst}.txt"
-    assert abs(test_crt.state.report.txt_path.stat().st_size - template_report_path.stat().st_size) < 1000
-    assert abs(test_crt.state.pp.txt_path.stat().st_size - template_pp_path.stat().st_size) < 1000
+
+    compare_to_template(template_report_path, test_crt.state.report.txt_path)
+    compare_to_template(template_pp_path, test_crt.state.pp.txt_path)
 
 
 def test_keyword_extraction(toy_pp_dataset: ProtectionProfileDataset, pp_data_dir: Path, tmpdir):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,11 +4,13 @@ from importlib.resources import as_file, files
 from pathlib import Path
 
 import pytest
+from rapidfuzz import fuzz
 
 import tests.data.common
 from sec_certs.configuration import config
 from sec_certs.converter import has_docling, has_pdftotext
 from sec_certs.dataset import CPEDataset, CVEDataset
+from sec_certs.utils.strings import normalize_whitespace
 
 
 def get_converters():
@@ -22,6 +24,19 @@ def get_converters():
 
         converters.append(pytest.param(DoclingConverter, marks=pytest.mark.docling))
     return converters
+
+
+def compare_to_template(template: Path, actual: Path) -> None:
+    with template.open("r", encoding="utf-8") as f:
+        template_text = f.read()
+
+    with actual.open("r", encoding="utf-8") as f:
+        actual_text = f.read()
+
+    template_text = normalize_whitespace(template_text)
+    actual_text = normalize_whitespace(actual_text)
+    ratio = fuzz.ratio(template_text, actual_text)
+    assert ratio >= 95
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/fips/test_fips_dataset.py
+++ b/tests/fips/test_fips_dataset.py
@@ -9,7 +9,7 @@ from tempfile import TemporaryDirectory
 
 import pytest
 import tests.data.fips.dataset
-from tests.conftest import get_converters
+from tests.conftest import compare_to_template, get_converters
 
 from sec_certs import constants
 from sec_certs.configuration import config
@@ -141,7 +141,8 @@ def test_convert_pdfs(downloaded_toy_dataset: FIPSDataset, data_dir: Path, conve
 
     test_crt = downloaded_toy_dataset["184097a88a9b4ad9"]
     template_policy_path = data_dir / f"templates/{converter.get_name()}/policies/{test_crt.dgst}.txt"
-    assert abs(test_crt.state.policy_txt_path.stat().st_size - template_policy_path.stat().st_size) < 1000
+
+    compare_to_template(template_policy_path, test_crt.state.policy_txt_path)
 
 
 def test_to_pandas(toy_dataset: FIPSDataset):


### PR DESCRIPTION
This PR fixes https://github.com/crocs-muni/sec-certs/issues/547.

I've decided to relax the assertions using the insertion/deletion similarity between the template and the actual conversion result. 

First, it normalizes the whitespaces and then computes the similarity using the RapidFuzz library, which I've leveraged since it is already in the project deps.

The threshold was set by playing around with the templates and actual content on my MacBook, and can be adjusted as needed.