### PR TITLE
fix(dashboard): correct pie chart Y-axis and Color By behavior

### DIFF
--- a/sec_certs_page/dashboard/callbacks/modal.py
+++ b/sec_certs_page/dashboard/callbacks/modal.py
@@ -785,6 +785,8 @@ def _register_y_axis_visibility(dash_app: "Dash", collection_name: CollectionNam
     @dash_app.callback(
         output={
             "y_controls_style": Output(component_builder(ComponentID.MODAL_Y_VALUE_CONTROLS), "style"),
+            "color_controls_style": Output(component_builder(ComponentID.MODAL_COLOR_CONTROLS), "style"),
+            "color_value": Output(component_builder(ComponentID.MODAL_COLOR_FIELD), "value", allow_duplicate=True),
             "aggregation_disabled": Output(component_builder(ComponentID.MODAL_AGGREGATION), "disabled"),
             "y_field_disabled": Output(component_builder(ComponentID.MODAL_Y_FIELD), "disabled", allow_duplicate=True),
             "y_label_disabled": Output(component_builder(ComponentID.MODAL_Y_LABEL), "disabled"),
@@ -796,9 +798,11 @@ def _register_y_axis_visibility(dash_app: "Dash", collection_name: CollectionNam
         prevent_initial_call=True,
     )
     def update_y_axis_visibility(chart_type):
-        """Adjust Y-axis controls per chart type.
+        """Adjust Y-axis and Color By controls per chart type.
 
-        - Pie charts have no Y-axis, so the whole Y-axis controls block is hidden.
+        - Pie charts have no Y-axis and cannot render a secondary color grouping,
+          so the whole Y-axis block and the Color By control are hidden. The Color
+          By value is also cleared so a stale selection cannot split the pie data.
         - Histograms compute frequency automatically, so the aggregation/field
           controls are disabled and forced to COUNT.
         """
@@ -807,6 +811,8 @@ def _register_y_axis_visibility(dash_app: "Dash", collection_name: CollectionNam
 
         return {
             "y_controls_style": {"display": "none"} if is_pie else {"display": "block"},
+            "color_controls_style": {"display": "none"} if is_pie else {"display": "block"},
+            "color_value": None if is_pie else no_update,
             "aggregation_disabled": is_histogram,
             "y_field_disabled": is_histogram,
             "y_label_disabled": False,  # Keep label editable for all chart types

--- a/sec_certs_page/dashboard/callbacks/modal.py
+++ b/sec_certs_page/dashboard/callbacks/modal.py
@@ -779,11 +779,12 @@ def _register_chart_type_help(dash_app: "Dash", collection_name: CollectionName)
 
 
 def _register_y_axis_visibility(dash_app: "Dash", collection_name: CollectionName) -> None:
-    """Hide/disable Y-axis aggregation fields for histograms."""
+    """Hide/disable Y-axis aggregation fields based on chart type."""
     component_builder = ComponentIDBuilder(collection_name)
 
     @dash_app.callback(
         output={
+            "y_controls_style": Output(component_builder(ComponentID.MODAL_Y_VALUE_CONTROLS), "style"),
             "aggregation_disabled": Output(component_builder(ComponentID.MODAL_AGGREGATION), "disabled"),
             "y_field_disabled": Output(component_builder(ComponentID.MODAL_Y_FIELD), "disabled", allow_duplicate=True),
             "y_label_disabled": Output(component_builder(ComponentID.MODAL_Y_LABEL), "disabled"),
@@ -795,10 +796,17 @@ def _register_y_axis_visibility(dash_app: "Dash", collection_name: CollectionNam
         prevent_initial_call=True,
     )
     def update_y_axis_visibility(chart_type):
-        """Disable Y-axis aggregation controls for histograms since they compute frequency automatically."""
+        """Adjust Y-axis controls per chart type.
+
+        - Pie charts have no Y-axis, so the whole Y-axis controls block is hidden.
+        - Histograms compute frequency automatically, so the aggregation/field
+          controls are disabled and forced to COUNT.
+        """
+        is_pie = chart_type == "pie"
         is_histogram = chart_type == "histogram"
 
         return {
+            "y_controls_style": {"display": "none"} if is_pie else {"display": "block"},
             "aggregation_disabled": is_histogram,
             "y_field_disabled": is_histogram,
             "y_label_disabled": False,  # Keep label editable for all chart types

--- a/sec_certs_page/dashboard/chart/config.py
+++ b/sec_certs_page/dashboard/chart/config.py
@@ -130,6 +130,18 @@ class ChartConfig:
     created_at: datetime | None = None
     updated_at: datetime | None = None
 
+    def __post_init__(self) -> None:
+        """Normalize configuration invariants that must hold for every chart.
+
+        Pie charts render a single ``names``/``values`` series and cannot show a
+        secondary color grouping. Keeping a ``color_axis`` on a pie would still
+        split the underlying aggregation by (x, color), producing duplicate slice
+        names and distorted values. Drop it here so the invariant holds no matter
+        how the config was built (modal form, saved dashboard, predefined chart).
+        """
+        if self.chart_type == ChartType.PIE and self.color_axis is not None:
+            self.color_axis = None
+
     def add_filter(self, filter_config: FilterSpec) -> None:
         """Add or update a filter configuration.
 

--- a/sec_certs_page/dashboard/dependencies.py
+++ b/sec_certs_page/dashboard/dependencies.py
@@ -70,6 +70,7 @@ class ComponentID(str, Enum):
     MODAL_X_FIELD = "modal-x-field"
     MODAL_X_LABEL = "modal-x-label"
     MODAL_COLOR_FIELD = "modal-color-field"
+    MODAL_COLOR_CONTROLS = "modal-color-controls"
     MODAL_AGGREGATION = "modal-aggregation"
     MODAL_Y_FIELD = "modal-y-field"
     MODAL_Y_LABEL = "modal-y-label"

--- a/sec_certs_page/dashboard/dependencies.py
+++ b/sec_certs_page/dashboard/dependencies.py
@@ -73,6 +73,7 @@ class ComponentID(str, Enum):
     MODAL_AGGREGATION = "modal-aggregation"
     MODAL_Y_FIELD = "modal-y-field"
     MODAL_Y_LABEL = "modal-y-label"
+    MODAL_Y_VALUE_CONTROLS = "modal-y-value-controls"
     MODAL_SHOW_LEGEND = "modal-show-legend"
     MODAL_SHOW_GRID = "modal-show-grid"
     MODAL_Y_LOG_SCALE = "modal-y-log-scale"

--- a/sec_certs_page/dashboard/pages/common.py
+++ b/sec_certs_page/dashboard/pages/common.py
@@ -522,11 +522,18 @@ def _create_x_axis_settings(cid: ComponentIDBuilder) -> html.Div:
                 label="Label",
                 placeholder="Optional label...",
             ),
-            labeled_dropdown(
-                component_id=cid(ComponentID.MODAL_COLOR_FIELD),
-                label="Color By",
-                placeholder="Optional secondary grouping...",
-                class_name="",
+            # Color By is a secondary grouping that some chart types (e.g. pie)
+            # cannot render, so it is wrapped to be hidden for those types.
+            html.Div(
+                id=cid(ComponentID.MODAL_COLOR_CONTROLS),
+                children=[
+                    labeled_dropdown(
+                        component_id=cid(ComponentID.MODAL_COLOR_FIELD),
+                        label="Color By",
+                        placeholder="Optional secondary grouping...",
+                        class_name="",
+                    ),
+                ],
             ),
             # Hidden components for backwards compatibility
             hidden_collapse_components(cid),

--- a/sec_certs_page/dashboard/pages/common.py
+++ b/sec_certs_page/dashboard/pages/common.py
@@ -543,60 +543,66 @@ def _create_y_axis_settings(cid: ComponentIDBuilder) -> html.Div:
     return html.Div(
         className="mb-3",
         children=[
-            subsection_header("Y-Axis", "fas fa-arrows-alt-v"),
-            # Aggregation dropdown
+            # Y-axis-specific controls, hidden for chart types without a Y-axis (e.g. pie)
             html.Div(
-                className="mb-3",
+                id=cid(ComponentID.MODAL_Y_VALUE_CONTROLS),
                 children=[
-                    dbc.Label("Aggregation", className="small text-muted mb-1"),
-                    dcc.Dropdown(
-                        id=cid(ComponentID.MODAL_AGGREGATION),
-                        options=get_aggregation_options(),
-                        value="count",
-                        clearable=False,
-                        className="dash-bootstrap",
+                    subsection_header("Y-Axis", "fas fa-arrows-alt-v"),
+                    # Aggregation dropdown
+                    html.Div(
+                        className="mb-3",
+                        children=[
+                            dbc.Label("Aggregation", className="small text-muted mb-1"),
+                            dcc.Dropdown(
+                                id=cid(ComponentID.MODAL_AGGREGATION),
+                                options=get_aggregation_options(),
+                                value="count",
+                                clearable=False,
+                                className="dash-bootstrap",
+                            ),
+                        ],
                     ),
+                    # Field to aggregate
+                    html.Div(
+                        className="mb-1",
+                        children=[
+                            dbc.Label("Field to Aggregate", className="small text-muted mb-1"),
+                            dcc.Dropdown(
+                                id=cid(ComponentID.MODAL_Y_FIELD),
+                                options=[],
+                                placeholder="For SUM/AVG/MIN/MAX...",
+                                disabled=True,
+                                className="dash-bootstrap",
+                            ),
+                        ],
+                    ),
+                    dbc.FormText(
+                        id=cid(ComponentID.MODAL_Y_FIELD_HELP),
+                        children="Not required for COUNT.",
+                        className="text-muted small mb-3",
+                    ),
+                    labeled_input(
+                        component_id=cid(ComponentID.MODAL_Y_LABEL),
+                        label="Label",
+                        placeholder="Optional label...",
+                    ),
+                    # Y Values options
+                    dbc.Checkbox(
+                        id=cid(ComponentID.MODAL_SHOW_NON_ZERO),
+                        label="Show only non-zero values",
+                        value=False,
+                        className="mb-2",
+                    ),
+                    dbc.Checkbox(
+                        id=cid(ComponentID.MODAL_Y_LOG_SCALE),
+                        label="Y-axis Logarithmic Scale",
+                        value=False,
+                        className="mb-2",
+                    ),
+                    # Display options
+                    html.Hr(className="my-3"),
                 ],
             ),
-            # Field to aggregate
-            html.Div(
-                className="mb-1",
-                children=[
-                    dbc.Label("Field to Aggregate", className="small text-muted mb-1"),
-                    dcc.Dropdown(
-                        id=cid(ComponentID.MODAL_Y_FIELD),
-                        options=[],
-                        placeholder="For SUM/AVG/MIN/MAX...",
-                        disabled=True,
-                        className="dash-bootstrap",
-                    ),
-                ],
-            ),
-            dbc.FormText(
-                id=cid(ComponentID.MODAL_Y_FIELD_HELP),
-                children="Not required for COUNT.",
-                className="text-muted small mb-3",
-            ),
-            labeled_input(
-                component_id=cid(ComponentID.MODAL_Y_LABEL),
-                label="Label",
-                placeholder="Optional label...",
-            ),
-            # Y Values options
-            dbc.Checkbox(
-                id=cid(ComponentID.MODAL_SHOW_NON_ZERO),
-                label="Show only non-zero values",
-                value=False,
-                className="mb-2",
-            ),
-            dbc.Checkbox(
-                id=cid(ComponentID.MODAL_Y_LOG_SCALE),
-                label="Y-axis Logarithmic Scale",
-                value=False,
-                className="mb-2",
-            ),
-            # Display options
-            html.Hr(className="my-3"),
             dbc.Checkbox(
                 id=cid(ComponentID.MODAL_SHOW_LEGEND),
                 label="Show Legend",

--- a/tests/unit/test_chart_config.py
+++ b/tests/unit/test_chart_config.py
@@ -623,3 +623,57 @@ class TestChartWithColorAxis:
 
         assert chart.color_axis is not None
         assert chart.color_axis.field == "scheme"
+
+
+class TestPieChartColorAxisInvariant:
+    """Pie charts cannot render a secondary color grouping.
+
+    A color_axis on a pie would split the aggregation by (x, color), producing
+    duplicate slice names and distorted values, so it must be dropped no matter
+    how the config is constructed.
+    """
+
+    def test_pie_construction_drops_color_axis(self) -> None:
+        """Building a pie Chart with a color axis clears it."""
+        chart = Chart(
+            chart_id=uuid4(),
+            name="pie-test",
+            chart_type=ChartType.PIE,
+            collection_name=CollectionName.CommonCriteria,
+            x_axis=AxisConfig(field="category", label="Category"),
+            y_axis=AxisConfig(field="count", label="Count", aggregation=AggregationType.COUNT),
+            color_axis=AxisConfig(field="scheme", label="Scheme"),
+        )
+
+        assert chart.color_axis is None
+
+    def test_pie_from_dict_drops_color_axis(self) -> None:
+        """Deserializing a saved/legacy pie config drops the color axis."""
+        data = {
+            "chart_id": str(uuid4()),
+            "name": "pie-test",
+            "chart_type": ChartType.PIE.value,
+            "collection_name": CollectionName.CommonCriteria.value,
+            "x_axis": {"field": "category", "label": "Category"},
+            "y_axis": {"field": "count", "label": "Count", "aggregation": AggregationType.COUNT},
+            "color_axis": {"field": "scheme", "label": "Scheme"},
+        }
+
+        chart = Chart.from_dict(data)
+
+        assert chart.color_axis is None
+
+    def test_non_pie_keeps_color_axis(self) -> None:
+        """The invariant only affects pie charts; other types are untouched."""
+        chart = Chart(
+            chart_id=uuid4(),
+            name="bar-test",
+            chart_type=ChartType.BAR,
+            collection_name=CollectionName.CommonCriteria,
+            x_axis=AxisConfig(field="category", label="Category"),
+            y_axis=AxisConfig(field="count", label="Count", aggregation=AggregationType.COUNT),
+            color_axis=AxisConfig(field="scheme", label="Scheme"),
+        )
+
+        assert chart.color_axis is not None
+        assert chart.color_axis.field == "scheme"


### PR DESCRIPTION
Addresses **point 8** of the UI review in crocs-muni/sec-certs#568.

- **Y-axis controls hidden for pie** — pie charts have no Y-axis, so the aggregation/field/label block is hidden (previously shown but inert).
- **Color By hidden for pie + cleared on switch** — pie cannot render a secondary color grouping.
- **Model invariant** — `ChartConfig.__post_init__` drops `color_axis` for pie charts.

"Color By" wasn't just unusable on pie — it **corrupted data**. When set, both the MongoDB pipeline and the pandas fallback grouped by `(x, color)`, but `px.pie` only uses `names=x`, producing **duplicate slice names and distorted values**.

The model-level invariant covers every construction path (modal form, saved dashboards via `from_dict`, predefined charts), so even an old stored pie config renders correctly regardless of the UI.
