### PR TITLE
Fix: undefined variable type access

### DIFF
--- a/sec_certs_page/static/modal.js
+++ b/sec_certs_page/static/modal.js
@@ -128,9 +128,9 @@ export function compare_do(cc_url, fips_url) {
     let url;
     if (selected[0]["type"] === "cc") {
         url = cc_url;
-    } else if (selected[0][type] == "fips") {
+    } else if (selected[0]["type"] == "fips") {
         url = fips_url;
-    } else if (selected[0][type] == "pp") {
+    } else if (selected[0]["type"] == "pp") {
         $("#compare-error").text("Comparing protection profiles not supported (yet).").show();
         return;
     }


### PR DESCRIPTION
In `compare_do()`, which handles certificate comparison `selected[0][type]` was using `type` as a variable reference but it's not defined in the scope, causing:

`Uncaught ReferenceError: type is not defined`

Fixed by using a string literal instead, as already used correctly in the first branch.
