### PR TITLE
Modified certificate regex for the Netherlands; add certificate regex for Sweden

### DIFF
--- a/src/sec_certs/rules.yaml
+++ b/src/sec_certs/rules.yaml
@@ -29,8 +29,8 @@ cc_cert_id:
     # EUCC-3090-2025-10-0004
   NL:
     - "(?:NSCIB-|CC-|NSCIB-CC-)(?P<core>((?P<year>[0-9]{2})-)?(?:-?[0-9]+)+)(?:-?(?P<doc>(?:CR|MA|MR)(?P<version>[0-9]*)))?"
-    - "EUCC-3110-(?P<year>[0-9]{4})-(?P<id>[0-9]+)-(?P<revision_number>[0-9]+)$"
-    - "EUCC-3110-(?P<year>[0-9]{4})-(?P<id>[0-9]+)-(?P<id2>[0-9]+)-(?P<revision_number>[0-9]+)$"
+    - "EUCC-(?:3110|3100)-(?P<year>[0-9]{4})-(?P<id>[0-9]+)-(?P<revision_number>[0-9]+)$"
+    - "EUCC-(?:3110|3100)-(?P<year>[0-9]{4})-(?P<id>[0-9]+)-(?P<id2>[0-9]+)-(?P<revision_number>[0-9]+)$"
     # Examples:
     # NSCIB-CC-22-0428888-CR2  (with year=22 and CR2)
     # NSCIB-CC-228723-CR  (no year)
@@ -109,6 +109,7 @@ cc_cert_id:
     # 21.0.03/TSE-CCCS-33
   SE:
     - "CSEC ?(?P<year>[0-9]{4})(?P<counter>[0-9]{2,3})"
+    - "EUCC-3135-(?P<year>[0-9]{4})-(?P<id>[0-9]+)-(?P<revision_number>[0-9]+)$"
     # Examples:
     # CSEC2019015
     # CSEC 2019012

--- a/tests/eucc/test_eucc_certificate.py
+++ b/tests/eucc/test_eucc_certificate.py
@@ -89,6 +89,8 @@ def test_parse_package(input_text, expected_output):
         ("EUCC-3110-2025-08-2500052-01", "NL"),
         ("EUCC-3110-2025-0002500052-00001", "NL"),
         ("EUCC-3090-2025-0000000006-00000", "FR"),
+        ("EUCC-3135-2026-0000000001-00000", "SE"),
+        ("EUCC-3100-2026-0007001701-00000", "NL")
     ],
 )
 def test_get_scheme_from_cert_id(cert_id, expected_output):

--- a/tests/eucc/test_eucc_certificate.py
+++ b/tests/eucc/test_eucc_certificate.py
@@ -90,7 +90,7 @@ def test_parse_package(input_text, expected_output):
         ("EUCC-3110-2025-0002500052-00001", "NL"),
         ("EUCC-3090-2025-0000000006-00000", "FR"),
         ("EUCC-3135-2026-0000000001-00000", "SE"),
-        ("EUCC-3100-2026-0007001701-00000", "NL")
+        ("EUCC-3100-2026-0007001701-00000", "NL"),
     ],
 )
 def test_get_scheme_from_cert_id(cert_id, expected_output):


### PR DESCRIPTION
- modified the regex for the certificate from the Netherlands, because the [NANDO ID 3100](https://webgate.ec.europa.eu/single-market-compliance-space/notified-bodies/free-search?filter=notificationStatus:1,bodyNumber:3100) is also Dutch
- first Swedish certificate has dropped -> added regex for it