### PR TITLE
fix: dashboard charts and configuration section separation

### DIFF
--- a/sec_certs_page/dashboard/pages/common.py
+++ b/sec_certs_page/dashboard/pages/common.py
@@ -230,7 +230,7 @@ def _create_dashboard_name_row(cid: ComponentIDBuilder) -> dbc.Row:
                 className="d-flex align-items-center gap-2 flex-wrap",
                 children=[
                     dbc.Button(
-                        [html.I(className="fas fa-sync-alt me-2"), "Refresh All"],
+                        [html.I(className="fas fa-sync-alt me-2"), "Refresh Charts"],
                         id=cid(ComponentID.UPDATE_ALL_BTN),
                         n_clicks=0,
                         disabled=True,
@@ -238,6 +238,10 @@ def _create_dashboard_name_row(cid: ComponentIDBuilder) -> dbc.Row:
                         outline=True,
                         size="lg",
                         className="refresh-all-btn",
+                    ),
+                    dbc.Tooltip(
+                        "Reload data and redraw every chart in this dashboard.",
+                        target=cid(ComponentID.UPDATE_ALL_BTN),
                     ),
                     dbc.Button(
                         [html.I(className="fas fa-save me-2"), "Save Dashboard"],

--- a/sec_certs_page/dashboard/pages/common.py
+++ b/sec_certs_page/dashboard/pages/common.py
@@ -360,18 +360,25 @@ def _create_dashboard_content(collection_name: CollectionName) -> html.Div:
                 className="d-flex align-items-center justify-content-between mb-3",
                 children=[
                     section_header("Charts", "fas fa-chart-line", icon_color="text-primary"),
-                    dbc.Button(
-                        [html.I(className="fas fa-sync-alt me-2"), "Refresh Charts"],
-                        id=cid(ComponentID.UPDATE_ALL_BTN),
-                        n_clicks=0,
-                        disabled=True,
-                        color="secondary",
-                        outline=True,
-                        className="refresh-all-btn",
-                    ),
-                    dbc.Tooltip(
-                        "Reload data and redraw every chart in this dashboard.",
-                        target=cid(ComponentID.UPDATE_ALL_BTN),
+                    # Wrap the button and its tooltip so the toolbar has only two flex
+                    # items (left header + right button group); the tooltip is not a
+                    # visible layout element and must not participate in the flex spacing.
+                    html.Div(
+                        children=[
+                            dbc.Button(
+                                [html.I(className="fas fa-sync-alt me-2"), "Refresh Charts"],
+                                id=cid(ComponentID.UPDATE_ALL_BTN),
+                                n_clicks=0,
+                                disabled=True,
+                                color="secondary",
+                                outline=True,
+                                className="refresh-all-btn",
+                            ),
+                            dbc.Tooltip(
+                                "Reload data and redraw every chart in this dashboard.",
+                                target=cid(ComponentID.UPDATE_ALL_BTN),
+                            ),
+                        ],
                     ),
                 ],
             ),

--- a/sec_certs_page/dashboard/pages/common.py
+++ b/sec_certs_page/dashboard/pages/common.py
@@ -102,30 +102,30 @@ def _create_page_header(title: str) -> html.Div:
     )
 
 
-def _create_dashboard_control_panel(collection_name: CollectionName) -> dbc.Card:
-    """Create the unified dashboard control panel with all controls in one card.
+def _create_dashboard_control_panel(collection_name: CollectionName) -> html.Div:
+    """Create the dashboard control panel as two visually separated cards.
 
-    Contains:
-    - Dashboard selector and create new button
-    - Dashboard name input
-    - Action buttons (refresh, save)
-    - Chart controls
+    The "Load Dashboard" card (selector + create new) is kept distinct from
+    the dashboard setup card (name, actions and chart controls) so it is clear
+    that loading an existing dashboard and configuring one are separate tasks.
 
     :param collection_name: The collection name for component IDs
-    :return: Card containing all dashboard controls
+    :return: Div containing the load card and the setup card
     """
     cid = ComponentIDBuilder(collection_name)
-    return dbc.Card(
-        className="mb-4 border-0",
+    return html.Div(
         children=[
-            dbc.CardBody(
+            # Card 1: load an existing dashboard or create a new one
+            dbc.Card(
+                className="mb-4 border-0 shadow-sm",
                 children=[
-                    # Row 1: Dashboard selection / creation
-                    _create_dashboard_selector_row(cid),
-                    # Row 2: Dashboard name and actions (shown when dashboard is active)
-                    _create_dashboard_active_controls(cid),
+                    dbc.CardBody(
+                        children=[_create_dashboard_selector_row(cid)],
+                    ),
                 ],
             ),
+            # Card 2: dashboard setup (shown only when a dashboard is active)
+            _create_dashboard_active_controls(cid),
         ],
     )
 
@@ -174,20 +174,27 @@ def _create_dashboard_selector_row(cid: ComponentIDBuilder) -> dbc.Row:
     )
 
 
-def _create_dashboard_active_controls(cid: ComponentIDBuilder) -> html.Div:
-    """Create the controls shown when a dashboard is active.
+def _create_dashboard_active_controls(cid: ComponentIDBuilder) -> dbc.Card:
+    """Create the dashboard setup card shown when a dashboard is active.
+
+    Rendered as its own card so it is visually separated from the
+    "Load Dashboard" card above it.
 
     :param cid: Component ID builder
-    :return: Div containing active dashboard controls
+    :return: Card containing active dashboard controls
     """
-    return html.Div(
+    return dbc.Card(
         id=cid(ComponentID.DASHBOARD_HEADER),
+        className="mb-4 border-0 shadow-sm",
         style={"display": "none"},
         children=[
-            html.Hr(className="my-3"),
-            _create_dashboard_name_row(cid),
-            html.Hr(className="my-3"),
-            _create_chart_controls_row(cid),
+            dbc.CardBody(
+                children=[
+                    _create_dashboard_name_row(cid),
+                    html.Hr(className="my-3"),
+                    _create_chart_controls_row(cid),
+                ],
+            ),
         ],
     )
 

--- a/sec_certs_page/dashboard/pages/common.py
+++ b/sec_certs_page/dashboard/pages/common.py
@@ -120,7 +120,10 @@ def _create_dashboard_control_panel(collection_name: CollectionName) -> html.Div
                 className="mb-4 border-0 shadow-sm",
                 children=[
                     dbc.CardBody(
-                        children=[_create_dashboard_selector_row(cid)],
+                        children=[
+                            section_header("Load Dashboard", "fas fa-folder-open"),
+                            _create_dashboard_selector_row(cid),
+                        ],
                     ),
                 ],
             ),
@@ -144,7 +147,6 @@ def _create_dashboard_selector_row(cid: ComponentIDBuilder) -> dbc.Row:
                 width=12,
                 lg=True,
                 children=[
-                    dbc.Label("Load Dashboard", className="fw-bold mb-2"),
                     dcc.Dropdown(
                         id=cid(ComponentID.SELECTOR),
                         options=[],
@@ -190,6 +192,7 @@ def _create_dashboard_active_controls(cid: ComponentIDBuilder) -> dbc.Card:
         children=[
             dbc.CardBody(
                 children=[
+                    section_header("Configure Dashboard", "fas fa-sliders-h"),
                     _create_dashboard_name_row(cid),
                     html.Hr(className="my-3"),
                     _create_chart_controls_row(cid),
@@ -229,20 +232,6 @@ def _create_dashboard_name_row(cid: ComponentIDBuilder) -> dbc.Row:
                 lg="auto",
                 className="d-flex align-items-center gap-2 flex-wrap",
                 children=[
-                    dbc.Button(
-                        [html.I(className="fas fa-sync-alt me-2"), "Refresh Charts"],
-                        id=cid(ComponentID.UPDATE_ALL_BTN),
-                        n_clicks=0,
-                        disabled=True,
-                        color="secondary",
-                        outline=True,
-                        size="lg",
-                        className="refresh-all-btn",
-                    ),
-                    dbc.Tooltip(
-                        "Reload data and redraw every chart in this dashboard.",
-                        target=cid(ComponentID.UPDATE_ALL_BTN),
-                    ),
                     dbc.Button(
                         [html.I(className="fas fa-save me-2"), "Save Dashboard"],
                         id=cid(ComponentID.SAVE_DASHBOARD_BTN),
@@ -364,6 +353,28 @@ def _create_dashboard_content(collection_name: CollectionName) -> html.Div:
         id=cid(ComponentID.DASHBOARD_CONTENT),
         style={"display": "none"},
         children=[
+            # Charts toolbar: "Charts" heading on the left, bulk refresh on the right.
+            # Placed next to the chart grid (and the per-chart refresh buttons) so it is
+            # clear the button refreshes the charts, not the dashboard settings above.
+            html.Div(
+                className="d-flex align-items-center justify-content-between mb-3",
+                children=[
+                    section_header("Charts", "fas fa-chart-line", icon_color="text-primary"),
+                    dbc.Button(
+                        [html.I(className="fas fa-sync-alt me-2"), "Refresh Charts"],
+                        id=cid(ComponentID.UPDATE_ALL_BTN),
+                        n_clicks=0,
+                        disabled=True,
+                        color="secondary",
+                        outline=True,
+                        className="refresh-all-btn",
+                    ),
+                    dbc.Tooltip(
+                        "Reload data and redraw every chart in this dashboard.",
+                        target=cid(ComponentID.UPDATE_ALL_BTN),
+                    ),
+                ],
+            ),
             # Chart container
             html.Div(id=cid(ComponentID.CHART_CONTAINER)),
             # Chart creation modal


### PR DESCRIPTION
So, based on points 5 and 6 from Issue #568, I came up with this change.

The screenshots will describe it the best.

<img width="2118" height="645" alt="image" src="https://github.com/user-attachments/assets/b3b2cc16-0373-40af-a54d-26efe44fd3d5" />

<img width="2169" height="1316" alt="image" src="https://github.com/user-attachments/assets/49156c0b-4a0a-46b0-b4ac-844ab4a742dc" />

It is preparing the page for changes that will come with implementing requests from point 7.