### PR TITLE
Page compatibility with unified DocumentState

### DIFF
--- a/sec_certs_page/cc/tasks.py
+++ b/sec_certs_page/cc/tasks.py
@@ -247,10 +247,10 @@ class CCUpdater(Updater, CCMixin):  # pragma: no cover
 
             with sentry_sdk.start_span(op="cc.move", name="Move files"), suppress_child_spans():
                 for cert in dset:
-                    if cert.state.report.pdf_path and cert.state.report.pdf_path.exists():
+                    if cert.state.report.source_path and cert.state.report.source_path.exists():
                         dst = paths["report_pdf"] / f"{cert.dgst}.pdf"
-                        if not dst.exists() or get_sha256_filepath(dst) != cert.state.report.pdf_hash:
-                            cert.state.report.pdf_path.replace(dst)
+                        if not dst.exists() or get_sha256_filepath(dst) != cert.state.report.source_hash:
+                            cert.state.report.source_path.replace(dst)
                     if cert.state.report.txt_path and cert.state.report.txt_path.exists():
                         dst = paths["report_txt"] / f"{cert.dgst}.txt"
                         if not dst.exists() or get_sha256_filepath(dst) != cert.state.report.txt_hash:
@@ -261,10 +261,10 @@ class CCUpdater(Updater, CCMixin):  # pragma: no cover
                         #    to_update_kb.add((cert.dgst, "report", None))
                         # elif reports_fmap[name][1] < dst.stat().st_mtime:
                         #    to_update_kb.add((cert.dgst, "report", reports_fmap[name][0]))
-                    if cert.state.st.pdf_path and cert.state.st.pdf_path.exists():
+                    if cert.state.st.source_path and cert.state.st.source_path.exists():
                         dst = paths["target_pdf"] / f"{cert.dgst}.pdf"
-                        if not dst.exists() or get_sha256_filepath(dst) != cert.state.st.pdf_hash:
-                            cert.state.st.pdf_path.replace(dst)
+                        if not dst.exists() or get_sha256_filepath(dst) != cert.state.st.source_hash:
+                            cert.state.st.source_path.replace(dst)
                     if cert.state.st.txt_path and cert.state.st.txt_path.exists():
                         dst = paths["target_txt"] / f"{cert.dgst}.txt"
                         if not dst.exists() or get_sha256_filepath(dst) != cert.state.st.txt_hash:
@@ -275,10 +275,10 @@ class CCUpdater(Updater, CCMixin):  # pragma: no cover
                         #    to_update_kb.add((cert.dgst, "target", None))
                         # elif targets_fmap[name][1] < dst.stat().st_mtime:
                         #    to_update_kb.add((cert.dgst, "target", targets_fmap[name][0]))
-                    if cert.state.cert.pdf_path and cert.state.cert.pdf_path.exists():
+                    if cert.state.cert.source_path and cert.state.cert.source_path.exists():
                         dst = paths["cert_pdf"] / f"{cert.dgst}.pdf"
-                        if not dst.exists() or get_sha256_filepath(dst) != cert.state.cert.pdf_hash:
-                            cert.state.cert.pdf_path.replace(dst)
+                        if not dst.exists() or get_sha256_filepath(dst) != cert.state.cert.source_hash:
+                            cert.state.cert.source_path.replace(dst)
                     if cert.state.cert.txt_path and cert.state.cert.txt_path.exists():
                         dst = paths["cert_txt"] / f"{cert.dgst}.txt"
                         if not dst.exists() or get_sha256_filepath(dst) != cert.state.cert.txt_hash:

--- a/sec_certs_page/cc/views.py
+++ b/sec_certs_page/cc/views.py
@@ -376,9 +376,9 @@ def entry(hashid):
                 "name": 1,
                 "dgst": 1,
                 "heuristics.cert_id": 1,
-                "state.cert.pdf_hash": 1,
-                "state.report.pdf_hash": 1,
-                "state.st.pdf_hash": 1,
+                "state.cert.source_hash": 1,
+                "state.report.source_hash": 1,
+                "state.st.source_hash": 1,
             }
             exact_queries = []
             if doc["name"]:
@@ -388,8 +388,8 @@ def entry(hashid):
             exact = list(mongo.db.cc.find({"$or": exact_queries}, similar_projection)) if exact_queries else []
             doc_hash_queries = []
             for doctype in ("cert", "report", "st"):
-                if doc["state"][doctype]["pdf_hash"]:
-                    doc_hash_queries.append({f"state.{doctype}.pdf_hash": doc["state"][doctype]["pdf_hash"]})
+                if doc["state"][doctype]["source_hash"]:
+                    doc_hash_queries.append({f"state.{doctype}.source_hash": doc["state"][doctype]["source_hash"]})
             doc_hash_match = (
                 list(mongo.db.cc.find({"$or": doc_hash_queries}, similar_projection)) if doc_hash_queries else []
             )
@@ -420,8 +420,8 @@ def entry(hashid):
                 if (cert_id := doc["heuristics"]["cert_id"]) and other["heuristics"]["cert_id"] == cert_id:
                     score += 1
                 for doctype in ("cert", "report", "st"):
-                    if (pdf_hash := doc["state"][doctype]["pdf_hash"]) and other["state"][doctype][
-                        "pdf_hash"
+                    if (pdf_hash := doc["state"][doctype]["source_hash"]) and other["state"][doctype][
+                        "source_hash"
                     ] == pdf_hash:
                         score += 1
                 if score >= 2:

--- a/sec_certs_page/common/diffs.py
+++ b/sec_certs_page/common/diffs.py
@@ -723,7 +723,7 @@ cc_diff_method = {
             "convert_ok": diff_bool(),
             "download_ok": diff_bool(),
             "extract_ok": diff_bool(),
-            "pdf_hash": diff_ident(),
+            "source_hash": diff_ident(),
             "txt_hash": diff_ident(),
         },
         "report": {
@@ -732,8 +732,9 @@ cc_diff_method = {
             "convert_ok": diff_bool(),
             "download_ok": diff_bool(),
             "extract_ok": diff_bool(),
-            "pdf_hash": diff_ident(),
+            "source_hash": diff_ident(),
             "txt_hash": diff_ident(),
+            "json_hash": diff_ident()
         },
         "st": {
             "_type": diff_none(),
@@ -741,8 +742,9 @@ cc_diff_method = {
             "convert_ok": diff_bool(),
             "download_ok": diff_bool(),
             "extract_ok": diff_bool(),
-            "pdf_hash": diff_ident(),
+            "source_hash": diff_ident(),
             "txt_hash": diff_ident(),
+            "json_hash": diff_ident()
         },
     },
 }
@@ -784,14 +786,26 @@ fips_diff_method = {
     },
     "state": {
         "_type": diff_none(),
-        "module_download_ok": diff_bool(),
-        "module_extract_ok": diff_bool(),
-        "policy_convert_garbage": diff_bool(),
-        "policy_convert_ok": diff_bool(),
-        "policy_download_ok": diff_bool(),
-        "policy_extract_ok": diff_bool(),
-        "policy_pdf_hash": diff_ident(),
-        "policy_txt_hash": diff_ident(),
+        "module": {
+            "_type": diff_none(),
+            "convert_garbage": diff_bool(),
+            "convert_ok": diff_bool(),
+            "download_ok": diff_bool(),
+            "extract_ok": diff_bool(),
+            "source_hash": diff_ident(),
+            "txt_hash": diff_ident(),
+            "json_hash": diff_ident()
+        },
+        "policy": {
+            "_type": diff_none(),
+            "convert_garbage": diff_bool(),
+            "convert_ok": diff_bool(),
+            "download_ok": diff_bool(),
+            "extract_ok": diff_bool(),
+            "source_hash": diff_ident(),
+            "txt_hash": diff_ident(),
+            "json_hash": diff_ident()
+        },
     },
     "web_data": {
         "_type": diff_none(),

--- a/sec_certs_page/fips/tasks.py
+++ b/sec_certs_page/fips/tasks.py
@@ -227,14 +227,14 @@ class FIPSUpdater(Updater, FIPSMixin):  # pragma: no cover
 
             with sentry_sdk.start_span(op="fips.move", name="Move files"), suppress_child_spans():
                 for cert in dset:
-                    if cert.state.policy_pdf_path and cert.state.policy_pdf_path.exists():
+                    if cert.state.policy.source_path and cert.state.policy.source_path.exists():
                         dst = paths["target_pdf"] / f"{cert.dgst}.pdf"
-                        if not dst.exists() or get_sha256_filepath(dst) != cert.state.policy_pdf_hash:
-                            cert.state.policy_pdf_path.replace(dst)
-                    if cert.state.policy_txt_path and cert.state.policy_txt_path.exists():
+                        if not dst.exists() or get_sha256_filepath(dst) != cert.state.policy.source_hash:
+                            cert.state.policy.source_path.replace(dst)
+                    if cert.state.policy.txt_path and cert.state.policy.txt_path.exists():
                         dst = paths["target_txt"] / f"{cert.dgst}.txt"
-                        if not dst.exists() or get_sha256_filepath(dst) != cert.state.policy_txt_hash:
-                            cert.state.policy_txt_path.replace(dst)
+                        if not dst.exists() or get_sha256_filepath(dst) != cert.state.policy.txt_hash:
+                            cert.state.policy.txt_path.replace(dst)
                             to_reindex.add((cert.dgst, "target"))
         return to_reindex, to_update_kb
 

--- a/sec_certs_page/pp/tasks.py
+++ b/sec_certs_page/pp/tasks.py
@@ -170,19 +170,19 @@ class PPUpdater(Updater, PPMixin):  # pragma: no cover
 
             with sentry_sdk.start_span(op="pp.move", name="Move files"), suppress_child_spans():
                 for prof in dset:
-                    if prof.state.pp.pdf_path and prof.state.pp.pdf_path.exists():
+                    if prof.state.pp.source_path and prof.state.pp.source_path.exists():
                         dst = paths["profile_pdf"] / f"{prof.dgst}.pdf"
-                        if not dst.exists() or get_sha256_filepath(dst) != prof.state.pp.pdf_hash:
-                            prof.state.pp.pdf_path.replace(dst)
+                        if not dst.exists() or get_sha256_filepath(dst) != prof.state.pp.source_hash:
+                            prof.state.pp.source_path.replace(dst)
                     if prof.state.pp.txt_path and prof.state.pp.txt_path.exists():
                         dst = paths["profile_txt"] / f"{prof.dgst}.txt"
                         if not dst.exists() or get_sha256_filepath(dst) != prof.state.pp.txt_hash:
                             prof.state.pp.txt_path.replace(dst)
                             to_reindex.add((prof.dgst, "profile"))
-                    if prof.state.report.pdf_path and prof.state.report.pdf_path.exists():
+                    if prof.state.report.source_path and prof.state.report.source_path.exists():
                         dst = paths["report_pdf"] / f"{prof.dgst}.pdf"
-                        if not dst.exists() or get_sha256_filepath(dst) != prof.state.report.pdf_hash:
-                            prof.state.report.pdf_path.replace(dst)
+                        if not dst.exists() or get_sha256_filepath(dst) != prof.state.report.source_hash:
+                            prof.state.report.source_path.replace(dst)
                     if prof.state.report.txt_path and prof.state.report.txt_path.exists():
                         dst = paths["report_txt"] / f"{prof.dgst}.txt"
                         if not dst.exists() or get_sha256_filepath(dst) != prof.state.report.txt_hash:

--- a/sec_certs_page/templates/cc/entry/index.html.jinja2
+++ b/sec_certs_page/templates/cc/entry/index.html.jinja2
@@ -452,19 +452,19 @@
                                                         class="fas fa-equals"></i></span>
                                             {% endif %}
                                             {% if "state" in similar_cert %}
-                                                {% if "cert" in similar_cert["state"] and similar_cert["state"]["cert"]["pdf_hash"] == cert["state"]["cert"]["pdf_hash"] and cert["state"]["cert"]["pdf_hash"] %}
+                                                {% if "cert" in similar_cert["state"] and similar_cert["state"]["cert"]["source_hash"] == cert["state"]["cert"]["source_hash"] and cert["state"]["cert"]["source_hash"] %}
                                                     <span class="badge rounded-pill bg-info text-dark"
                                                           title="Certificate PDF file matches exactly."
                                                           data-bs-toggle="tooltip"><i
                                                             class="fas fa-file-alt"></i></span>
                                                 {% endif %}
-                                                {% if "report" in similar_cert["state"] and similar_cert["state"]["report"]["pdf_hash"] == cert["state"]["report"]["pdf_hash"] and cert["state"]["report"]["pdf_hash"] %}
+                                                {% if "report" in similar_cert["state"] and similar_cert["state"]["report"]["source_hash"] == cert["state"]["report"]["source_hash"] and cert["state"]["report"]["source_hash"] %}
                                                     <span class="badge rounded-pill bg-info text-dark"
                                                           title="Certification report PDF file matches exactly."
                                                           data-bs-toggle="tooltip"><i
                                                             class="fas fa-file-alt"></i></span>
                                                 {% endif %}
-                                                {% if "st" in similar_cert["state"] and similar_cert["state"]["st"]["pdf_hash"] == cert["state"]["st"]["pdf_hash"] and cert["state"]["st"]["pdf_hash"] %}
+                                                {% if "st" in similar_cert["state"] and similar_cert["state"]["st"]["source_hash"] == cert["state"]["st"]["source_hash"] and cert["state"]["st"]["source_hash"] %}
                                                     <span class="badge rounded-pill bg-info text-dark"
                                                           title="Security target PDF file matches exactly."
                                                           data-bs-toggle="tooltip"><i

--- a/tests/functional/data/cert1.json
+++ b/tests/functional/data/cert1.json
@@ -635,8 +635,9 @@
       "convert_garbage": false,
       "convert_ok": true,
       "extract_ok": true,
-      "pdf_hash": "e7c086c70299aca424631061977f57ce10fcdef0c35fb4d176728902f97bb5cd",
-      "txt_hash": "3d5038a440a97ef73272230a467d9ca44ab5e8e52a67899980aade1739262c12"
+      "source_hash": "e7c086c70299aca424631061977f57ce10fcdef0c35fb4d176728902f97bb5cd",
+      "txt_hash": "3d5038a440a97ef73272230a467d9ca44ab5e8e52a67899980aade1739262c12",
+      "json_hash": null
     },
     "st": {
       "_type": "sec_certs.sample.document_state.DocumentState",
@@ -644,8 +645,9 @@
       "convert_garbage": false,
       "convert_ok": true,
       "extract_ok": false,
-      "pdf_hash": "4f952a10b82c8d91e61308ad53fc9a61b487408c6a3a06807bfc62c68ab1f454",
-      "txt_hash": "bcda924ae83a838cfff75a31c53b3d461d1e077c3e1139b5bc9082d0ca8b80be"
+      "source_hash": "4f952a10b82c8d91e61308ad53fc9a61b487408c6a3a06807bfc62c68ab1f454",
+      "txt_hash": "bcda924ae83a838cfff75a31c53b3d461d1e077c3e1139b5bc9082d0ca8b80be",
+      "json_hash": null
     },
     "cert": {
       "_type": "sec_certs.sample.document_state.DocumentState",
@@ -653,8 +655,9 @@
       "convert_garbage": false,
       "convert_ok": false,
       "extract_ok": false,
-      "pdf_hash": null,
-      "txt_hash": null
+      "source_hash": null,
+      "txt_hash": null,
+      "json_hash": null
     }
   },
   "status": "archived"

