### PR TITLE
fix: improve advanced syntax handling

### DIFF
--- a/sec_certs_page/common/search/query.py
+++ b/sec_certs_page/common/search/query.py
@@ -51,6 +51,7 @@ def detect_advanced_syntax(query: str) -> set[str]:
         ("set", r"\bIN\s*\[[^\]]*\]"),
         ("boost", r"\^(\d+|\d*\.\d*)"),
         ("regex", r"/[^/\n]+/"),
+        ("match_all", r"^\s*\*\s*$"),
     ]
 
     matched = set()

--- a/sec_certs_page/common/search/query.py
+++ b/sec_certs_page/common/search/query.py
@@ -61,6 +61,22 @@ def detect_advanced_syntax(query: str) -> set[str]:
     return matched
 
 
+_HAS_FIELD_PREFIX = re.compile(r"^\s*[+\-(]*\w+:")
+
+
+def need_field_targeting(query: str, advanced_features: set[str]) -> bool:
+    is_needed = {"range", "set", "regex"} & advanced_features
+    return bool(is_needed) and not _HAS_FIELD_PREFIX.match(query)
+
+
+def parse_field_query(index: Index, value: str, field_name: str, allow_regexes: bool) -> tuple[Query, Any]:
+    advanced_features = detect_advanced_syntax(value)
+    text = f"{field_name}:{value}" if need_field_targeting(value, advanced_features) else value
+    return index.parse_query_lenient(
+        text, default_field_names=[field_name], conjunction_by_default=True, allow_regexes=allow_regexes
+    )
+
+
 def get_expanded_query(query: str, field_name: str, raw: bool, prefix: bool, schema: Schema) -> Query:
     words = default_tokenizer.analyze(query) if not raw else query.split()
     subqueries = []
