### PR TITLE
fix: make test_process_parallel_callback order-independent

### DIFF
--- a/tests/test_parallel_processing.py
+++ b/tests/test_parallel_processing.py
@@ -51,7 +51,7 @@ def test_process_parallel_callback():
         collected.append(result)
 
     process_parallel(_identity, [10, 20, 30], callback=_on_result, progress_bar=False)
-    assert collected == [10, 20, 30]
+    assert sorted(collected) == [10, 20, 30]
 
 
 def test_process_parallel_empty_items():


### PR DESCRIPTION
Fix of issue #656 
Now it should be correctly order independent. I tested the fix by starting the test 50 times and everytime it was correct.