--- a/tests/functional/data/cert2.json
+++ b/tests/functional/data/cert2.json
@@ -641,8 +641,10 @@
       "convert_garbage": false,
       "convert_ok": true,
       "extract_ok": true,
-      "pdf_hash": "e7c086c70299aca424631061977f57ce10fcdef0c35fb4d176728902f97bb5cd",
-      "txt_hash": "3d5038a440a97ef73272230a467d9ca44ab5e8e52a67899980aade1739262c12"
+      "source_hash": "e7c086c70299aca424631061977f57ce10fcdef0c35fb4d176728902f97bb5cd",
+      "txt_hash": "3d5038a440a97ef73272230a467d9ca44ab5e8e52a67899980aade1739262c12",
+      "json_hash": null
+
     },
     "st": {
       "_type": "sec_certs.sample.document_state.DocumentState",
@@ -650,8 +652,9 @@
       "convert_garbage": false,
       "convert_ok": true,
       "extract_ok": false,
-      "pdf_hash": "4f952a10b82c8d91e61308ad53fc9a61b487408c6a3a06807bfc62c68ab1f454",
-      "txt_hash": "bcda924ae83a838cfff75a31c53b3d461d1e077c3e1139b5bc9082d0ca8b80be"
+      "source_hash": "4f952a10b82c8d91e61308ad53fc9a61b487408c6a3a06807bfc62c68ab1f454",
+      "txt_hash": "bcda924ae83a838cfff75a31c53b3d461d1e077c3e1139b5bc9082d0ca8b80be",
+      "json_hash": null
     },
     "cert": {
       "_type": "sec_certs.sample.document_state.DocumentState",
@@ -659,8 +662,9 @@
       "convert_garbage": false,
       "convert_ok": false,
       "extract_ok": false,
-      "pdf_hash": null,
-      "txt_hash": null
+      "source_hash": null,
+      "txt_hash": null,
+      "json_hash": null
     }
   },
   "status": "archived"

--- a/tests/functional/data/mongo/cc.json
+++ b/tests/functional/data/mongo/cc.json
@@ -44,8 +44,9 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "fe165dd9a7399dd5063f6a051bb9fab2de906f3949f9e9bf08df22d6d67818d2",
-			"txt_hash": "c7e083548678887a9dce5c544e217d49628c0e4c5c9aa4db5bc84238cb86bf09"
+			"source_hash": "fe165dd9a7399dd5063f6a051bb9fab2de906f3949f9e9bf08df22d6d67818d2",
+			"txt_hash": "c7e083548678887a9dce5c544e217d49628c0e4c5c9aa4db5bc84238cb86bf09",
+			"json_hash": "fc7a035b5f4233b73ff2f94cfeb126a43766809dd0a0a36bf6dcabfcf3df7818"
 		},
 		"st": {
 			"_type": "sec_certs.sample.document_state.DocumentState",
@@ -53,8 +54,9 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "d57ff01507ab99d75e185c1ebde2bcb03553e139ff3b4d7833d34fc2f6ff3acd",
-			"txt_hash": "208569ac4e98fa34ce71c4adebd1c61fed7fcc7ffb1e0bf324fd0f39ec4cc53b"
+			"source_hash": "d57ff01507ab99d75e185c1ebde2bcb03553e139ff3b4d7833d34fc2f6ff3acd",
+			"txt_hash": "208569ac4e98fa34ce71c4adebd1c61fed7fcc7ffb1e0bf324fd0f39ec4cc53b",
+			"json_hash": "15ca950b56c98c71e44f68aeecacf71b9d305c1e6824d141dfc80cea5442d136"
 		},
 		"cert": {
 			"_type": "sec_certs.sample.document_state.DocumentState",
@@ -62,8 +64,9 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "589838ef5e10753b89f5d8e845950bdf5786142e158f0bf44cdce323bd9bfaf4",
-			"txt_hash": "11f93d790b9a81a71dae294af43527e0e847d8b15487e9c396a708466ec801e5"
+			"source_hash": "589838ef5e10753b89f5d8e845950bdf5786142e158f0bf44cdce323bd9bfaf4",
+			"txt_hash": "11f93d790b9a81a71dae294af43527e0e847d8b15487e9c396a708466ec801e5",
+			"json_hash": "996a375e82013b4397b199938f52404f876e710d6d373cd78a64c9fce08193d5"
 		}
 	},
 	"pdf_data": {
@@ -1089,8 +1092,9 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "f1840e2ef500d15093d5f552581bb9a972d757c30d157bcf45d7fbc7fdb4a745",
-			"txt_hash": "21533fe78646caab51b211558b4ff6a82a4cf909b0faa1aa5d81b1aa9870d24a"
+			"source_hash": "f1840e2ef500d15093d5f552581bb9a972d757c30d157bcf45d7fbc7fdb4a745",
+			"txt_hash": "21533fe78646caab51b211558b4ff6a82a4cf909b0faa1aa5d81b1aa9870d24a",
+			"json_hash": "7fb9ec41da97057621de8c6f06f1738fe428f3cffb91cb802737f1d91b6be552"
 		},
 		"st": {
 			"_type": "sec_certs.sample.document_state.DocumentState",
@@ -1098,8 +1102,9 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "0a81c560fcdbfeee1165bf3c96d64fd3b07518a6bfdf33fb9f58f5cf29bb5779",
-			"txt_hash": "155dd5d49e53d403a117e5cfacab64afd1e150ceeeb4a84b76b6abde67dd1a09"
+			"source_hash": "0a81c560fcdbfeee1165bf3c96d64fd3b07518a6bfdf33fb9f58f5cf29bb5779",
+			"txt_hash": "155dd5d49e53d403a117e5cfacab64afd1e150ceeeb4a84b76b6abde67dd1a09",
+			"json_hash": "3f0b1252fe0726b900fa576a6c5346e236d983bf036a1a52e66db30221808cfd"
 		},
 		"cert": {
 			"_type": "sec_certs.sample.document_state.DocumentState",
@@ -1107,8 +1112,9 @@
 			"convert_garbage": false,
 			"convert_ok": false,
 			"extract_ok": false,
-			"pdf_hash": null,
-			"txt_hash": null
+			"source_hash": null,
+			"txt_hash": null,
+			"json_hash": null
 		}
 	},
 	"pdf_data": {
@@ -1996,8 +2002,9 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "6900408c92dbd88ced9b2d5caa7089a6ff4911c9d8130f1896734953972eaecb",
-			"txt_hash": "ae82395ac3623adeb01030433a768beacc1cc4510aa964b33b9bb4b3eabb58f1"
+			"source_hash": "6900408c92dbd88ced9b2d5caa7089a6ff4911c9d8130f1896734953972eaecb",
+			"txt_hash": "ae82395ac3623adeb01030433a768beacc1cc4510aa964b33b9bb4b3eabb58f1",
+			"json_hash": "ec83b91ea097c274ebb93c8ca67dd1167c4c4604f421ef92a6e4027889f15522"
 		},
 		"st": {
 			"_type": "sec_certs.sample.document_state.DocumentState",
@@ -2005,8 +2012,9 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "8cb071786715c1b6a51f512f6106ceb650e28d083a971529d1c04d52d0424cb1",
-			"txt_hash": "a6b17d5491e2f0c12a49d751bf91d5b20b65772b0c804df6a512909b5956afba"
+			"source_hash": "8cb071786715c1b6a51f512f6106ceb650e28d083a971529d1c04d52d0424cb1",
+			"txt_hash": "a6b17d5491e2f0c12a49d751bf91d5b20b65772b0c804df6a512909b5956afba",
+			"json_hash": "1a2aa199e257c6163e7576d2286074b3bca83d7ef7be6b3b07b1b90d8cf8a1e5"
 		},
 		"cert": {
 			"_type": "sec_certs.sample.document_state.DocumentState",
@@ -2014,8 +2022,9 @@
 			"convert_garbage": true,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "39455bc4e95c015a9e19aa537f6578735f2b9d920b3d31157080f2c772eae0f2",
-			"txt_hash": "f4341e76ec140e33941c937297602a8b0cf1297296a86bda1cefec934d7b4b1d"
+			"source_hash": "39455bc4e95c015a9e19aa537f6578735f2b9d920b3d31157080f2c772eae0f2",
+			"txt_hash": "f4341e76ec140e33941c937297602a8b0cf1297296a86bda1cefec934d7b4b1d",
+			"json_hash": "16d742f65bca009b2b125f9352c9ceefbd25b4da786812ba0bfc289a48494917"
 		}
 	},
 	"pdf_data": {
@@ -2704,8 +2713,9 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "a6c878382223c0d3f707da7b8fed3f5a86bcd2c45c5141c991a03c7219454552",
-			"txt_hash": "169e05f0c2a2a902ae6ac8b34ad058f18a95c7ac48a185503127e797ee8506d2"
+			"source_hash": "a6c878382223c0d3f707da7b8fed3f5a86bcd2c45c5141c991a03c7219454552",
+			"txt_hash": "169e05f0c2a2a902ae6ac8b34ad058f18a95c7ac48a185503127e797ee8506d2",
+			"json_hash": "f5b1c6265eaddd7e5898766266503825a4ff6c2eb1f1bb6dcccf1a5a9a207eb7"
 		},
 		"st": {
 			"_type": "sec_certs.sample.document_state.DocumentState",
@@ -2713,8 +2723,9 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "90f8571cb4ca3b572e28f702a5d81fe720f41fe9c354ef8da9d3de5b7cfba527",
-			"txt_hash": "cc31bfbb6e43ab9dbb149fb09e378648293eaf45cecf834f3565c9fd63a10221"
+			"source_hash": "90f8571cb4ca3b572e28f702a5d81fe720f41fe9c354ef8da9d3de5b7cfba527",
+			"txt_hash": "cc31bfbb6e43ab9dbb149fb09e378648293eaf45cecf834f3565c9fd63a10221",
+			"json_hash": "bcf6ddfb7e4203c6960c396965e885e7a09380b25bf99fbcbf8678468d9d9896"
 		},
 		"cert": {
 			"_type": "sec_certs.sample.document_state.DocumentState",
@@ -2722,8 +2733,9 @@
 			"convert_garbage": false,
 			"convert_ok": false,
 			"extract_ok": false,
-			"pdf_hash": null,
-			"txt_hash": null
+			"source_hash": null,
+			"txt_hash": null,
+			"json_hash": null
 		}
 	},
 	"pdf_data": {
@@ -3226,8 +3238,9 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "6fbc3b28d1be4672e7e2026d84ff715f8dc4bf7c1c6c4a3c4ad6a75da0764006",
-			"txt_hash": "fd83e127ccb79a51b00892334e29ef092b5c1c56c9c775ee36fcd1113fb2a0ca"
+			"source_hash": "6fbc3b28d1be4672e7e2026d84ff715f8dc4bf7c1c6c4a3c4ad6a75da0764006",
+			"txt_hash": "fd83e127ccb79a51b00892334e29ef092b5c1c56c9c775ee36fcd1113fb2a0ca",
+			"json_hash": "3383727bcd5e73bf7ea85b178f4e3b91cea98aac2189b1905a7ecf508469606f"
 		},
 		"st": {
 			"_type": "sec_certs.sample.document_state.DocumentState",
@@ -3235,8 +3248,9 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "ec092f763133271b508c753ab609a4619824da935b9456403766882d8ae57759",
-			"txt_hash": "96d35b228571591e8488fb184c60fae0532be3f536ce66fcb7cb56788f9b12ae"
+			"source_hash": "ec092f763133271b508c753ab609a4619824da935b9456403766882d8ae57759",
+			"txt_hash": "96d35b228571591e8488fb184c60fae0532be3f536ce66fcb7cb56788f9b12ae",
+			"json_hash": "5e75afc0536c9c7c13735c52968591e9b9358372eab78504d723da5391b5676d"
 		},
 		"cert": {
 			"_type": "sec_certs.sample.document_state.DocumentState",
@@ -3244,8 +3258,9 @@
 			"convert_garbage": false,
 			"convert_ok": false,
 			"extract_ok": false,
-			"pdf_hash": null,
-			"txt_hash": null
+			"source_hash": null,
+			"txt_hash": null,
+			"json_hash": null
 		}
 	},
 	"pdf_data": {
@@ -3961,8 +3976,9 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "512f1da62ce4f5835e8b31e36524bd134f7742b0faac623e92c9665a584a6ed2",
-			"txt_hash": "aa1315d75f2a52c82a16f6f5a20bd964cee5c4b2fcb48be2dc395da6bc196365"
+			"source_hash": "512f1da62ce4f5835e8b31e36524bd134f7742b0faac623e92c9665a584a6ed2",
+			"txt_hash": "aa1315d75f2a52c82a16f6f5a20bd964cee5c4b2fcb48be2dc395da6bc196365",
+			"json_hash": "280ed3f4cfd4184766657261650ae6bd94089284b7801df9c7e560ca88b7a1ae"
 		},
 		"st": {
 			"_type": "sec_certs.sample.document_state.DocumentState",
@@ -3970,8 +3986,9 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "a60c776ddd9b8ec08bb3c118665dabf5b1cd5d51d00a7fa4fec7920f56859557",
-			"txt_hash": "96f8d2f32e1f56eb718a302367ae57ac65331a0c15b64e859cbdf8fc40fc4976"
+			"source_hash": "a60c776ddd9b8ec08bb3c118665dabf5b1cd5d51d00a7fa4fec7920f56859557",
+			"txt_hash": "96f8d2f32e1f56eb718a302367ae57ac65331a0c15b64e859cbdf8fc40fc4976",
+			"json_hash": "72057d86555fdf79911b11d464aa069bbeee0bb6269be5c504c61a6a2c0c2f26"
 		},
 		"cert": {
 			"_type": "sec_certs.sample.document_state.DocumentState",
@@ -3979,8 +3996,9 @@
 			"convert_garbage": false,
 			"convert_ok": false,
 			"extract_ok": false,
-			"pdf_hash": null,
-			"txt_hash": null
+			"source_hash": null,
+			"txt_hash": null,
+			"json_hash": null
 		}
 	},
 	"pdf_data": {
@@ -4374,8 +4392,9 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "7f1504235e6203001d8a76829161dad2290439c3c12894114ea7f7c9af2e598b",
-			"txt_hash": "b72deb54b7d3a3c7d4e27a30d2b21b02943bd661fb0f55dbcf3cc559d5122f55"
+			"source_hash": "7f1504235e6203001d8a76829161dad2290439c3c12894114ea7f7c9af2e598b",
+			"txt_hash": "b72deb54b7d3a3c7d4e27a30d2b21b02943bd661fb0f55dbcf3cc559d5122f55",
+			"json_hash": "8c99d5ec13175364aea9b84c403e7bd0fe00a11815bf1332f3e765c702ea3b11"
 		},
 		"st": {
 			"_type": "sec_certs.sample.document_state.DocumentState",
@@ -4383,8 +4402,9 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "8ecc55bb7d90483234c84c1ef8e3aea602013c1585e69406bc137d231dc0f32c",
-			"txt_hash": "c10744f3c323cbe99996cfc8b0920f015b178f0a01a10a499893eb3ad1b88ea2"
+			"source_hash": "8ecc55bb7d90483234c84c1ef8e3aea602013c1585e69406bc137d231dc0f32c",
+			"txt_hash": "c10744f3c323cbe99996cfc8b0920f015b178f0a01a10a499893eb3ad1b88ea2",
+			"json_hash": "9850345a59a754102958ea024e8594ca8f057445c42b08195ab465729f287c70"
 		},
 		"cert": {
 			"_type": "sec_certs.sample.document_state.DocumentState",
@@ -4392,8 +4412,9 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "8a0e4a3f1fc96a5708a0abfe59a7e3be697280f725215c928a2191988585c544",
-			"txt_hash": "6ab337ad3cabd654b4207f25aede5eaf286ace65eaf13d94a4075eb09f230fb0"
+			"source_hash": "8a0e4a3f1fc96a5708a0abfe59a7e3be697280f725215c928a2191988585c544",
+			"txt_hash": "6ab337ad3cabd654b4207f25aede5eaf286ace65eaf13d94a4075eb09f230fb0",
+			"json_hash": "306a2b7d3ea70f0dd4c962d66db1dabe6149742596455102ea02ba55d7a67d31"
 		}
 	},
 	"pdf_data": {
@@ -5182,8 +5203,9 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "8dd4c4edd973a7e452c641db48c8eb33354f85e05844f701c90561e1c43a694d",
-			"txt_hash": "7483bc89235d6fc41cffa0952905a7fa4ea415e2556190e4f0b0c48e132685ed"
+			"source_hash": "8dd4c4edd973a7e452c641db48c8eb33354f85e05844f701c90561e1c43a694d",
+			"txt_hash": "7483bc89235d6fc41cffa0952905a7fa4ea415e2556190e4f0b0c48e132685ed",
+			"json_hash": "50866f078b07251a5764a47074fc65a2d3decca7cf2db8c1d2d6336d18dd8b69"
 		},
 		"st": {
 			"_type": "sec_certs.sample.document_state.DocumentState",
@@ -5191,8 +5213,9 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "9ec9bc244cd2cdfa133da188f67f6302f7086acec87b2c453d19e5b906713150",
-			"txt_hash": "fe1f6fa6f2e466702df203929aa00510b8e554f774195f4ef29eddf064801fdb"
+			"source_hash": "9ec9bc244cd2cdfa133da188f67f6302f7086acec87b2c453d19e5b906713150",
+			"txt_hash": "fe1f6fa6f2e466702df203929aa00510b8e554f774195f4ef29eddf064801fdb",
+			"json_hash": "31d2834acd0740f8cbb5ab636507d3252757db1c7f2ffe3092255f944f2b2f6d"
 		},
 		"cert": {
 			"_type": "sec_certs.sample.document_state.DocumentState",
@@ -5200,8 +5223,9 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "4cd0982b954a019eb3c343c539948aa268bca50a5e1b79de557393146da50220",
-			"txt_hash": "0a56c1990efb616ab129cad19db0ced8506235cb7e0511dfe8713d97d01153c0"
+			"source_hash": "9ec9bc244cd2cdfa133da188f67f6302f7086acec87b2c453d19e5b906713150",
+			"txt_hash": "0a56c1990efb616ab129cad19db0ced8506235cb7e0511dfe8713d97d01153c0",
+			"json_hash": "35348900cd0b0bae2f889b0b773a40a7bd6a06a94255c80512e973ec74da9a9c"
 		}
 	},
 	"pdf_data": {
@@ -6252,8 +6276,9 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "ef1e331d623caff5d9c2a8d69618406dea561d93e2ae41a86dbec88b7235d915",
-			"txt_hash": "b5100b444e1f1cbb511b4a25626c161a2eed6f4c38be913a47ac937a9a325bf3"
+			"source_hash": "ef1e331d623caff5d9c2a8d69618406dea561d93e2ae41a86dbec88b7235d915",
+			"txt_hash": "b5100b444e1f1cbb511b4a25626c161a2eed6f4c38be913a47ac937a9a325bf3",
+			"json_hash": "853312bbf9ef8c1c13ba570fe6b5a5a4e7483f0176a5b7c71a39ce92dfc45540"
 		},
 		"st": {
 			"_type": "sec_certs.sample.document_state.DocumentState",
@@ -6261,8 +6286,9 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "f82ad5e1cee4bcfcae9d7cbaf04b045331c17d93664a6e84df6b0ceb3f5a1268",
-			"txt_hash": "6e4019d8338c73fa8565073c764dd5399c635d7068e8762da83dd0f1bfaed7bf"
+			"source_hash": "f82ad5e1cee4bcfcae9d7cbaf04b045331c17d93664a6e84df6b0ceb3f5a1268",
+			"txt_hash": "6e4019d8338c73fa8565073c764dd5399c635d7068e8762da83dd0f1bfaed7bf",
+			"json_hash": "5e911431f17519aeb3877187e292761362e6833281675fbc6bd6d71d4f8efbf6"
 		},
 		"cert": {
 			"_type": "sec_certs.sample.document_state.DocumentState",
@@ -6270,8 +6296,9 @@
 			"convert_garbage": true,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "f7c91a1b171bde1b889ea01e4c1c7c7453a9e6519c661265cfce39ffad6b6123",
-			"txt_hash": "c60e2f8d622969b2f2d95e03e43c1b41d2f292ef85d39416ebad98a6cf3dceaa"
+			"source_hash": "f7c91a1b171bde1b889ea01e4c1c7c7453a9e6519c661265cfce39ffad6b6123",
+			"txt_hash": "c60e2f8d622969b2f2d95e03e43c1b41d2f292ef85d39416ebad98a6cf3dceaa",
+			"json_hash": "72f61b7feaa96fc5a68450d98f922248241ae8b548dc2df5947a7bee78ebe9c7"
 		}
 	},
 	"pdf_data": {
@@ -7093,8 +7120,9 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "3ac839d1ef5db4ced5bbf9efbcf8198a6a3dd6ebed3d6dc92ae1dc81aef72a9f",
-			"txt_hash": "d755e77be9c6b423acc65511df48fa0e92a8a1290b373272601bef2ccaef453d"
+			"source_hash": "3ac839d1ef5db4ced5bbf9efbcf8198a6a3dd6ebed3d6dc92ae1dc81aef72a9f",
+			"txt_hash": "d755e77be9c6b423acc65511df48fa0e92a8a1290b373272601bef2ccaef453d",
+			"json_hash": "fefecca5d688cc83d940f462492ca9ad12edd7ffeeea331b187591c0156425d9"
 		},
 		"st": {
 			"_type": "sec_certs.sample.document_state.DocumentState",
@@ -7102,8 +7130,9 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "152484a7247105fb4bcdfbb13c6e13a83c03bc737486e802b35b3c0b1296b220",
-			"txt_hash": "b62e7c1f834374fde5c0a8253f1d4724403507673f5a767f00762972f569e255"
+			"source_hash": "152484a7247105fb4bcdfbb13c6e13a83c03bc737486e802b35b3c0b1296b220",
+			"txt_hash": "b62e7c1f834374fde5c0a8253f1d4724403507673f5a767f00762972f569e255",
+			"json_hash": "121703b0f9d841892128d5235156324c50b7cf437ef12b43cf9b5cc95abc3c57"
 		},
 		"cert": {
 			"_type": "sec_certs.sample.document_state.DocumentState",
@@ -7111,8 +7140,9 @@
 			"convert_garbage": true,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "ee0900cf79bde6803939a2be5b73daa8aeafcb308537e30d0692edf2a59130b1",
-			"txt_hash": "cb483314f2ca894958c836cdbc56f88415d7ae8695fcf6d6160506af40e6c56b"
+			"source_hash": "ee0900cf79bde6803939a2be5b73daa8aeafcb308537e30d0692edf2a59130b1",
+			"txt_hash": "cb483314f2ca894958c836cdbc56f88415d7ae8695fcf6d6160506af40e6c56b",
+			"json_hash": "5caf141be0c3c2b0e9d8f1a197771e73bacc4732f9a091ec4a5693754a6be484"
 		}
 	},
 	"pdf_data": {
@@ -7814,8 +7844,9 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "a2fe7f1c2e1be47f06363ecbfab39a87b0d23ca34e7c3aa365df65c14b47bf51",
-			"txt_hash": "d6ac0d7185d4fa38fa98dc98146ddf4b6ea9ea01f39e55e34e7a1154bedade64"
+			"source_hash": "a2fe7f1c2e1be47f06363ecbfab39a87b0d23ca34e7c3aa365df65c14b47bf51",
+			"txt_hash": "d6ac0d7185d4fa38fa98dc98146ddf4b6ea9ea01f39e55e34e7a1154bedade64",
+			"json_hash": "6cfe3e850db319b44ced3203e87df5cae6646c4a16ef4d41dd8336ed0cdd7ffa"
 		},
 		"st": {
 			"_type": "sec_certs.sample.document_state.DocumentState",
@@ -7823,8 +7854,9 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "2653ed6302e324c0bd7e28d37d670f6a06c261a2efcc3d4a58516987c7cf1bdb",
-			"txt_hash": "70071e2450c0e9406b73cb05b1b478c1c19780f674a5819fd8dd3616810a41d9"
+			"source_hash": "2653ed6302e324c0bd7e28d37d670f6a06c261a2efcc3d4a58516987c7cf1bdb",
+			"txt_hash": "70071e2450c0e9406b73cb05b1b478c1c19780f674a5819fd8dd3616810a41d9",
+			"json_hash": "4f509e4477ee9a068af52bbf5c0989af17362dc733c066073f23e1c2e2d78644"
 		},
 		"cert": {
 			"_type": "sec_certs.sample.document_state.DocumentState",
@@ -7832,8 +7864,9 @@
 			"convert_garbage": false,
 			"convert_ok": false,
 			"extract_ok": false,
-			"pdf_hash": null,
-			"txt_hash": null
+			"source_hash": null,
+			"txt_hash": null,
+			"json_hash": null
 		}
 	},
 	"pdf_data": {
@@ -8754,8 +8787,9 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "089411731eb98ce7d5db0a412ad0c2454a5879ce69cbf14f4ad8a6835ff51150",
-			"txt_hash": "ed68d88a4f19c0647798f9f3310b65fdd08ede647d1811214b7b27719d008e58"
+			"source_hash": "089411731eb98ce7d5db0a412ad0c2454a5879ce69cbf14f4ad8a6835ff51150",
+			"txt_hash": "ed68d88a4f19c0647798f9f3310b65fdd08ede647d1811214b7b27719d008e58",
+			"json_hash": "db13251297ee4056e2ecf2c993914617c2c36f4081fde0401d9f433b92e4a31e"
 		},
 		"st": {
 			"_type": "sec_certs.sample.document_state.DocumentState",
@@ -8763,8 +8797,9 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "fbc9605c42f92dbaba8fc84b282b8fcea7376b123b0c9a646d59835df7690899",
-			"txt_hash": "ec775d534c9d647b4aff65b2835e9ef67c77f7e843c3fc7b47e2e32f099c2a57"
+			"source_hash": "fbc9605c42f92dbaba8fc84b282b8fcea7376b123b0c9a646d59835df7690899",
+			"txt_hash": "ec775d534c9d647b4aff65b2835e9ef67c77f7e843c3fc7b47e2e32f099c2a57",
+			"json_hash": "729a72a3042d359461825a00130cf077fccfec5d0ba0a2e03c98eb90e323bc2f"
 		},
 		"cert": {
 			"_type": "sec_certs.sample.document_state.DocumentState",
@@ -8772,8 +8807,9 @@
 			"convert_garbage": true,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "85ea73592ba0bef4cac8117e97fdfb1ecb6d73cdf906fb00243a561cc3d87795",
-			"txt_hash": "5d8b4031853238bb052f2555556d0aaae45170f6cff56c3786e13e8e5c227739"
+			"source_hash": "85ea73592ba0bef4cac8117e97fdfb1ecb6d73cdf906fb00243a561cc3d87795",
+			"txt_hash": "5d8b4031853238bb052f2555556d0aaae45170f6cff56c3786e13e8e5c227739",
+			"json_hash": "58f4236ecbe327f950399af87a46ebd19a9fc7dd24b2d2e969627b4610400662"
 		}
 	},
 	"pdf_data": {

--- a/tests/functional/data/mongo/cc_diff.json
+++ b/tests/functional/data/mongo/cc_diff.json
@@ -2606,17 +2606,39 @@
 					"report": {
 						"__update__": {
 							"_type": "sec_certs.sample.document_state.DocumentState"
-						}
+						},
+						"__insert__": {
+							"source_hash": "8dd4c4edd973a7e452c641db48c8eb33354f85e05844f701c90561e1c43a694d",
+							"json_hash": "50866f078b07251a5764a47074fc65a2d3decca7cf2db8c1d2d6336d18dd8b69"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					},
 					"st": {
 						"__update__": {
 							"_type": "sec_certs.sample.document_state.DocumentState"
-						}
+
+						},
+						"__insert__": {
+							"source_hash": "9ec9bc244cd2cdfa133da188f67f6302f7086acec87b2c453d19e5b906713150",
+							"json_hash": "31d2834acd0740f8cbb5ab636507d3252757db1c7f2ffe3092255f944f2b2f6d"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					},
 					"cert": {
 						"__update__": {
 							"_type": "sec_certs.sample.document_state.DocumentState"
-						}
+						},
+						"__insert__": {
+							"source_hash": "9ec9bc244cd2cdfa133da188f67f6302f7086acec87b2c453d19e5b906713150",
+							"json_hash": "35348900cd0b0bae2f889b0b773a40a7bd6a06a94255c80512e973ec74da9a9c"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					}
 				}
 			},
