### PR TITLE
fix(dashboard): make the chart title a visible required field

### DIFF
--- a/sec_certs_page/dashboard/pages/common.py
+++ b/sec_certs_page/dashboard/pages/common.py
@@ -432,22 +432,20 @@ def _create_modal_header(cid: ComponentIDBuilder) -> dbc.ModalHeader:
                         children=[html.I(className="fas fa-chart-bar me-2"), "Create Custom Chart"],
                         className="text-muted d-block mb-3",
                     ),
-                    html.Div(
-                        className="d-flex align-items-center mb-3",
-                        children=[
-                            dbc.Input(
-                                id=cid(ComponentID.MODAL_CHART_TITLE),
-                                type="text",
-                                placeholder="New chart",
-                                value="",
-                                className="border-0 fs-4 fw-bold p-0 bg-transparent",
-                                style={"outline": "none", "boxShadow": "none"},
-                            ),
-                            html.I(
-                                className="fas fa-pencil-alt ms-2 text-muted",
-                                style={"fontSize": "0.9rem"},
-                            ),
+                    dbc.Label(
+                        [
+                            "Chart title",
+                            html.Span("*", className="text-danger ms-1"),
                         ],
+                        html_for=cid(ComponentID.MODAL_CHART_TITLE),
+                        className="fw-bold mb-1",
+                    ),
+                    dbc.Input(
+                        id=cid(ComponentID.MODAL_CHART_TITLE),
+                        type="text",
+                        placeholder="e.g. Certificates per year",
+                        value="",
+                        className="fs-5 fw-bold mb-3",
                     ),
                     dbc.Alert(
                         id=cid(ComponentID.MODAL_VALIDATION_ALERT),


### PR DESCRIPTION
Addresses **point 1** of the UI review in crocs-muni/sec-certs#568.

## The problem
The custom-chart modal's title input was disguised as a label — borderless, transparent, no box, only a faint pencil icon. It is **mandatory**, but users couldn't tell it was a fillable required field until Save failed with a validation error (see the review screenshots).

Now it renders as a proper field:
- a visible **"Chart title"** label with a red required **\***,
- a normal bordered input with an instructive placeholder (`e.g. Certificates per year`).

