### PR TITLE
 Fix crash on EUCC duplicate-certificate view

### DIFF
--- a/sec_certs_page/templates/eucc/entry/components/header.html.jinja2
+++ b/sec_certs_page/templates/eucc/entry/components/header.html.jinja2
@@ -30,7 +30,7 @@
                                     <a href="{{ url_for("eucc.entry", hashid=other["_id"]) }}">{{ other["name"] }}</a>
                                 </td>
                                 <td class="py-2"
-                                    class="align-middle">{{ other["other_metadata"]["certificate_id"] }}</td>
+                                    class="align-middle">{{ other["cert_id"] }}</td>
                                 <td class="py-2">
                                     <a href="{{ url_for("eucc.compare", one_hashid=hashid, other_hashid=other["_id"]) }}"
                                        class="btn btn-outline-secondary">Compare</a></td>

--- a/sec_certs_page/templates/include/entry.html.jinja2
+++ b/sec_certs_page/templates/include/entry.html.jinja2
@@ -501,13 +501,15 @@
 {% endmacro %}
 
 {% macro clickable_contact(value) %}
-    {% set words = value.split(" ") %}
-    {% for word in words %}
-        {% if word.startswith("http://") or word.startswith("https://") %}
-            <a href="{{ word }}" target="_blank" rel="noopener noreferrer">{{ word }}</a>
-        {%- else -%}
-            {{ word }}
-        {%- endif %}
-        {% if not loop.last %} {% endif %}
-    {% endfor %}
+    {% if value %}
+        {% set words = value.split(" ") %}
+        {% for word in words %}
+            {% if word.startswith("http://") or word.startswith("https://") %}
+                <a href="{{ word }}" target="_blank" rel="noopener noreferrer">{{ word }}</a>
+            {%- else -%}
+                {{ word }}
+            {%- endif %}
+            {% if not loop.last %} {% endif %}
+        {% endfor %}
+    {% endif %}
 {% endmacro %}


### PR DESCRIPTION
After the last certificate update in the ENISA registry, missing documents (certificate, certification report, and security target) were added to six certificates. This changed the dgst values for those certificates because the digest is calculated from the hashes of these documents.

There was also a bug in this alert:

<img width="1392" height="195" alt="image" src="https://github.com/user-attachments/assets/df5089e6-59d7-4736-aec3-ba35657cc4ec" />

The certificate ID was taken from the ENISA metadata, but the database projection only fetches a limited set of fields. It does not include the certificate ID from the nested ENISA metadata, although it is available as the top-level cert_id field.

I also fixed the function that makes the contact field clickable. Some certificates do not have this data, which previously caused an issue. I suggest deleting the six certificates that were previously missing these documents, as they do not archive anything important and only add noise to the list of certificates.