@@ -4981,17 +5003,39 @@
 					"report": {
 						"__update__": {
 							"_type": "sec_certs.sample.document_state.DocumentState"
-						}
+						},
+						"__insert__": {
+							"source_hash": "fe165dd9a7399dd5063f6a051bb9fab2de906f3949f9e9bf08df22d6d67818d2",
+							"json_hash": "fc7a035b5f4233b73ff2f94cfeb126a43766809dd0a0a36bf6dcabfcf3df7818"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					},
 					"st": {
 						"__update__": {
 							"_type": "sec_certs.sample.document_state.DocumentState"
-						}
+
+						},
+						"__insert__": {
+							"source_hash": "d57ff01507ab99d75e185c1ebde2bcb03553e139ff3b4d7833d34fc2f6ff3acd",
+							"json_hash": "15ca950b56c98c71e44f68aeecacf71b9d305c1e6824d141dfc80cea5442d136"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					},
 					"cert": {
 						"__update__": {
 							"_type": "sec_certs.sample.document_state.DocumentState"
-						}
+						},
+						"__insert__": {
+							"source_hash": "589838ef5e10753b89f5d8e845950bdf5786142e158f0bf44cdce323bd9bfaf4",
+							"json_hash": "996a375e82013b4397b199938f52404f876e710d6d373cd78a64c9fce08193d5"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					}
 				}
 			},
