### PR TITLE
fix: set convert_ok before extraction

### DIFF
--- a/src/sec_certs/dataset/fips.py
+++ b/src/sec_certs/dataset/fips.py
@@ -150,10 +150,6 @@ class FIPSDataset(Dataset[FIPSCertificate], ComplexSerializableType):
     @only_backed()
     def extract_data(self) -> None:
         logger.info("Extracting various data from certification artifacts.")
-        for cert in self:
-            cert.state.policy.extract_ok = True
-            cert.state.module.extract_ok = True
-
         self._extract_data_from_html_modules()
         self._extract_policy_pdf_metadata()
         self._extract_policy_pdf_keywords()

--- a/src/sec_certs/sample/fips.py
+++ b/src/sec_certs/sample/fips.py
@@ -459,7 +459,6 @@ class FIPSCertificate(
         algorithms, cert.web_data = parser.get_web_data_and_algorithms()
         cert.heuristics.algorithms |= algorithms
         cert.state.module.extract_ok = True
-        cert.state.module.convert_ok = True  # No conversion needed for html, so we set it to True
 
         return cert
 
@@ -475,6 +474,8 @@ class FIPSCertificate(
             cert.state.module.download_ok = False
         else:
             cert.state.module.download_ok = True
+            cert.state.module.convert_ok = True  # No conversion needed for html, so we set it to True
+
         return cert
 
     @staticmethod
@@ -519,6 +520,7 @@ class FIPSCertificate(
         """
         try:
             cert.pdf_data.policy_metadata = extract_pdf_metadata(cert.state.policy.source_path)
+            cert.state.policy.extract_ok = True
         except ValueError:
             cert.state.policy.extract_ok = False
         return cert


### PR DESCRIPTION
This PR fixes a bug in FIPS processing when metadata from HTML modules wasn't parsed due to the wrong flag order.

`convert_ok` flag for module state was set to `True` inside `parse_html_module`, but `_extract_data_from_html_modules` filters certificates via `module.is_ok_to_analyze()`, which requires `convert_ok` to be `True`. This caused lists of certs to process to be empty, so no HTML module metadata was parsed.


Fixed by setting the flag when the module is successfully downloaded. 