### PR TITLE
Fix EUCC date parsing

### DIFF
--- a/src/sec_certs/sample/eucc.py
+++ b/src/sec_certs/sample/eucc.py
@@ -275,7 +275,7 @@ class EUCCCertificate(
         if not issuance_date_full:
             return None
         try:
-            not_valid_before = helpers.parse_date(issuance_date_full)
+            not_valid_before = helpers.parse_date(issuance_date_full, format="%d/%m/%Y")
             return not_valid_before
         except Exception:
             return None
@@ -285,7 +285,7 @@ class EUCCCertificate(
         if not issuance_date_full:
             return None
         try:
-            issuance_date = helpers.parse_date(issuance_date_full)
+            issuance_date = helpers.parse_date(issuance_date_full, format="%d/%m/%Y")
             not_valid_after = issuance_date + relativedelta(years=5)
             return not_valid_after
         except Exception:

--- a/tests/eucc/test_eucc_certificate.py
+++ b/tests/eucc/test_eucc_certificate.py
@@ -100,7 +100,7 @@ def test_get_scheme_from_cert_id(cert_id, expected_output):
     "input_text, expected_output",
     [
         ("2023-01-01", date(2023, 1, 1)),
-        ("02/04/2025", date(2025, 2, 4)),
+        ("02/04/2025", date(2025, 4, 2)),
         ("", None),
         (None, None),
         ("not a date string", None),


### PR DESCRIPTION
On the EUCC portal, dates appear to be in `DD/MM/YYYY` format. Without explicitly specifying the format, ambiguous dates (both values ≤ 12) were being parsed as `MM/DD/YYYY`, resulting in incorrect parsed dates. 

@tkachyna, is this fix ok? Feel free to adjust it (maybe consider whether testing multiple date formats even makes sense)

(I've already used this code to parse the portal, and the dates now seem correct on the page. For instance, [this entry](https://sec-certs.org/eucc/8e752071a70ac568/) is one that changed.