@@ -6876,18 +6920,41 @@
 					"report": {
 						"__update__": {
 							"_type": "sec_certs.sample.document_state.DocumentState"
-						}
+						},
+						"__insert__": {
+							"source_hash": "f1840e2ef500d15093d5f552581bb9a972d757c30d157bcf45d7fbc7fdb4a745",
+							"json_hash": "7fb9ec41da97057621de8c6f06f1738fe428f3cffb91cb802737f1d91b6be552"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					},
 					"st": {
 						"__update__": {
 							"_type": "sec_certs.sample.document_state.DocumentState"
-						}
+
+						},
+						"__insert__": {
+							"source_hash": "0a81c560fcdbfeee1165bf3c96d64fd3b07518a6bfdf33fb9f58f5cf29bb5779",
+							"json_hash": "3f0b1252fe0726b900fa576a6c5346e236d983bf036a1a52e66db30221808cfd"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					},
 					"cert": {
 						"__update__": {
 							"_type": "sec_certs.sample.document_state.DocumentState"
-						}
+						},
+						"__insert__": {
+							"source_hash": null,
+							"json_hash": null
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					}
+
 				}
 			},
 			"heuristics": {
@@ -7860,18 +7927,41 @@
 					"report": {
 						"__update__": {
 							"_type": "sec_certs.sample.document_state.DocumentState"
-						}
+						},
+						"__insert__": {
+							"source_hash": "512f1da62ce4f5835e8b31e36524bd134f7742b0faac623e92c9665a584a6ed2",
+							"json_hash": "280ed3f4cfd4184766657261650ae6bd94089284b7801df9c7e560ca88b7a1ae"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					},
 					"st": {
 						"__update__": {
 							"_type": "sec_certs.sample.document_state.DocumentState"
-						}
+
+						},
+						"__insert__": {
+							"source_hash": "a60c776ddd9b8ec08bb3c118665dabf5b1cd5d51d00a7fa4fec7920f56859557",
+							"json_hash": "72057d86555fdf79911b11d464aa069bbeee0bb6269be5c504c61a6a2c0c2f26"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					},
 					"cert": {
 						"__update__": {
 							"_type": "sec_certs.sample.document_state.DocumentState"
-						}
+						},
+						"__insert__": {
+							"source_hash": null,
+							"json_hash": null
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					}
+
 				}
 			},
 			"heuristics": {
@@ -9994,18 +10084,41 @@
 					"report": {
 						"__update__": {
 							"_type": "sec_certs.sample.document_state.DocumentState"
-						}
+						},
+						"__insert__": {
+							"source_hash": "a2fe7f1c2e1be47f06363ecbfab39a87b0d23ca34e7c3aa365df65c14b47bf51",
+							"json_hash": "6cfe3e850db319b44ced3203e87df5cae6646c4a16ef4d41dd8336ed0cdd7ffa"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					},
 					"st": {
 						"__update__": {
 							"_type": "sec_certs.sample.document_state.DocumentState"
-						}
+
+						},
+						"__insert__": {
+							"source_hash": "2653ed6302e324c0bd7e28d37d670f6a06c261a2efcc3d4a58516987c7cf1bdb",
+							"json_hash": "4f509e4477ee9a068af52bbf5c0989af17362dc733c066073f23e1c2e2d78644"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					},
 					"cert": {
 						"__update__": {
 							"_type": "sec_certs.sample.document_state.DocumentState"
-						}
+						},
+						"__insert__": {
+							"source_hash": null,
+							"json_hash": null
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					}
+
 				}
 			},
 			"heuristics": {
@@ -11175,18 +11288,41 @@
 					"report": {
 						"__update__": {
 							"_type": "sec_certs.sample.document_state.DocumentState"
-						}
+						},
+						"__insert__": {
+							"source_hash": "a6c878382223c0d3f707da7b8fed3f5a86bcd2c45c5141c991a03c7219454552",
+							"json_hash": "f5b1c6265eaddd7e5898766266503825a4ff6c2eb1f1bb6dcccf1a5a9a207eb7"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					},
 					"st": {
 						"__update__": {
 							"_type": "sec_certs.sample.document_state.DocumentState"
-						}
+
+						},
+						"__insert__": {
+							"source_hash": "90f8571cb4ca3b572e28f702a5d81fe720f41fe9c354ef8da9d3de5b7cfba527",
+							"json_hash": "bcf6ddfb7e4203c6960c396965e885e7a09380b25bf99fbcbf8678468d9d9896"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					},
 					"cert": {
 						"__update__": {
 							"_type": "sec_certs.sample.document_state.DocumentState"
-						}
+						},
+						"__insert__": {
+							"source_hash": null,
+							"json_hash": null
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					}
+
 				}
 			},
 			"heuristics": {
@@ -12937,17 +13073,39 @@
 					"report": {
 						"__update__": {
 							"_type": "sec_certs.sample.document_state.DocumentState"
-						}
+						},
+						"__insert__": {
+							"source_hash": "7f1504235e6203001d8a76829161dad2290439c3c12894114ea7f7c9af2e598b",
+							"json_hash": "8c99d5ec13175364aea9b84c403e7bd0fe00a11815bf1332f3e765c702ea3b11"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					},
 					"st": {
 						"__update__": {
 							"_type": "sec_certs.sample.document_state.DocumentState"
-						}
+
+						},
+						"__insert__": {
+							"source_hash": "8ecc55bb7d90483234c84c1ef8e3aea602013c1585e69406bc137d231dc0f32c",
+							"json_hash": "9850345a59a754102958ea024e8594ca8f057445c42b08195ab465729f287c70"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					},
 					"cert": {
 						"__update__": {
 							"_type": "sec_certs.sample.document_state.DocumentState"
-						}
+						},
+						"__insert__": {
+							"source_hash": "8a0e4a3f1fc96a5708a0abfe59a7e3be697280f725215c928a2191988585c544",
+							"json_hash": "306a2b7d3ea70f0dd4c962d66db1dabe6149742596455102ea02ba55d7a67d31"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					}
 				}
 			},
@@ -14709,17 +14867,39 @@
 					"report": {
 						"__update__": {
 							"_type": "sec_certs.sample.document_state.DocumentState"
-						}
+						},
+						"__insert__": {
+							"source_hash": "6900408c92dbd88ced9b2d5caa7089a6ff4911c9d8130f1896734953972eaecb",
+							"json_hash": "ec83b91ea097c274ebb93c8ca67dd1167c4c4604f421ef92a6e4027889f15522"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					},
 					"st": {
 						"__update__": {
 							"_type": "sec_certs.sample.document_state.DocumentState"
-						}
+
+						},
+						"__insert__": {
+							"source_hash": "8cb071786715c1b6a51f512f6106ceb650e28d083a971529d1c04d52d0424cb1",
+							"json_hash": "1a2aa199e257c6163e7576d2286074b3bca83d7ef7be6b3b07b1b90d8cf8a1e5"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					},
 					"cert": {
 						"__update__": {
 							"_type": "sec_certs.sample.document_state.DocumentState"
-						}
+						},
+						"__insert__": {
+							"source_hash": "39455bc4e95c015a9e19aa537f6578735f2b9d920b3d31157080f2c772eae0f2",
+							"json_hash": "16d742f65bca009b2b125f9352c9ceefbd25b4da786812ba0bfc289a48494917"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					}
 				}
 			},
@@ -15926,17 +16106,39 @@
 					"report": {
 						"__update__": {
 							"_type": "sec_certs.sample.document_state.DocumentState"
-						}
+						},
+						"__insert__": {
+							"source_hash": "089411731eb98ce7d5db0a412ad0c2454a5879ce69cbf14f4ad8a6835ff51150",
+							"json_hash": "db13251297ee4056e2ecf2c993914617c2c36f4081fde0401d9f433b92e4a31e"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					},
 					"st": {
 						"__update__": {
 							"_type": "sec_certs.sample.document_state.DocumentState"
-						}
+
+						},
+						"__insert__": {
+							"source_hash": "fbc9605c42f92dbaba8fc84b282b8fcea7376b123b0c9a646d59835df7690899",
+							"json_hash": "729a72a3042d359461825a00130cf077fccfec5d0ba0a2e03c98eb90e323bc2f"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					},
 					"cert": {
 						"__update__": {
 							"_type": "sec_certs.sample.document_state.DocumentState"
-						}
+						},
+						"__insert__": {
+							"source_hash": "85ea73592ba0bef4cac8117e97fdfb1ecb6d73cdf906fb00243a561cc3d87795",
+							"json_hash": "58f4236ecbe327f950399af87a46ebd19a9fc7dd24b2d2e969627b4610400662"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					}
 				}
 			},