@@ -86,16 +102,10 @@ def get_text_query(
     if query is None:
         return Query.all_query(), None
 
-    advanced_features = detect_advanced_syntax(query)
-    if not advanced_features:
+    if not detect_advanced_syntax(query):
         return get_expanded_query(query, field_name, raw, prefix, schema), None
 
-    if not re.search(r"\w+:", query):
-        query = f"{field_name}:{query}"
-
-    return index.parse_query_lenient(
-        query, default_field_names=[field_name], conjunction_by_default=True, allow_regexes=True
-    )
+    return parse_field_query(index, query, field_name, allow_regexes=True)
 
 
 def build_keyword_query(schema: Schema, units: list[list[str]], fields: list[str], mode: str) -> Query:
@@ -199,14 +209,11 @@ def get_body_query(index: Callable[[], Index], value: str | None, doc_types: lis
     if value is None:
         return Query.empty_query()
 
-    advanced_features = detect_advanced_syntax(value)
+    idx = index()
     subqueries = []
     for doc_type in doc_types:
         field_name = f"body_{doc_type}" if doc_type else "body"
-        text = value if not advanced_features or re.match(r"\w+:", value) else f"{field_name}:{value}"
-        parsed_query, err = index().parse_query_lenient(
-            text, default_field_names=[field_name], conjunction_by_default=True, allow_regexes=False
-        )
+        parsed_query, err = parse_field_query(idx, value, field_name, allow_regexes=False)
         errors.add("query", err)
         subqueries.append((Occur.Should, parsed_query))
 

--- a/sec_certs_page/fips/search.py
+++ b/sec_certs_page/fips/search.py
@@ -8,7 +8,6 @@ from ..common.search.query import (
     Search,
     SearchConfig,
     build_must_query,
-    detect_advanced_syntax,
     get_body_query,
     get_date_query,
     get_keyword_query,
@@ -16,6 +15,7 @@ from ..common.search.query import (
     get_term_query,
     get_term_set_query,
     get_text_field_query,
+    parse_field_query,
     select_by_bitmask,
     select_by_id,
 )
@@ -28,10 +28,7 @@ def _fips_cert_id_query(value: str | None, errors: Errors) -> Query:
     if value is None:
         return Query.all_query()
 
-    text = value if not detect_advanced_syntax(value) else f"cert_id:{value}"
-    parsed_query, err = fips_index().parse_query_lenient(
-        text, default_field_names=["cert_id"], conjunction_by_default=True, allow_regexes=False
-    )
+    parsed_query, err = parse_field_query(fips_index(), value, "cert_id", allow_regexes=False)
     errors.add("cert_id", err)
     return parsed_query
 

--- a/tests/unit/search/test_fields.py
+++ b/tests/unit/search/test_fields.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 
 from sec_certs_page.common.search.fields import DateField, FloatField, IntField, OptionField, TextField
-from sec_certs_page.common.search.query import detect_advanced_syntax, select_by_bitmask, select_by_id
 
 
 def _result(res):
@@ -60,28 +59,3 @@ def test_date_field():
     assert _result(field.parse("2020-01-02")) == (True, datetime(2020, 1, 2), None)
     assert field.parse("not-a-date").ok is False
     assert _result(field.parse(None)) == (True, None, None)
-
-
-def test_detect_advanced_syntax():
-    assert detect_advanced_syntax("simple query") == set()
-    assert "boolean_op" in detect_advanced_syntax("foo AND bar")
-    assert "phrase" in detect_advanced_syntax('"foo bar"')
-    assert "range" in detect_advanced_syntax("[2020-01-01 TO 2021-01-01]")
-    assert "regex" in detect_advanced_syntax("/foo.*bar/")
-
-
-def test_select_by_bitmask():
-    options = ["a", "b", "c", "d"]
-    assert select_by_bitmask(None, options) == options
-    assert select_by_bitmask(0, options) == options
-    assert select_by_bitmask(0b1010, options) == ["b", "d"]
-    assert select_by_bitmask(0b0001, options) == ["a"]
-
-
-def test_select_by_id():
-    options = {"x": {"id": "a"}, "y": {"id": "b"}}
-    selected = select_by_id("a", options)
-    assert selected["x"]["selected"] is True
-    assert selected["y"]["selected"] is False
-    assert all(val["selected"] for val in select_by_id("", options).values())
-    assert all(val["selected"] for val in select_by_id(None, options).values())

--- a/tests/unit/search/test_query_builders.py
+++ b/tests/unit/search/test_query_builders.py
@@ -4,6 +4,7 @@ import pytest
 from sec_certs_page.cc.index import cc_schema
 from sec_certs_page.common.search.query import (
     Errors,
+    detect_advanced_syntax,
     get_body_query,
     get_date_query,
     get_id_query,
@@ -12,6 +13,9 @@ from sec_certs_page.common.search.query import (
     get_term_query,
     get_term_set_query,
     get_text_field_query,
+    need_field_targeting,
+    select_by_bitmask,
+    select_by_id,
 )
 from sec_certs_page.vuln.index import cve_schema
 
@@ -47,6 +51,52 @@ def cc_body_index(make_index):
             {"dgst": "B", "body_report": "no findings of note"},
         ],
     )
+
+
+def test_detect_advanced_syntax():
+    assert detect_advanced_syntax("simple query") == set()
+    assert "boolean_op" in detect_advanced_syntax("foo AND bar")
+    assert "phrase" in detect_advanced_syntax('"foo bar"')
+    assert "must_exclude" in detect_advanced_syntax("foo -bar")
+    assert "range" in detect_advanced_syntax("[2020-01-01 TO 2021-01-01]")
+    assert "set" in detect_advanced_syntax("IN [1 2 3]")
+    assert "regex" in detect_advanced_syntax("/foo.*bar/")
+    assert "boost" in detect_advanced_syntax("foo^2")
+    assert "match_all" in detect_advanced_syntax("*")
+
+
+def test_need_field_targeting():
+    assert need_field_targeting("[1 TO 2]", {"range"})
+    assert need_field_targeting("IN [1 2 3]", {"set"})
+    assert need_field_targeting("/foo.*/", {"regex"})
+    assert need_field_targeting("[2020-01-01T00:00:00 TO 2021-01-01T00:00:00]", {"range"})
+    assert need_field_targeting("/host:.*/", {"regex"})
+
+    assert not need_field_targeting("field:[1 TO 2]", {"range"})
+    assert not need_field_targeting("field:[2020-01-01T00:00:00 TO 2021-01-01T00:00:00]", {"range"})
+    assert not need_field_targeting("foo AND bar", {"boolean_op"})
+    assert not need_field_targeting('"redhat"', {"phrase"})
+    assert not need_field_targeting("+apple", {"must_exclude"})
+    assert not need_field_targeting("foo^2", {"boost"})
+    assert not need_field_targeting("*", {"match_all"})
+    assert not need_field_targeting("simple", set())
+
+
+def test_select_by_bitmask():
+    options = ["a", "b", "c", "d"]
+    assert select_by_bitmask(None, options) == options
+    assert select_by_bitmask(0, options) == options
+    assert select_by_bitmask(0b1010, options) == ["b", "d"]
+    assert select_by_bitmask(0b0001, options) == ["a"]
+
+
+def test_select_by_id():
+    options = {"x": {"id": "a"}, "y": {"id": "b"}}
+    selected = select_by_id("a", options)
+    assert selected["x"]["selected"] is True
+    assert selected["y"]["selected"] is False
+    assert all(val["selected"] for val in select_by_id("", options).values())
+    assert all(val["selected"] for val in select_by_id(None, options).values())
 
 
 def test_id_query_exact_raw_match(cc_id_index, hits):


### PR DESCRIPTION
- Prefix the query with `field:` for advanced syntax only when necessary. This fixes the issue when you only wrote exclude `-term`; with prepend `field:` it was parsed as a real search query instead of an exclude term. Without it, Tantivy parses it correctly as an exclude term. Currently, it prefixes just range, set, and regex queries that actually need it if the user doesn't prefix it.

- Parse `*` as all query. 