### PR TITLE
Fix slow tooltip delay

### DIFF
--- a/sec_certs_page/static/base.css
+++ b/sec_certs_page/static/base.css
@@ -1193,3 +1193,9 @@ h6 {
     outline-offset: 2px;
     border-radius: 0.25rem;
 }
+
+abbr {
+    text-decoration: underline dotted;
+    text-decoration-skip-ink: none;
+    cursor: help;
+}

--- a/sec_certs_page/templates/common/base.html.jinja2
+++ b/sec_certs_page/templates/common/base.html.jinja2
@@ -224,9 +224,12 @@
 <a href="#content" class="skip-link">Skip to main content</a>
 <script>
     $(function () {
-        let tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
-        tooltipTriggerList.map(function (tooltipTriggerEl) {
-            return new bootstrap.Tooltip(tooltipTriggerEl);
+        // Turn every hover hint into a faster Bootstrap tooltip
+        let tooltipTriggerList = [].slice.call(document.querySelectorAll(
+            '[data-bs-toggle="tooltip"], [title]:not([data-bs-toggle])'
+        ));
+        tooltipTriggerList.forEach(function (tooltipTriggerEl) {
+            new bootstrap.Tooltip(tooltipTriggerEl);
         });
     });
 </script>

--- a/sec_certs_page/templates/common/base.html.jinja2
+++ b/sec_certs_page/templates/common/base.html.jinja2
@@ -229,7 +229,7 @@
             '[data-bs-toggle="tooltip"], [title]:not([data-bs-toggle])'
         ));
         tooltipTriggerList.forEach(function (tooltipTriggerEl) {
-            new bootstrap.Tooltip(tooltipTriggerEl);
+            new bootstrap.Tooltip(tooltipTriggerEl, {delay: {show: 100, hide: 0}});
         });
     });
 </script>


### PR DESCRIPTION
Belongs to issue #662 

Hover hints (EAL, extracted keywords…) used the browser's
native "title" tooltip, which has a 1s delay. This switches them to the
Bootstrap tooltips the site already uses elsewhere, so they appear after ~0.1s
and look consistent. Also now the color of the small window that appers is dependent on the mode that you use. 
Light mode->black window; Dark mode->white window.

- `base.html`: apply Bootstrap tooltips to all "title" elements, with a 0.1s show delay
- `base.css`: re-add the dotted underline + "?" cursor on "<abbr>" (Bootstrap strips "title", which removed the default styling)

To consider:
sec_certs_page/templates/common/base.html.jinja2 line 232: This delay seems nice to me, but it can be easily changed if needed.