@@ -17785,18 +17987,41 @@
 					"report": {
 						"__update__": {
 							"_type": "sec_certs.sample.document_state.DocumentState"
-						}
+						},
+						"__insert__": {
+							"source_hash": "3ac839d1ef5db4ced5bbf9efbcf8198a6a3dd6ebed3d6dc92ae1dc81aef72a9f",
+							"json_hash": "fefecca5d688cc83d940f462492ca9ad12edd7ffeeea331b187591c0156425d9"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					},
 					"st": {
 						"__update__": {
 							"_type": "sec_certs.sample.document_state.DocumentState"
-						}
+
+						},
+						"__insert__": {
+							"source_hash": "152484a7247105fb4bcdfbb13c6e13a83c03bc737486e802b35b3c0b1296b220",
+							"json_hash": "121703b0f9d841892128d5235156324c50b7cf437ef12b43cf9b5cc95abc3c57"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					},
 					"cert": {
 						"__update__": {
 							"_type": "sec_certs.sample.document_state.DocumentState"
-						}
+						},
+						"__insert__": {
+							"source_hash": "ee0900cf79bde6803939a2be5b73daa8aeafcb308537e30d0692edf2a59130b1",
+							"json_hash": "5caf141be0c3c2b0e9d8f1a197771e73bacc4732f9a091ec4a5693754a6be484"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					}
+
 				}
 			},
 			"heuristics": {
@@ -19788,18 +20013,41 @@
 					"report": {
 						"__update__": {
 							"_type": "sec_certs.sample.document_state.DocumentState"
-						}
+						},
+						"__insert__": {
+							"source_hash": "6fbc3b28d1be4672e7e2026d84ff715f8dc4bf7c1c6c4a3c4ad6a75da0764006",
+							"json_hash": "3383727bcd5e73bf7ea85b178f4e3b91cea98aac2189b1905a7ecf508469606f"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					},
 					"st": {
 						"__update__": {
 							"_type": "sec_certs.sample.document_state.DocumentState"
-						}
+
+						},
+						"__insert__": {
+							"source_hash": "ec092f763133271b508c753ab609a4619824da935b9456403766882d8ae57759",
+							"json_hash": "5e75afc0536c9c7c13735c52968591e9b9358372eab78504d723da5391b5676d"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					},
 					"cert": {
 						"__update__": {
 							"_type": "sec_certs.sample.document_state.DocumentState"
-						}
+						},
+						"__insert__": {
+							"source_hash": null,
+							"json_hash": null
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					}
+
 				}
 			},
 			"heuristics": {
@@ -21768,18 +22016,41 @@
 					"report": {
 						"__update__": {
 							"_type": "sec_certs.sample.document_state.DocumentState"
-						}
+						},
+						"__insert__": {
+							"source_hash": "ef1e331d623caff5d9c2a8d69618406dea561d93e2ae41a86dbec88b7235d915",
+							"json_hash": "853312bbf9ef8c1c13ba570fe6b5a5a4e7483f0176a5b7c71a39ce92dfc45540"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					},
 					"st": {
 						"__update__": {
 							"_type": "sec_certs.sample.document_state.DocumentState"
-						}
+
+						},
+						"__insert__": {
+							"source_hash": "f82ad5e1cee4bcfcae9d7cbaf04b045331c17d93664a6e84df6b0ceb3f5a1268",
+							"json_hash": "5e911431f17519aeb3877187e292761362e6833281675fbc6bd6d71d4f8efbf6"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					},
 					"cert": {
 						"__update__": {
 							"_type": "sec_certs.sample.document_state.DocumentState"
-						}
+						},
+						"__insert__": {
+							"source_hash": "f7c91a1b171bde1b889ea01e4c1c7c7453a9e6519c661265cfce39ffad6b6123",
+							"json_hash": "72f61b7feaa96fc5a68450d98f922248241ae8b548dc2df5947a7bee78ebe9c7"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					}
+
 				}
 			},
 			"heuristics": {

--- a/tests/functional/data/mongo/fips.json
+++ b/tests/functional/data/mongo/fips.json
@@ -146,14 +146,26 @@
 	},
 	"state": {
 		"_type": "sec_certs.sample.fips.FIPSCertificate.InternalState",
-		"module_download_ok": true,
-		"policy_download_ok": true,
-		"policy_convert_garbage": true,
-		"policy_convert_ok": true,
-		"module_extract_ok": true,
-		"policy_extract_ok": true,
-		"policy_pdf_hash": "e85d2b3dceae2285830e03819c255d22a691aaa340b735a497e79685a8ae4c27",
-		"policy_txt_hash": "f2a653b4879554630ac981eb9c28119e9689b9fa3abbff2e82c486f2a73dfccc"
+		"module": {
+			"_type": "sec_certs.sample.document_state.DocumentState",
+			"download_ok": true,
+			"convert_garbage": false,
+			"convert_ok": true,
+			"extract_ok": true,
+			"source_hash": null,
+			"txt_hash": null,
+			"json_hash": null
+		},
+		"policy": {
+			"_type": "sec_certs.sample.document_state.DocumentState",
+			"download_ok": true,
+			"convert_garbage": false,
+			"convert_ok": true,
+			"extract_ok": true,
+			"source_hash": "e85d2b3dceae2285830e03819c255d22a691aaa340b735a497e79685a8ae4c27",
+			"txt_hash": "f2a653b4879554630ac981eb9c28119e9689b9fa3abbff2e82c486f2a73dfccc",
+			"json_hash": "651373b50dcdaffd547269bf56149e42038c4abeb7a3fd5c36b3e36aba67c728"
+		}
 	}
 },
 {
@@ -436,14 +448,26 @@
 	},
 	"state": {
 		"_type": "sec_certs.sample.fips.FIPSCertificate.InternalState",
-		"module_download_ok": true,
-		"policy_download_ok": true,
-		"policy_convert_garbage": false,
-		"policy_convert_ok": true,
-		"module_extract_ok": true,
-		"policy_extract_ok": true,
-		"policy_pdf_hash": "2dea082518933e794bcce27efb708bbb0c95243df4e89ee6005c4f65c9afc6b2",
-		"policy_txt_hash": "f2173fa3706d9c93c7a68883697e737b6709822acc8cca72b8c87fb8be2393de"
+		"module": {
+			"_type": "sec_certs.sample.document_state.DocumentState",
+			"download_ok": true,
+			"convert_garbage": false,
+			"convert_ok": true,
+			"extract_ok": true,
+			"source_hash": null,
+			"txt_hash": null,
+			"json_hash": null
+		},
+		"policy": {
+			"_type": "sec_certs.sample.document_state.DocumentState",
+			"download_ok": true,
+			"convert_garbage": false,
+			"convert_ok": true,
+			"extract_ok": true,
+			"source_hash": "2dea082518933e794bcce27efb708bbb0c95243df4e89ee6005c4f65c9afc6b2",
+			"txt_hash": "f2173fa3706d9c93c7a68883697e737b6709822acc8cca72b8c87fb8be2393de",
+			"json_hash": "c0e4b55c50156cce63737dfea2b64b4f8b03be049f4d26a1b1eab6ee58c046af"
+		}
 	}
 },
 {
@@ -800,14 +824,26 @@
 	},
 	"state": {
 		"_type": "sec_certs.sample.fips.FIPSCertificate.InternalState",
-		"module_download_ok": true,
-		"policy_download_ok": true,
-		"policy_convert_garbage": false,
-		"policy_convert_ok": true,
-		"module_extract_ok": true,
-		"policy_extract_ok": true,
-		"policy_pdf_hash": "c7305b318364bfcd082579022ef5e2c52a05f5cbb9c6c7086e880da3235eca93",
-		"policy_txt_hash": "b79ff5b0885fb9e6d6fb39b50aafec0dba25425c44bcc24c656c7acbffb944ef"
+		"module": {
+			"_type": "sec_certs.sample.document_state.DocumentState",
+			"download_ok": true,
+			"convert_garbage": false,
+			"convert_ok": true,
+			"extract_ok": true,
+			"source_hash": null,
+			"txt_hash": null,
+			"json_hash": null
+		},
+		"policy": {
+			"_type": "sec_certs.sample.document_state.DocumentState",
+			"download_ok": true,
+			"convert_garbage": false,
+			"convert_ok": true,
+			"extract_ok": true,
+			"source_hash": "c7305b318364bfcd082579022ef5e2c52a05f5cbb9c6c7086e880da3235eca93",
+			"txt_hash": "b79ff5b0885fb9e6d6fb39b50aafec0dba25425c44bcc24c656c7acbffb944ef",
+			"json_hash": "350d8b1517f7d46e2598223c7fceec360101252e7db85c806ec8b3f0388944a4"
+		}
 	}
 },
 {
@@ -1165,14 +1201,26 @@
 	},
 	"state": {
 		"_type": "sec_certs.sample.fips.FIPSCertificate.InternalState",
-		"module_download_ok": true,
-		"policy_download_ok": true,
-		"policy_convert_garbage": false,
-		"policy_convert_ok": true,
-		"module_extract_ok": true,
-		"policy_extract_ok": true,
-		"policy_pdf_hash": "9609ce126a5b9716ed814a6cf80c4961178bce82099ba22756b745d84294c090",
-		"policy_txt_hash": "3ae75390122b6e601c736cee575c1be45faa896858c8026cd14b12e4944853df"
+		"module": {
+			"_type": "sec_certs.sample.document_state.DocumentState",
+			"download_ok": true,
+			"convert_garbage": false,
+			"convert_ok": true,
+			"extract_ok": true,
+			"source_hash": null,
+			"txt_hash": null,
+			"json_hash": null
+		},
+		"policy": {
+			"_type": "sec_certs.sample.document_state.DocumentState",
+			"download_ok": true,
+			"convert_garbage": false,
+			"convert_ok": true,
+			"extract_ok": true,
+			"source_hash": "9609ce126a5b9716ed814a6cf80c4961178bce82099ba22756b745d84294c090",
+			"txt_hash": "3ae75390122b6e601c736cee575c1be45faa896858c8026cd14b12e4944853df",
+			"json_hash": "db346483aade7452b98184686d2b7ae13289a0a13fcd1d939e4592237562f3f9"
+		}
 	}
 },
 {
@@ -1445,14 +1493,26 @@
 	},
 	"state": {
 		"_type": "sec_certs.sample.fips.FIPSCertificate.InternalState",
-		"module_download_ok": true,
-		"policy_download_ok": true,
-		"policy_convert_garbage": false,
-		"policy_convert_ok": true,
-		"module_extract_ok": true,
-		"policy_extract_ok": true,
-		"policy_pdf_hash": "10835848c2f2a88514aac49bb1fc7c2394cc3153d5436fa14e0e55b36ecacdeb",
-		"policy_txt_hash": "f78936cf9faf03e15f980dc0d9e6478de9983f2e3a45e374d8280f6854c373e9"
+		"module": {
+			"_type": "sec_certs.sample.document_state.DocumentState",
+			"download_ok": true,
+			"convert_garbage": false,
+			"convert_ok": true,
+			"extract_ok": true,
+			"source_hash": null,
+			"txt_hash": null,
+			"json_hash": null
+		},
+		"policy": {
+			"_type": "sec_certs.sample.document_state.DocumentState",
+			"download_ok": true,
+			"convert_garbage": false,
+			"convert_ok": true,
+			"extract_ok": true,
+			"source_hash": "10835848c2f2a88514aac49bb1fc7c2394cc3153d5436fa14e0e55b36ecacdeb",
+			"txt_hash": "f78936cf9faf03e15f980dc0d9e6478de9983f2e3a45e374d8280f6854c373e9",
+			"json_hash": "f39ba0008a95f50211011f19b16924621795bce1cac036ad52d505235dce8605"
+		}
 	}
 },
 {
@@ -1774,14 +1834,26 @@
 	},
 	"state": {
 		"_type": "sec_certs.sample.fips.FIPSCertificate.InternalState",
-		"module_download_ok": true,
-		"policy_download_ok": true,
-		"policy_convert_garbage": false,
-		"policy_convert_ok": true,
-		"module_extract_ok": true,
-		"policy_extract_ok": true,
-		"policy_pdf_hash": "f9c624b080c2ff6e3ff24c03ce58aa5944f1566190e7c26482f3251c138ea0cf",
-		"policy_txt_hash": "863ca04cb2f5f3a33499440b8e8f8ad69038557831a527534b8b0133141c136e"
+		"module": {
+			"_type": "sec_certs.sample.document_state.DocumentState",
+			"download_ok": true,
+			"convert_garbage": false,
+			"convert_ok": true,
+			"extract_ok": true,
+			"source_hash": null,
+			"txt_hash": null,
+			"json_hash": null
+		},
+		"policy": {
+			"_type": "sec_certs.sample.document_state.DocumentState",
+			"download_ok": true,
+			"convert_garbage": false,
+			"convert_ok": true,
+			"extract_ok": true,
+			"source_hash": "f9c624b080c2ff6e3ff24c03ce58aa5944f1566190e7c26482f3251c138ea0cf",
+			"txt_hash": "863ca04cb2f5f3a33499440b8e8f8ad69038557831a527534b8b0133141c136e",
+			"json_hash": "029937f5edef3d8add3d8e0d249480e97eb9bdab8886518eba8133d45a9e645f"
+		}
 	}
 },
 {
@@ -2133,14 +2205,26 @@
 	},
 	"state": {
 		"_type": "sec_certs.sample.fips.FIPSCertificate.InternalState",
-		"module_download_ok": true,
-		"policy_download_ok": true,
-		"policy_convert_garbage": false,
-		"policy_convert_ok": true,
-		"module_extract_ok": true,
-		"policy_extract_ok": true,
-		"policy_pdf_hash": "3d653c513f816e3f97a1481ba9477a037b83281b13c0d29e45b9c2ffd089b03f",
-		"policy_txt_hash": "450a27673c4a87677fdafdcd9405a017b3bf6e4bea98a2effa19e3ebf14cd810"
+		"module": {
+			"_type": "sec_certs.sample.document_state.DocumentState",
+			"download_ok": true,
+			"convert_garbage": false,
+			"convert_ok": true,
+			"extract_ok": true,
+			"source_hash": null,
+			"txt_hash": null,
+			"json_hash": null
+		},
+		"policy": {
+			"_type": "sec_certs.sample.document_state.DocumentState",
+			"download_ok": true,
+			"convert_garbage": false,
+			"convert_ok": true,
+			"extract_ok": true,
+			"source_hash": "3d653c513f816e3f97a1481ba9477a037b83281b13c0d29e45b9c2ffd089b03f",
+			"txt_hash": "450a27673c4a87677fdafdcd9405a017b3bf6e4bea98a2effa19e3ebf14cd810",
+			"json_hash": "7755440c24f6d738debc1de0c8f935f0ecc868027b22d7ddf9816f8910dbfef3"
+		}
 	}
 },
 {
@@ -2371,14 +2455,26 @@
 	},
 	"state": {
 		"_type": "sec_certs.sample.fips.FIPSCertificate.InternalState",
-		"module_download_ok": true,
-		"policy_download_ok": true,
-		"policy_convert_garbage": false,
-		"policy_convert_ok": true,
-		"module_extract_ok": true,
-		"policy_extract_ok": true,
-		"policy_pdf_hash": "391714adb4cb0ad11447f81ef6d7c8a1fcaee27e6c65542e42d3273c9a5cba97",
-		"policy_txt_hash": "c5afc790293023dd1c13f884ecff9a76ded8425573a4c25c7c15c95c67956b43"
+		"module": {
+			"_type": "sec_certs.sample.document_state.DocumentState",
+			"download_ok": true,
+			"convert_garbage": false,
+			"convert_ok": true,
+			"extract_ok": true,
+			"source_hash": null,
+			"txt_hash": null,
+			"json_hash": null
+		},
+		"policy": {
+			"_type": "sec_certs.sample.document_state.DocumentState",
+			"download_ok": true,
+			"convert_garbage": false,
+			"convert_ok": true,
+			"extract_ok": true,
+			"source_hash": "391714adb4cb0ad11447f81ef6d7c8a1fcaee27e6c65542e42d3273c9a5cba97",
+			"txt_hash": "c5afc790293023dd1c13f884ecff9a76ded8425573a4c25c7c15c95c67956b43",
+			"json_hash": "cf0daa83f5bd16537a87231a491a7e1920bc94331c7ac4e3ffa8b1a3ddde9ead"
+		}
 	}
 },
 {
@@ -2712,14 +2808,26 @@
 	},
 	"state": {
 		"_type": "sec_certs.sample.fips.FIPSCertificate.InternalState",
-		"module_download_ok": true,
-		"policy_download_ok": true,
-		"policy_convert_garbage": false,
-		"policy_convert_ok": true,
-		"module_extract_ok": true,
-		"policy_extract_ok": true,
-		"policy_pdf_hash": "303965660db170405adae9da7a441821ef483c57e354d8195f17ae28261b8dc8",
-		"policy_txt_hash": "159eb42ccb8cf8f4c2e9d2310abdec062d12bdf09d3d9da3faf67e7ad1510c36"
+		"module": {
+			"_type": "sec_certs.sample.document_state.DocumentState",
+			"download_ok": true,
+			"convert_garbage": false,
+			"convert_ok": true,
+			"extract_ok": true,
+			"source_hash": null,
+			"txt_hash": null,
+			"json_hash": null
+		},
+		"policy": {
+			"_type": "sec_certs.sample.document_state.DocumentState",
+			"download_ok": true,
+			"convert_garbage": false,
+			"convert_ok": true,
+			"extract_ok": true,
+			"source_hash": "303965660db170405adae9da7a441821ef483c57e354d8195f17ae28261b8dc8",
+			"txt_hash": "159eb42ccb8cf8f4c2e9d2310abdec062d12bdf09d3d9da3faf67e7ad1510c36",
+			"json_hash": "5808c7b9b11edcd3dfe65a1c8bb54e1a2b9bdf8c9364597f0eddfcea435822a4"
+		}
 	}
 },
 {
@@ -2879,14 +2987,26 @@
 	},
 	"state": {
 		"_type": "sec_certs.sample.fips.FIPSCertificate.InternalState",
-		"module_download_ok": true,
-		"policy_download_ok": true,
-		"policy_convert_garbage": true,
-		"policy_convert_ok": true,
-		"module_extract_ok": true,
-		"policy_extract_ok": true,
-		"policy_pdf_hash": "1e4424e859b1af2fceef6143b19167a671a47f24a4cd56a1d40600061911f71a",
-		"policy_txt_hash": "7f0c1804e8bf0f8c248b9d049d2ccb091cba9b7813b7824f0edde2c2372f5973"
+		"module": {
+			"_type": "sec_certs.sample.document_state.DocumentState",
+			"download_ok": true,
+			"convert_garbage": false,
+			"convert_ok": true,
+			"extract_ok": true,
+			"source_hash": null,
+			"txt_hash": null,
+			"json_hash": null
+		},
+		"policy": {
+			"_type": "sec_certs.sample.document_state.DocumentState",
+			"download_ok": true,
+			"convert_garbage": false,
+			"convert_ok": true,
+			"extract_ok": true,
+			"source_hash": "1e4424e859b1af2fceef6143b19167a671a47f24a4cd56a1d40600061911f71a",
+			"txt_hash": "7f0c1804e8bf0f8c248b9d049d2ccb091cba9b7813b7824f0edde2c2372f5973",
+			"json_hash": "50c3bbe3fdf7ddb7ea382158538feb9e2dbdaed6eaf7babfa5229f1a45551629"
+		}
 	}
 },
 {
@@ -3249,14 +3369,26 @@
 	},
 	"state": {
 		"_type": "sec_certs.sample.fips.FIPSCertificate.InternalState",
-		"module_download_ok": true,
-		"policy_download_ok": true,
-		"policy_convert_garbage": false,
-		"policy_convert_ok": true,
-		"module_extract_ok": true,
-		"policy_extract_ok": true,
-		"policy_pdf_hash": "a55604650526a64f06d9f3a4cf1f41817693c3d1111ba357b8f69ead62268897",
-		"policy_txt_hash": "14c0b5ef2111e191396f490f03a0373507bb6ec5097318ddf085b4826c62c786"
+		"module": {
+			"_type": "sec_certs.sample.document_state.DocumentState",
+			"download_ok": true,
+			"convert_garbage": false,
+			"convert_ok": true,
+			"extract_ok": true,
+			"source_hash": null,
+			"txt_hash": null,
+			"json_hash": null
+		},
+		"policy": {
+			"_type": "sec_certs.sample.document_state.DocumentState",
+			"download_ok": true,
+			"convert_garbage": false,
+			"convert_ok": true,
+			"extract_ok": true,
+			"source_hash": "a55604650526a64f06d9f3a4cf1f41817693c3d1111ba357b8f69ead62268897",
+			"txt_hash": "14c0b5ef2111e191396f490f03a0373507bb6ec5097318ddf085b4826c62c786",
+			"json_hash": "379ac8d7bc68fb541c4debd4306d7204c46d123d7ba01e6112500689c52a96e0"
+		}
 	}
 },
 {
@@ -3416,14 +3548,26 @@
 	},
 	"state": {
 		"_type": "sec_certs.sample.fips.FIPSCertificate.InternalState",
-		"module_download_ok": true,
-		"policy_download_ok": true,
-		"policy_convert_garbage": true,
-		"policy_convert_ok": true,
-		"module_extract_ok": true,
-		"policy_extract_ok": true,
-		"policy_pdf_hash": "3b5bba3b1aea9e1d98e5e57804db2d5694961133103ab117f9e7606b5a420bc3",
-		"policy_txt_hash": "7f0c1804e8bf0f8c248b9d049d2ccb091cba9b7813b7824f0edde2c2372f5973"
+		"module": {
+			"_type": "sec_certs.sample.document_state.DocumentState",
+			"download_ok": true,
+			"convert_garbage": false,
+			"convert_ok": true,
+			"extract_ok": true,
+			"source_hash": null,
+			"txt_hash": null,
+			"json_hash": null
+		},
+		"policy": {
+			"_type": "sec_certs.sample.document_state.DocumentState",
+			"download_ok": true,
+			"convert_garbage": false,
+			"convert_ok": true,
+			"extract_ok": true,
+			"source_hash": "3b5bba3b1aea9e1d98e5e57804db2d5694961133103ab117f9e7606b5a420bc3",
+			"txt_hash": "7f0c1804e8bf0f8c248b9d049d2ccb091cba9b7813b7824f0edde2c2372f5973",
+			"json_hash": "c0de63003b63815f75a95e627a79a0a930e5c859245ca9bf5b508ab6b4055223"
+		}
 	}
 },
 {
@@ -3767,14 +3911,26 @@
 	},
 	"state": {
 		"_type": "sec_certs.sample.fips.FIPSCertificate.InternalState",
-		"module_download_ok": true,
-		"policy_download_ok": true,
-		"policy_convert_garbage": false,
-		"policy_convert_ok": true,
-		"module_extract_ok": true,
-		"policy_extract_ok": true,
-		"policy_pdf_hash": "9cfe70e20befd7737398ede450302163cc6253487c219fb274edd86b7c2e92f4",
-		"policy_txt_hash": "2db96b5ba5ac2b2703ba4e799050bcfc91af0fe830fb54b9a7602f83bf7d2a46"
+		"module": {
+			"_type": "sec_certs.sample.document_state.DocumentState",
+			"download_ok": true,
+			"convert_garbage": false,
+			"convert_ok": true,
+			"extract_ok": true,
+			"source_hash": null,
+			"txt_hash": null,
+			"json_hash": null
+		},
+		"policy": {
+			"_type": "sec_certs.sample.document_state.DocumentState",
+			"download_ok": true,
+			"convert_garbage": false,
+			"convert_ok": true,
+			"extract_ok": true,
+			"source_hash": "9cfe70e20befd7737398ede450302163cc6253487c219fb274edd86b7c2e92f4",
+			"txt_hash": "2db96b5ba5ac2b2703ba4e799050bcfc91af0fe830fb54b9a7602f83bf7d2a46",
+			"json_hash": "ac760103d43aba4661f8616ef1d5e0791421c15af669bcd0bc9d489f53ca7d69"
+		}
 	}
