### PR TITLE
fix: handle missing package

### DIFF
--- a/sec_certs_page/templates/eucc/entry/components/webpage_info.html.jinja2
+++ b/sec_certs_page/templates/eucc/entry/components/webpage_info.html.jinja2
@@ -124,6 +124,7 @@
             <tr data-cs-name="Package">
                 <th scope="row">Package</th>
                 <td>
+                {% if cert["other_metadata"]["package"] %}
                     {% for level, components in cert["other_metadata"]["package"].items() %}
                         {% if level == "COMP" %}
                             <abbr title="Composite evaluation package">COMP</abbr>
@@ -150,6 +151,9 @@
                         {% endif %}
                         {% if not loop.last %}<br>{% endif %}
                     {% endfor %}
+                {% else %}
+                    N/A
+                {% endif %}
                 </td>
             </tr>
             </tbody>


### PR DESCRIPTION
This should've gone together with https://github.com/crocs-muni/sec-certs/pull/661. 

It handles missing `package` in the EUCC web entry by displaying N/A instead.