### PR TITLE
fix: handle missing package key

### DIFF
--- a/src/sec_certs/sample/eucc.py
+++ b/src/sec_certs/sample/eucc.py
@@ -332,7 +332,7 @@ class EUCCCertificate(
         product_name = metadata.get("product_name", "")
         holder_name = metadata.get("holder_name", "")
         scheme = EUCCCertificate._get_scheme_from_cert_id(certificate_id)
-        security_level = EUCCCertificate._extract_first_eal(metadata["package"])
+        security_level = EUCCCertificate._extract_first_eal(metadata.get("package", ""))
         not_valid_before = EUCCCertificate._get_not_valid_before(metadata.get("issuance_date_full"))
         not_valid_after = EUCCCertificate._get_not_valid_after(metadata.get("issuance_date_full"))
         status = EUCCCertificate._get_status(not_valid_after)


### PR DESCRIPTION
`_from_metadata_dict` assumed the `package` key was always present, but some EUCC certificate (https://certification.enisa.europa.eu/certificates/eucc-3087-2026-0000000006-00000_en) do not include this entry in the table. It is now handled by defaulting to an empty string if there is no package parsed, consistent with other metadata.