-}]
-
+}
+]

--- a/tests/functional/data/mongo/fips_diff.json
+++ b/tests/functional/data/mongo/fips_diff.json
@@ -4120,14 +4120,27 @@
 			},
 			"state": {
 				"__insert__": {
-					"module_download_ok": true,
-					"policy_download_ok": true,
-					"policy_convert_garbage": false,
-					"policy_convert_ok": true,
-					"module_extract_ok": true,
-					"policy_extract_ok": true,
-					"policy_pdf_hash": "10835848c2f2a88514aac49bb1fc7c2394cc3153d5436fa14e0e55b36ecacdeb",
-					"policy_txt_hash": "f78936cf9faf03e15f980dc0d9e6478de9983f2e3a45e374d8280f6854c373e9"
+					"_type": "sec_certs.sample.fips.FIPSCertificate.InternalState",
+					"module": {
+						"_type": "sec_certs.sample.document_state.DocumentState",
+						"download_ok": true,
+						"convert_garbage": false,
+						"convert_ok": true,
+						"extract_ok": true,
+						"source_hash": null,
+						"txt_hash": null,
+						"json_hash": null
+					},
+					"policy": {
+						"_type": "sec_certs.sample.document_state.DocumentState",
+						"download_ok": true,
+						"convert_garbage": false,
+						"convert_ok": true,
+						"extract_ok": true,
+						"source_hash": "10835848c2f2a88514aac49bb1fc7c2394cc3153d5436fa14e0e55b36ecacdeb",
+						"txt_hash": "f78936cf9faf03e15f980dc0d9e6478de9983f2e3a45e374d8280f6854c373e9",
+						"json_hash": "f39ba0008a95f50211011f19b16924621795bce1cac036ad52d505235dce8605"
+					}
 				},
 				"__delete__": [
 					"sp_path",
@@ -14383,14 +14396,27 @@
 			},
 			"state": {
 				"__insert__": {
-					"module_download_ok": true,
-					"policy_download_ok": true,
-					"policy_convert_garbage": false,
-					"policy_convert_ok": true,
-					"module_extract_ok": true,
-					"policy_extract_ok": true,
-					"policy_pdf_hash": "a55604650526a64f06d9f3a4cf1f41817693c3d1111ba357b8f69ead62268897",
-					"policy_txt_hash": "14c0b5ef2111e191396f490f03a0373507bb6ec5097318ddf085b4826c62c786"
+					"_type": "sec_certs.sample.fips.FIPSCertificate.InternalState",
+					"module": {
+						"_type": "sec_certs.sample.document_state.DocumentState",
+						"download_ok": true,
+						"convert_garbage": false,
+						"convert_ok": true,
+						"extract_ok": true,
+						"source_hash": null,
+						"txt_hash": null,
+						"json_hash": null
+					},
+					"policy": {
+						"_type": "sec_certs.sample.document_state.DocumentState",
+						"download_ok": true,
+						"convert_garbage": false,
+						"convert_ok": true,
+						"extract_ok": true,
+						"source_hash": "a55604650526a64f06d9f3a4cf1f41817693c3d1111ba357b8f69ead62268897",
+						"txt_hash": "14c0b5ef2111e191396f490f03a0373507bb6ec5097318ddf085b4826c62c786",
+						"json_hash": "379ac8d7bc68fb541c4debd4306d7204c46d123d7ba01e6112500689c52a96e0"
+					}
 				},
 				"__delete__": [
 					"sp_path",
@@ -16135,14 +16161,27 @@
 			},
 			"state": {
 				"__insert__": {
-					"module_download_ok": true,
-					"policy_download_ok": true,
-					"policy_convert_garbage": false,
-					"policy_convert_ok": true,
-					"module_extract_ok": true,
-					"policy_extract_ok": true,
-					"policy_pdf_hash": "391714adb4cb0ad11447f81ef6d7c8a1fcaee27e6c65542e42d3273c9a5cba97",
-					"policy_txt_hash": "c5afc790293023dd1c13f884ecff9a76ded8425573a4c25c7c15c95c67956b43"
+					"_type": "sec_certs.sample.fips.FIPSCertificate.InternalState",
+					"module": {
+						"_type": "sec_certs.sample.document_state.DocumentState",
+						"download_ok": true,
+						"convert_garbage": false,
+						"convert_ok": true,
+						"extract_ok": true,
+						"source_hash": null,
+						"txt_hash": null,
+						"json_hash": null
+					},
+					"policy": {
+						"_type": "sec_certs.sample.document_state.DocumentState",
+						"download_ok": true,
+						"convert_garbage": false,
+						"convert_ok": true,
+						"extract_ok": true,
+						"source_hash": "303965660db170405adae9da7a441821ef483c57e354d8195f17ae28261b8dc8",
+						"txt_hash": "159eb42ccb8cf8f4c2e9d2310abdec062d12bdf09d3d9da3faf67e7ad1510c36",
+						"json_hash": "379ac8d7bc68fb541c4debd4306d7204c46d123d7ba01e6112500689c52a96e0"
+					}
 				},
 				"__delete__": [
 					"sp_path",
@@ -22788,14 +22827,27 @@
 			},
 			"state": {
 				"__insert__": {
-					"module_download_ok": true,
-					"policy_download_ok": true,
-					"policy_convert_garbage": false,
-					"policy_convert_ok": true,
-					"module_extract_ok": true,
-					"policy_extract_ok": true,
-					"policy_pdf_hash": "303965660db170405adae9da7a441821ef483c57e354d8195f17ae28261b8dc8",
-					"policy_txt_hash": "159eb42ccb8cf8f4c2e9d2310abdec062d12bdf09d3d9da3faf67e7ad1510c36"
+					"_type": "sec_certs.sample.fips.FIPSCertificate.InternalState",
+					"module": {
+						"_type": "sec_certs.sample.document_state.DocumentState",
+						"download_ok": true,
+						"convert_garbage": false,
+						"convert_ok": true,
+						"extract_ok": true,
+						"source_hash": null,
+						"txt_hash": null,
+						"json_hash": null
+					},
+					"policy": {
+						"_type": "sec_certs.sample.document_state.DocumentState",
+						"download_ok": true,
+						"convert_garbage": false,
+						"convert_ok": true,
+						"extract_ok": true,
+						"source_hash": "303965660db170405adae9da7a441821ef483c57e354d8195f17ae28261b8dc8",
+						"txt_hash": "159eb42ccb8cf8f4c2e9d2310abdec062d12bdf09d3d9da3faf67e7ad1510c36",
+						"json_hash": "5808c7b9b11edcd3dfe65a1c8bb54e1a2b9bdf8c9364597f0eddfcea435822a4"
+					}
 				},
 				"__delete__": [
 					"sp_path",
@@ -23449,14 +23501,27 @@
 			},
 			"state": {
 				"__insert__": {
-					"module_download_ok": true,
-					"policy_download_ok": true,
-					"policy_convert_garbage": true,
-					"policy_convert_ok": true,
-					"module_extract_ok": true,
-					"policy_extract_ok": true,
-					"policy_pdf_hash": "e85d2b3dceae2285830e03819c255d22a691aaa340b735a497e79685a8ae4c27",
-					"policy_txt_hash": "f2a653b4879554630ac981eb9c28119e9689b9fa3abbff2e82c486f2a73dfccc"
+					"_type": "sec_certs.sample.fips.FIPSCertificate.InternalState",
+					"module": {
+						"_type": "sec_certs.sample.document_state.DocumentState",
+						"download_ok": true,
+						"convert_garbage": false,
+						"convert_ok": true,
+						"extract_ok": true,
+						"source_hash": null,
+						"txt_hash": null,
+						"json_hash": null
+					},
+					"policy": {
+						"_type": "sec_certs.sample.document_state.DocumentState",
+						"download_ok": true,
+						"convert_garbage": false,
+						"convert_ok": true,
+						"extract_ok": true,
+						"source_hash": "e85d2b3dceae2285830e03819c255d22a691aaa340b735a497e79685a8ae4c27",
+						"txt_hash": "f2a653b4879554630ac981eb9c28119e9689b9fa3abbff2e82c486f2a73dfccc",
+						"json_hash": "651373b50dcdaffd547269bf56149e42038c4abeb7a3fd5c36b3e36aba67c728"
+					}
 				},
 				"__delete__": [
 					"sp_path",
@@ -24204,14 +24269,27 @@
 			},
 			"state": {
 				"__insert__": {
-					"module_download_ok": true,
-					"policy_download_ok": true,
-					"policy_convert_garbage": true,
-					"policy_convert_ok": true,
-					"module_extract_ok": true,
-					"policy_extract_ok": true,
-					"policy_pdf_hash": "3b5bba3b1aea9e1d98e5e57804db2d5694961133103ab117f9e7606b5a420bc3",
-					"policy_txt_hash": "7f0c1804e8bf0f8c248b9d049d2ccb091cba9b7813b7824f0edde2c2372f5973"
+					"_type": "sec_certs.sample.fips.FIPSCertificate.InternalState",
+					"module": {
+						"_type": "sec_certs.sample.document_state.DocumentState",
+						"download_ok": true,
+						"convert_garbage": false,
+						"convert_ok": true,
+						"extract_ok": true,
+						"source_hash": null,
+						"txt_hash": null,
+						"json_hash": null
+					},
+					"policy": {
+						"_type": "sec_certs.sample.document_state.DocumentState",
+						"download_ok": true,
+						"convert_garbage": false,
+						"convert_ok": true,
+						"extract_ok": true,
+						"source_hash": "3b5bba3b1aea9e1d98e5e57804db2d5694961133103ab117f9e7606b5a420bc3",
+						"txt_hash": "7f0c1804e8bf0f8c248b9d049d2ccb091cba9b7813b7824f0edde2c2372f5973",
+						"json_hash": "c0de63003b63815f75a95e627a79a0a930e5c859245ca9bf5b508ab6b4055223"
+					}
 				},
 				"__delete__": [
 					"sp_path",
@@ -31471,14 +31549,27 @@
 			},
 			"state": {
 				"__insert__": {
-					"module_download_ok": true,
-					"policy_download_ok": true,
-					"policy_convert_garbage": false,
-					"policy_convert_ok": true,
-					"module_extract_ok": true,
-					"policy_extract_ok": true,
-					"policy_pdf_hash": "3d653c513f816e3f97a1481ba9477a037b83281b13c0d29e45b9c2ffd089b03f",
-					"policy_txt_hash": "450a27673c4a87677fdafdcd9405a017b3bf6e4bea98a2effa19e3ebf14cd810"
+					"_type": "sec_certs.sample.fips.FIPSCertificate.InternalState",
+					"module": {
+						"_type": "sec_certs.sample.document_state.DocumentState",
+						"download_ok": true,
+						"convert_garbage": false,
+						"convert_ok": true,
+						"extract_ok": true,
+						"source_hash": null,
+						"txt_hash": null,
+						"json_hash": null
+					},
+					"policy": {
+						"_type": "sec_certs.sample.document_state.DocumentState",
+						"download_ok": true,
+						"convert_garbage": false,
+						"convert_ok": true,
+						"extract_ok": true,
+						"source_hash": "3d653c513f816e3f97a1481ba9477a037b83281b13c0d29e45b9c2ffd089b03f",
+						"txt_hash": "450a27673c4a87677fdafdcd9405a017b3bf6e4bea98a2effa19e3ebf14cd810",
+						"json_hash": "7755440c24f6d738debc1de0c8f935f0ecc868027b22d7ddf9816f8910dbfef3"
+					}
 				},
 				"__delete__": [
 					"sp_path",
@@ -34676,14 +34767,27 @@
 			},
 			"state": {
 				"__insert__": {
-					"module_download_ok": true,
-					"policy_download_ok": true,
-					"policy_convert_garbage": false,
-					"policy_convert_ok": true,
-					"module_extract_ok": true,
-					"policy_extract_ok": true,
-					"policy_pdf_hash": "9609ce126a5b9716ed814a6cf80c4961178bce82099ba22756b745d84294c090",
-					"policy_txt_hash": "3ae75390122b6e601c736cee575c1be45faa896858c8026cd14b12e4944853df"
+					"_type": "sec_certs.sample.fips.FIPSCertificate.InternalState",
+					"module": {
+						"_type": "sec_certs.sample.document_state.DocumentState",
+						"download_ok": true,
+						"convert_garbage": false,
+						"convert_ok": true,
+						"extract_ok": true,
+						"source_hash": null,
+						"txt_hash": null,
+						"json_hash": null
+					},
+					"policy": {
+						"_type": "sec_certs.sample.document_state.DocumentState",
+						"download_ok": true,
+						"convert_garbage": false,
+						"convert_ok": true,
+						"extract_ok": true,
+						"source_hash": "9609ce126a5b9716ed814a6cf80c4961178bce82099ba22756b745d84294c090",
+						"txt_hash": "3ae75390122b6e601c736cee575c1be45faa896858c8026cd14b12e4944853df",
+						"json_hash": "db346483aade7452b98184686d2b7ae13289a0a13fcd1d939e4592237562f3f9"
+					}
 				},
 				"__delete__": [
 					"sp_path",
@@ -40343,14 +40447,27 @@
 			},
 			"state": {
 				"__insert__": {
-					"module_download_ok": true,
-					"policy_download_ok": true,
-					"policy_convert_garbage": false,
-					"policy_convert_ok": true,
-					"module_extract_ok": true,
-					"policy_extract_ok": true,
-					"policy_pdf_hash": "9cfe70e20befd7737398ede450302163cc6253487c219fb274edd86b7c2e92f4",
-					"policy_txt_hash": "2db96b5ba5ac2b2703ba4e799050bcfc91af0fe830fb54b9a7602f83bf7d2a46"
+					"_type": "sec_certs.sample.fips.FIPSCertificate.InternalState",
+					"module": {
+						"_type": "sec_certs.sample.document_state.DocumentState",
+						"download_ok": true,
+						"convert_garbage": false,
+						"convert_ok": true,
+						"extract_ok": true,
+						"source_hash": null,
+						"txt_hash": null,
+						"json_hash": null
+					},
+					"policy": {
+						"_type": "sec_certs.sample.document_state.DocumentState",
+						"download_ok": true,
+						"convert_garbage": false,
+						"convert_ok": true,
+						"extract_ok": true,
+						"source_hash": "9cfe70e20befd7737398ede450302163cc6253487c219fb274edd86b7c2e92f4",
+						"txt_hash": "2db96b5ba5ac2b2703ba4e799050bcfc91af0fe830fb54b9a7602f83bf7d2a46",
+						"json_hash": "ac760103d43aba4661f8616ef1d5e0791421c15af669bcd0bc9d489f53ca7d69"
+					}
 				},
 				"__delete__": [
 					"sp_path",
@@ -46746,14 +46863,27 @@
 			},
 			"state": {
 				"__insert__": {
-					"module_download_ok": true,
-					"policy_download_ok": true,
-					"policy_convert_garbage": false,
-					"policy_convert_ok": true,
-					"module_extract_ok": true,
-					"policy_extract_ok": true,
-					"policy_pdf_hash": "2dea082518933e794bcce27efb708bbb0c95243df4e89ee6005c4f65c9afc6b2",
-					"policy_txt_hash": "f2173fa3706d9c93c7a68883697e737b6709822acc8cca72b8c87fb8be2393de"
+					"_type": "sec_certs.sample.fips.FIPSCertificate.InternalState",
+					"module": {
+						"_type": "sec_certs.sample.document_state.DocumentState",
+						"download_ok": true,
+						"convert_garbage": false,
+						"convert_ok": true,
+						"extract_ok": true,
+						"source_hash": null,
+						"txt_hash": null,
+						"json_hash": null
+					},
+					"policy": {
+						"_type": "sec_certs.sample.document_state.DocumentState",
+						"download_ok": true,
+						"convert_garbage": false,
+						"convert_ok": true,
+						"extract_ok": true,
+						"source_hash": "2dea082518933e794bcce27efb708bbb0c95243df4e89ee6005c4f65c9afc6b2",
+						"txt_hash": "f2173fa3706d9c93c7a68883697e737b6709822acc8cca72b8c87fb8be2393de",
+						"json_hash": "c0e4b55c50156cce63737dfea2b64b4f8b03be049f4d26a1b1eab6ee58c046af"
+					}
 				},
 				"__delete__": [
 					"sp_path",
@@ -49849,14 +49979,27 @@
 			},
 			"state": {
 				"__insert__": {
-					"module_download_ok": true,
-					"policy_download_ok": true,
-					"policy_convert_garbage": false,
-					"policy_convert_ok": true,
-					"module_extract_ok": true,
-					"policy_extract_ok": true,
-					"policy_pdf_hash": "c7305b318364bfcd082579022ef5e2c52a05f5cbb9c6c7086e880da3235eca93",
-					"policy_txt_hash": "b79ff5b0885fb9e6d6fb39b50aafec0dba25425c44bcc24c656c7acbffb944ef"
+					"_type": "sec_certs.sample.fips.FIPSCertificate.InternalState",
+					"module": {
+						"_type": "sec_certs.sample.document_state.DocumentState",
+						"download_ok": true,
+						"convert_garbage": false,
+						"convert_ok": true,
+						"extract_ok": true,
+						"source_hash": null,
+						"txt_hash": null,
+						"json_hash": null
+					},
+					"policy": {
+						"_type": "sec_certs.sample.document_state.DocumentState",
+						"download_ok": true,
+						"convert_garbage": false,
+						"convert_ok": true,
+						"extract_ok": true,
+						"source_hash": "c7305b318364bfcd082579022ef5e2c52a05f5cbb9c6c7086e880da3235eca93",
+						"txt_hash": "b79ff5b0885fb9e6d6fb39b50aafec0dba25425c44bcc24c656c7acbffb944ef",
+						"json_hash": "350d8b1517f7d46e2598223c7fceec360101252e7db85c806ec8b3f0388944a4"
+					}
 				},
 				"__delete__": [
 					"sp_path",
@@ -54294,14 +54437,27 @@
 			},
 			"state": {
 				"__insert__": {
-					"module_download_ok": true,
-					"policy_download_ok": true,
-					"policy_convert_garbage": false,
-					"policy_convert_ok": true,
-					"module_extract_ok": true,
-					"policy_extract_ok": true,
-					"policy_pdf_hash": "f9c624b080c2ff6e3ff24c03ce58aa5944f1566190e7c26482f3251c138ea0cf",
-					"policy_txt_hash": "863ca04cb2f5f3a33499440b8e8f8ad69038557831a527534b8b0133141c136e"
+					"_type": "sec_certs.sample.fips.FIPSCertificate.InternalState",
+					"module": {
+						"_type": "sec_certs.sample.document_state.DocumentState",
+						"download_ok": true,
+						"convert_garbage": false,
+						"convert_ok": true,
+						"extract_ok": true,
+						"source_hash": null,
+						"txt_hash": null,
+						"json_hash": null
+					},
+					"policy": {
+						"_type": "sec_certs.sample.document_state.DocumentState",
+						"download_ok": true,
+						"convert_garbage": false,
+						"convert_ok": true,
+						"extract_ok": true,
+						"source_hash": "f9c624b080c2ff6e3ff24c03ce58aa5944f1566190e7c26482f3251c138ea0cf",
+						"txt_hash": "863ca04cb2f5f3a33499440b8e8f8ad69038557831a527534b8b0133141c136e",
+						"json_hash": "029937f5edef3d8add3d8e0d249480e97eb9bdab8886518eba8133d45a9e645f"
+					}
 				},
 				"__delete__": [
 					"sp_path",
@@ -55049,14 +55205,27 @@
 			},
 			"state": {
 				"__insert__": {
-					"module_download_ok": true,
-					"policy_download_ok": true,
-					"policy_convert_garbage": true,
-					"policy_convert_ok": true,
-					"module_extract_ok": true,
-					"policy_extract_ok": true,
-					"policy_pdf_hash": "1e4424e859b1af2fceef6143b19167a671a47f24a4cd56a1d40600061911f71a",
-					"policy_txt_hash": "7f0c1804e8bf0f8c248b9d049d2ccb091cba9b7813b7824f0edde2c2372f5973"
+					"_type": "sec_certs.sample.fips.FIPSCertificate.InternalState",
+					"module": {
+						"_type": "sec_certs.sample.document_state.DocumentState",
+						"download_ok": true,
+						"convert_garbage": false,
+						"convert_ok": true,
+						"extract_ok": true,
+						"source_hash": null,
+						"txt_hash": null,
+						"json_hash": null
+					},
+					"policy": {
+						"_type": "sec_certs.sample.document_state.DocumentState",
+						"download_ok": true,
+						"convert_garbage": false,
+						"convert_ok": true,
+						"extract_ok": true,
+						"source_hash": "1e4424e859b1af2fceef6143b19167a671a47f24a4cd56a1d40600061911f71a",
+						"txt_hash": "7f0c1804e8bf0f8c248b9d049d2ccb091cba9b7813b7824f0edde2c2372f5973",
+						"json_hash": "50c3bbe3fdf7ddb7ea382158538feb9e2dbdaed6eaf7babfa5229f1a45551629"
+					}
 				},
 				"__delete__": [
 					"sp_path",

--- a/tests/functional/data/mongo/pp.json
+++ b/tests/functional/data/mongo/pp.json
@@ -686,8 +686,9 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "3614e329b03c684af37104afecb0e9f801d953687d9b78a3c58b949cb835c73e",
-			"txt_hash": "b569aa03a1cdee37429bf6099dedab21a1ae82f28d37c24c4da71a968aaf0da2"
+			"source_hash": "3614e329b03c684af37104afecb0e9f801d953687d9b78a3c58b949cb835c73e",
+			"txt_hash": "b569aa03a1cdee37429bf6099dedab21a1ae82f28d37c24c4da71a968aaf0da2",
+			"json_hash": "5fcb570b7e49e0adcb5666ca52b32122288d3106309d4411e849f2cd7bd2c515"
 		},
 		"report": {
 			"_type": "sec_certs.sample.document_state.DocumentState",
@@ -695,8 +696,9 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "a488a660c60d9b62cf20608f3e66b913112ccd594f10b37003c55ab88a37409a",
-			"txt_hash": "fc4212cf12c413964cea742086c9a2ffb15feb130a34ecd567528907695104d5"
+			"source_hash": "a488a660c60d9b62cf20608f3e66b913112ccd594f10b37003c55ab88a37409a",
+			"txt_hash": "fc4212cf12c413964cea742086c9a2ffb15feb130a34ecd567528907695104d5",
+			"json_hash": "74070680d4f91428ac1f45b109c14d24f4f272f1cd8a0d31a8f5f6fab1f73852"
 		}
 	}
 },
@@ -1294,8 +1296,9 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "0977787f7217bf4cf76686e3d7dbb2cac8424843f5170cb08b0690c269ac9ec0",
-			"txt_hash": "1b52f4234e6a37e2be6709940409428bde684daf2af57bf85b97bf68a5f9f9dd"
+			"source_hash": "0977787f7217bf4cf76686e3d7dbb2cac8424843f5170cb08b0690c269ac9ec0",
+			"txt_hash": "1b52f4234e6a37e2be6709940409428bde684daf2af57bf85b97bf68a5f9f9dd",
+			"json_hash": "4bc83ef24631fb6a7d2e065cec76ba85df26085c7d8933bcfffae8e6877b953a"
 		},
 		"report": {
 			"_type": "sec_certs.sample.document_state.DocumentState",
@@ -1303,8 +1306,9 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "3d8977dee0fabf45b5066e2e62a50ec79ad18ccd42839f15325981c595691cf7",
-			"txt_hash": "8b704c5cdfc454d5e2dfa3c6a77f2f1dd188bb7ccc7409d88f3761ce594b57a7"
+			"source_hash": "3d8977dee0fabf45b5066e2e62a50ec79ad18ccd42839f15325981c595691cf7",
+			"txt_hash": "8b704c5cdfc454d5e2dfa3c6a77f2f1dd188bb7ccc7409d88f3761ce594b57a7",
+			"json_hash": "402c3795e63ce0be88f491257628604f188baf09aa3f1b8bb77220d89340b468"
 		}
 	}
 },
@@ -1889,8 +1893,9 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "1e85c4c28adbda2a0792f4445bf590b86077c20e616461f6b7674a19a643dc41",
-			"txt_hash": "d91111982276e193f7de8a60d775d1b40e5328be80f2799fc33506e8840b2011"
+			"source_hash": "1e85c4c28adbda2a0792f4445bf590b86077c20e616461f6b7674a19a643dc41",
+			"txt_hash": "d91111982276e193f7de8a60d775d1b40e5328be80f2799fc33506e8840b2011",
+			"json_hash": "f0acd588e147557eeacc64ee1d8f7630e75db4cadeeddcc141e9e1c48b4099ec"
 		},
 		"report": {
 			"_type": "sec_certs.sample.document_state.DocumentState",
@@ -1898,8 +1903,9 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "5cbe2329f14736c64d5bf70f37354cc5b309d836dedc4347b05cd9482bc0869b",
-			"txt_hash": "4fef94161ffa62cbd69f3f8ca6734daf680084f08e5436aceab622eb01966cc0"
+			"source_hash": "5cbe2329f14736c64d5bf70f37354cc5b309d836dedc4347b05cd9482bc0869b",
+			"txt_hash": "4fef94161ffa62cbd69f3f8ca6734daf680084f08e5436aceab622eb01966cc0",
+			"json_hash": "a8e01d96b8abe051c64c0b7bb278f052b4c9503d2b1fe3e49820b8f62d1a778d"
 		}
 	}
 },
@@ -2457,8 +2463,9 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "8971926fb9516eaefe2c48eda37fca7544d902b5bde1f0bd4ad153f44b3a1e10",
-			"txt_hash": "d7fe9655d51714c5bf45e63e61c2d881839185a1ff4e14f61ca7966eb5413589"
+			"source_hash": "8971926fb9516eaefe2c48eda37fca7544d902b5bde1f0bd4ad153f44b3a1e10",
+			"txt_hash": "d7fe9655d51714c5bf45e63e61c2d881839185a1ff4e14f61ca7966eb5413589",
+			"json_hash": "9973b520e5416c5a84831f06362e4068ce74bf66ef1b69c588113bb593978cf5"
 		},
 		"report": {
 			"_type": "sec_certs.sample.document_state.DocumentState",
@@ -2466,8 +2473,9 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "5d6639aa727515c822ed9f844361bdae928999b0f2ee524107a8692f1bcb6048",
-			"txt_hash": "b6eb438d9bc242189973aaae7ace80925e8a81fb5e19dcddf73bb6b7bc5ad012"
+			"source_hash": "5d6639aa727515c822ed9f844361bdae928999b0f2ee524107a8692f1bcb6048",
+			"txt_hash": "b6eb438d9bc242189973aaae7ace80925e8a81fb5e19dcddf73bb6b7bc5ad012",
+			"json_hash": "766cd90f5d657b482d18638b74044af50e24ec928f8afe69855df523f06a5665"
 		}
 	}
 },
@@ -3128,8 +3136,9 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "49332970ad55758017d5dcf4559c4900b24694c67ae1009db643bb6363405aab",
-			"txt_hash": "cf91b3a0eac4a2e07c489245d30e0456578a3efba2e8aca28cba19ff19ddcfe1"
+			"source_hash": "49332970ad55758017d5dcf4559c4900b24694c67ae1009db643bb6363405aab",
+			"txt_hash": "cf91b3a0eac4a2e07c489245d30e0456578a3efba2e8aca28cba19ff19ddcfe1",
+			"json_hash": "6347556bc4a7d231b731d7e058b4b12b69a50a69c173e0619f869e1f2f21abeb"
 		},
 		"report": {
 			"_type": "sec_certs.sample.document_state.DocumentState",
@@ -3137,9 +3146,10 @@
 			"convert_garbage": false,
 			"convert_ok": true,
 			"extract_ok": true,
-			"pdf_hash": "a6cd8a0c24f07cc877bc53f192d8c9d78980699db55c88dc140f75eee18b0d43",
-			"txt_hash": "288e1afe17b4fee889345278f73cff5a6d44b9e277cd73ba38352a95c659bf7a"
+			"source_hash": "a6cd8a0c24f07cc877bc53f192d8c9d78980699db55c88dc140f75eee18b0d43",
+			"txt_hash": "288e1afe17b4fee889345278f73cff5a6d44b9e277cd73ba38352a95c659bf7a",
+			"json_hash": "d03e7942a3b1b2246ece5b0ef2c52a9497f03b72c2e018d6a9ff719b65d1139e"
 		}
 	}
