### PR TITLE
Fix compatibility with pandas 3.0

### DIFF
--- a/src/sec_certs/dataset/cc.py
+++ b/src/sec_certs/dataset/cc.py
@@ -495,15 +495,11 @@ class CCDataset(Dataset[CCCertificate], ComplexSerializableType):
         df_base = df.loc[~df.is_maintenance].copy()
         df_main = df.loc[df.is_maintenance].copy()
 
-        df_base.report_link = df_base.report_link.map(map_ip_to_hostname).map(sanitization.sanitize_link)
-        df_base.st_link = df_base.st_link.map(map_ip_to_hostname).map(sanitization.sanitize_link)
+        df_base.report_link = df_base.report_link.map(map_ip_to_hostname)
+        df_base.st_link = df_base.st_link.map(map_ip_to_hostname)
 
-        df_main.maintenance_report_link = df_main.maintenance_report_link.map(map_ip_to_hostname).map(
-            sanitization.sanitize_link
-        )
-        df_main.maintenance_st_link = df_main.maintenance_st_link.map(map_ip_to_hostname).map(
-            sanitization.sanitize_link
-        )
+        df_main.maintenance_report_link = df_main.maintenance_report_link.map(map_ip_to_hostname)
+        df_main.maintenance_st_link = df_main.maintenance_st_link.map(map_ip_to_hostname)
 
         n_all = len(df_base)
         n_deduplicated = len(df_base.drop_duplicates(subset=["dgst"]))


### PR DESCRIPTION
pandas 3.0 changed the default string dtype from object to a new string type, which uses only `NaN` as the missing value ([release notes](https://pandas.pydata.org/docs/whatsnew/v3.0.0.html)). This caused an error in `CCDataset._parse_single_csv`. See the commit for details.

I reviewed the rest of the codebase against the new changes and don't think any further changes are needed to support pandas >= 3.0.