-}]
-
+}
+]

--- a/tests/functional/data/mongo/pp_diff.json
+++ b/tests/functional/data/mongo/pp_diff.json
@@ -3233,21 +3233,33 @@
 				"__update__": {
 					"pp": {
 						"__update__": {
-							"convert_garbage": true,
-							"convert_ok": false,
-							"extract_ok": false,
-							"pdf_hash": "6adef86c67e4bbbcbc8872bedf10c93c33839884a5cb1ca1d36f080444041ca7",
-							"txt_hash": null
-						}
+							"convert_garbage": false,
+							"convert_ok": true,
+							"extract_ok": true,
+							"txt_hash": "d91111982276e193f7de8a60d775d1b40e5328be80f2799fc33506e8840b2011"
+						},
+						"__insert__": {
+							"source_hash": "1e85c4c28adbda2a0792f4445bf590b86077c20e616461f6b7674a19a643dc41",
+							"json_hash": "f0acd588e147557eeacc64ee1d8f7630e75db4cadeeddcc141e9e1c48b4099ec"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					},
 					"report": {
 						"__update__": {
-							"convert_garbage": true,
-							"convert_ok": false,
-							"extract_ok": false,
-							"pdf_hash": "6adef86c67e4bbbcbc8872bedf10c93c33839884a5cb1ca1d36f080444041ca7",
-							"txt_hash": null
-						}
+							"convert_garbage": false,
+							"convert_ok": true,
+							"extract_ok": true,
+							"txt_hash": "4fef94161ffa62cbd69f3f8ca6734daf680084f08e5436aceab622eb01966cc0"
+						},
+						"__insert__": {
+							"source_hash": "5cbe2329f14736c64d5bf70f37354cc5b309d836dedc4347b05cd9482bc0869b",
+							"json_hash": "a8e01d96b8abe051c64c0b7bb278f052b4c9503d2b1fe3e49820b8f62d1a778d"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					}
 				}
 			}
@@ -3280,21 +3292,33 @@
 				"__update__": {
 					"pp": {
 						"__update__": {
-							"convert_garbage": true,
-							"convert_ok": false,
-							"extract_ok": false,
-							"pdf_hash": "6adef86c67e4bbbcbc8872bedf10c93c33839884a5cb1ca1d36f080444041ca7",
-							"txt_hash": null
-						}
+							"convert_garbage": false,
+							"convert_ok": true,
+							"extract_ok": true,
+							"txt_hash": "b569aa03a1cdee37429bf6099dedab21a1ae82f28d37c24c4da71a968aaf0da2"
+						},
+						"__insert__": {
+							"source_hash": "3614e329b03c684af37104afecb0e9f801d953687d9b78a3c58b949cb835c73e",
+							"json_hash": "5fcb570b7e49e0adcb5666ca52b32122288d3106309d4411e849f2cd7bd2c515"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					},
 					"report": {
 						"__update__": {
-							"convert_garbage": true,
-							"convert_ok": false,
-							"extract_ok": false,
-							"pdf_hash": "6adef86c67e4bbbcbc8872bedf10c93c33839884a5cb1ca1d36f080444041ca7",
-							"txt_hash": null
-						}
+							"convert_garbage": false,
+							"convert_ok": true,
+							"extract_ok": true,
+							"txt_hash": "fc4212cf12c413964cea742086c9a2ffb15feb130a34ecd567528907695104d5"
+						},
+						"__insert__": {
+							"source_hash": "a488a660c60d9b62cf20608f3e66b913112ccd594f10b37003c55ab88a37409a",
+							"json_hash": "74070680d4f91428ac1f45b109c14d24f4f272f1cd8a0d31a8f5f6fab1f73852"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					}
 				}
 			}
@@ -3327,21 +3351,33 @@
 				"__update__": {
 					"pp": {
 						"__update__": {
-							"convert_garbage": true,
-							"convert_ok": false,
-							"extract_ok": false,
-							"pdf_hash": "6adef86c67e4bbbcbc8872bedf10c93c33839884a5cb1ca1d36f080444041ca7",
-							"txt_hash": null
-						}
+							"convert_garbage": false,
+							"convert_ok": true,
+							"extract_ok": true,
+							"txt_hash": "d7fe9655d51714c5bf45e63e61c2d881839185a1ff4e14f61ca7966eb5413589"
+						},
+						"__insert__": {
+							"source_hash": "8971926fb9516eaefe2c48eda37fca7544d902b5bde1f0bd4ad153f44b3a1e10",
+							"json_hash": "9973b520e5416c5a84831f06362e4068ce74bf66ef1b69c588113bb593978cf5"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					},
 					"report": {
 						"__update__": {
-							"convert_garbage": true,
-							"convert_ok": false,
-							"extract_ok": false,
-							"pdf_hash": "6adef86c67e4bbbcbc8872bedf10c93c33839884a5cb1ca1d36f080444041ca7",
-							"txt_hash": null
-						}
+							"convert_garbage": false,
+							"convert_ok": true,
+							"extract_ok": true,
+							"txt_hash": "b6eb438d9bc242189973aaae7ace80925e8a81fb5e19dcddf73bb6b7bc5ad012"
+						},
+						"__insert__": {
+							"source_hash": "5d6639aa727515c822ed9f844361bdae928999b0f2ee524107a8692f1bcb6048",
+							"json_hash": "766cd90f5d657b482d18638b74044af50e24ec928f8afe69855df523f06a5665"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					}
 				}
 			}
@@ -3374,21 +3410,33 @@
 				"__update__": {
 					"pp": {
 						"__update__": {
-							"convert_garbage": true,
-							"convert_ok": false,
-							"extract_ok": false,
-							"pdf_hash": "6adef86c67e4bbbcbc8872bedf10c93c33839884a5cb1ca1d36f080444041ca7",
-							"txt_hash": null
-						}
+							"convert_garbage": false,
+							"convert_ok": true,
+							"extract_ok": true,
+							"txt_hash": "cf91b3a0eac4a2e07c489245d30e0456578a3efba2e8aca28cba19ff19ddcfe1"
+						},
+						"__insert__": {
+							"source_hash": "49332970ad55758017d5dcf4559c4900b24694c67ae1009db643bb6363405aab",
+							"json_hash": "6347556bc4a7d231b731d7e058b4b12b69a50a69c173e0619f869e1f2f21abeb"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					},
 					"report": {
 						"__update__": {
-							"convert_garbage": true,
-							"convert_ok": false,
-							"extract_ok": false,
-							"pdf_hash": "6adef86c67e4bbbcbc8872bedf10c93c33839884a5cb1ca1d36f080444041ca7",
-							"txt_hash": null
-						}
+							"convert_garbage": false,
+							"convert_ok": true,
+							"extract_ok": true,
+							"txt_hash": "288e1afe17b4fee889345278f73cff5a6d44b9e277cd73ba38352a95c659bf7a"
+						},
+						"__insert__": {
+							"source_hash": "a6cd8a0c24f07cc877bc53f192d8c9d78980699db55c88dc140f75eee18b0d43",
+							"json_hash": "d03e7942a3b1b2246ece5b0ef2c52a9497f03b72c2e018d6a9ff719b65d1139e"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					}
 				}
 			}
@@ -3421,21 +3469,33 @@
 				"__update__": {
 					"pp": {
 						"__update__": {
-							"convert_garbage": true,
-							"convert_ok": false,
-							"extract_ok": false,
-							"pdf_hash": "6adef86c67e4bbbcbc8872bedf10c93c33839884a5cb1ca1d36f080444041ca7",
-							"txt_hash": null
-						}
+							"convert_garbage": false,
+							"convert_ok": true,
+							"extract_ok": true,
+							"txt_hash": "1b52f4234e6a37e2be6709940409428bde684daf2af57bf85b97bf68a5f9f9dd"
+						},
+						"__insert__": {
+							"source_hash": "0977787f7217bf4cf76686e3d7dbb2cac8424843f5170cb08b0690c269ac9ec0",
+							"json_hash": "4bc83ef24631fb6a7d2e065cec76ba85df26085c7d8933bcfffae8e6877b953a"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					},
 					"report": {
 						"__update__": {
-							"convert_garbage": true,
-							"convert_ok": false,
-							"extract_ok": false,
-							"pdf_hash": "6adef86c67e4bbbcbc8872bedf10c93c33839884a5cb1ca1d36f080444041ca7",
-							"txt_hash": null
-						}
+							"convert_garbage": false,
+							"convert_ok": true,
+							"extract_ok": true,
+							"txt_hash": "8b704c5cdfc454d5e2dfa3c6a77f2f1dd188bb7ccc7409d88f3761ce594b57a7"
+						},
+						"__insert__": {
+							"source_hash": "3d8977dee0fabf45b5066e2e62a50ec79ad18ccd42839f15325981c595691cf7",
+							"json_hash": "402c3795e63ce0be88f491257628604f188baf09aa3f1b8bb77220d89340b468"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					}
 				}
 			}
@@ -4002,18 +4062,30 @@
 							"convert_garbage": false,
 							"convert_ok": true,
 							"extract_ok": true,
-							"pdf_hash": "1e85c4c28adbda2a0792f4445bf590b86077c20e616461f6b7674a19a643dc41",
 							"txt_hash": "d91111982276e193f7de8a60d775d1b40e5328be80f2799fc33506e8840b2011"
-						}
+						},
+						"__insert__": {
+							"source_hash": "1e85c4c28adbda2a0792f4445bf590b86077c20e616461f6b7674a19a643dc41",
+							"json_hash": "f0acd588e147557eeacc64ee1d8f7630e75db4cadeeddcc141e9e1c48b4099ec"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					},
 					"report": {
 						"__update__": {
 							"convert_garbage": false,
 							"convert_ok": true,
 							"extract_ok": true,
-							"pdf_hash": "5cbe2329f14736c64d5bf70f37354cc5b309d836dedc4347b05cd9482bc0869b",
 							"txt_hash": "4fef94161ffa62cbd69f3f8ca6734daf680084f08e5436aceab622eb01966cc0"
-						}
+						},
+						"__insert__": {
+							"source_hash": "5cbe2329f14736c64d5bf70f37354cc5b309d836dedc4347b05cd9482bc0869b",
+							"json_hash": "a8e01d96b8abe051c64c0b7bb278f052b4c9503d2b1fe3e49820b8f62d1a778d"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					}
 				}
 			}
@@ -4687,18 +4759,30 @@
 							"convert_garbage": false,
 							"convert_ok": true,
 							"extract_ok": true,
-							"pdf_hash": "3614e329b03c684af37104afecb0e9f801d953687d9b78a3c58b949cb835c73e",
 							"txt_hash": "b569aa03a1cdee37429bf6099dedab21a1ae82f28d37c24c4da71a968aaf0da2"
-						}
+						},
+						"__insert__": {
+							"source_hash": "3614e329b03c684af37104afecb0e9f801d953687d9b78a3c58b949cb835c73e",
+							"json_hash": "5fcb570b7e49e0adcb5666ca52b32122288d3106309d4411e849f2cd7bd2c515"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					},
 					"report": {
 						"__update__": {
 							"convert_garbage": false,
 							"convert_ok": true,
 							"extract_ok": true,
-							"pdf_hash": "a488a660c60d9b62cf20608f3e66b913112ccd594f10b37003c55ab88a37409a",
 							"txt_hash": "fc4212cf12c413964cea742086c9a2ffb15feb130a34ecd567528907695104d5"
-						}
+						},
+						"__insert__": {
+							"source_hash": "a488a660c60d9b62cf20608f3e66b913112ccd594f10b37003c55ab88a37409a",
+							"json_hash": "74070680d4f91428ac1f45b109c14d24f4f272f1cd8a0d31a8f5f6fab1f73852"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					}
 				}
 			}
@@ -5239,18 +5323,30 @@
 							"convert_garbage": false,
 							"convert_ok": true,
 							"extract_ok": true,
-							"pdf_hash": "8971926fb9516eaefe2c48eda37fca7544d902b5bde1f0bd4ad153f44b3a1e10",
 							"txt_hash": "d7fe9655d51714c5bf45e63e61c2d881839185a1ff4e14f61ca7966eb5413589"
-						}
+						},
+						"__insert__": {
+							"source_hash": "8971926fb9516eaefe2c48eda37fca7544d902b5bde1f0bd4ad153f44b3a1e10",
+							"json_hash": "9973b520e5416c5a84831f06362e4068ce74bf66ef1b69c588113bb593978cf5"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					},
 					"report": {
 						"__update__": {
 							"convert_garbage": false,
 							"convert_ok": true,
 							"extract_ok": true,
-							"pdf_hash": "5d6639aa727515c822ed9f844361bdae928999b0f2ee524107a8692f1bcb6048",
 							"txt_hash": "b6eb438d9bc242189973aaae7ace80925e8a81fb5e19dcddf73bb6b7bc5ad012"
-						}
+						},
+						"__insert__": {
+							"source_hash": "5d6639aa727515c822ed9f844361bdae928999b0f2ee524107a8692f1bcb6048",
+							"json_hash": "766cd90f5d657b482d18638b74044af50e24ec928f8afe69855df523f06a5665"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					}
 				}
 			}
@@ -5893,18 +5989,30 @@
 							"convert_garbage": false,
 							"convert_ok": true,
 							"extract_ok": true,
-							"pdf_hash": "49332970ad55758017d5dcf4559c4900b24694c67ae1009db643bb6363405aab",
 							"txt_hash": "cf91b3a0eac4a2e07c489245d30e0456578a3efba2e8aca28cba19ff19ddcfe1"
-						}
+						},
+						"__insert__": {
+							"source_hash": "49332970ad55758017d5dcf4559c4900b24694c67ae1009db643bb6363405aab",
+							"json_hash": "6347556bc4a7d231b731d7e058b4b12b69a50a69c173e0619f869e1f2f21abeb"
+						},
+						"__delete": [
+							"pdf_hash"
+						]
 					},
 					"report": {
 						"__update__": {
 							"convert_garbage": false,
 							"convert_ok": true,
 							"extract_ok": true,
-							"pdf_hash": "a6cd8a0c24f07cc877bc53f192d8c9d78980699db55c88dc140f75eee18b0d43",
 							"txt_hash": "288e1afe17b4fee889345278f73cff5a6d44b9e277cd73ba38352a95c659bf7a"
-						}
+						},
+						"__insert__": {
+							"source_hash": "a6cd8a0c24f07cc877bc53f192d8c9d78980699db55c88dc140f75eee18b0d43",
+							"json_hash": "d03e7942a3b1b2246ece5b0ef2c52a9497f03b72c2e018d6a9ff719b65d1139e"
+						},
+						"__delete": [
+							"pdf_hash"
+						]
 					}
 				}
 			}
@@ -6486,18 +6594,30 @@
 							"convert_garbage": false,
 							"convert_ok": true,
 							"extract_ok": true,
-							"pdf_hash": "0977787f7217bf4cf76686e3d7dbb2cac8424843f5170cb08b0690c269ac9ec0",
 							"txt_hash": "1b52f4234e6a37e2be6709940409428bde684daf2af57bf85b97bf68a5f9f9dd"
-						}
+						},
+						"__insert__": {
+							"source_hash": "0977787f7217bf4cf76686e3d7dbb2cac8424843f5170cb08b0690c269ac9ec0",
+							"json_hash": "4bc83ef24631fb6a7d2e065cec76ba85df26085c7d8933bcfffae8e6877b953a"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					},
 					"report": {
 						"__update__": {
 							"convert_garbage": false,
 							"convert_ok": true,
 							"extract_ok": true,
-							"pdf_hash": "3d8977dee0fabf45b5066e2e62a50ec79ad18ccd42839f15325981c595691cf7",
 							"txt_hash": "8b704c5cdfc454d5e2dfa3c6a77f2f1dd188bb7ccc7409d88f3761ce594b57a7"
-						}
+						},
+						"__insert__": {
+							"source_hash": "3d8977dee0fabf45b5066e2e62a50ec79ad18ccd42839f15325981c595691cf7",
+							"json_hash": "402c3795e63ce0be88f491257628604f188baf09aa3f1b8bb77220d89340b468"
+						},
+						"__delete__": [
+							"pdf_hash"
+						]
 					}
 				}
 			}


### PR DESCRIPTION
This PR ensures page compatibility with https://github.com/crocs-muni/sec-certs/pull/629, which introduces a unified `DocumentState` across all certificate types.

- Replace all usages of `pdf_path/pdf_hash` with `source_path/source_hash`
- Use the new nested `DocumentState` structure for FIPS, replacing the `module_*/policy_*` fields
- Update diff schemas to reflect the new field names and structure
- Update test fixtures to reflect the new field names and structure, including `json_hash` that was introduced some time ago