### PR TITLE
feat: allow dashboards for everyone

### DIFF
--- a/sec_certs_page/common/permissions.py
+++ b/sec_certs_page/common/permissions.py
@@ -3,5 +3,3 @@ from flask_principal import Permission, RoleNeed
 admin_permission = Permission(RoleNeed("admin"))
 
 chat_permission = Permission(RoleNeed("chat"), RoleNeed("admin"))
-
-dashboard_permission = Permission(RoleNeed("dashboard"), RoleNeed("admin"))

--- a/sec_certs_page/dashboard/__init__.py
+++ b/sec_certs_page/dashboard/__init__.py
@@ -4,11 +4,10 @@ from logging import Logger
 import dash
 import dash_bootstrap_components as dbc
 from dash import html
-from flask import Flask, abort, redirect, request, url_for
+from flask import Flask, redirect, request, url_for
 from flask_login import current_user
 from flask_wtf import CSRFProtect
 
-from ..common.permissions import dashboard_permission
 from .base import Dash
 from .callbacks import register_all_callbacks
 from .data import DataService
@@ -72,7 +71,7 @@ def init_dashboard(dash_app: Dash, flask_app: Flask, csrf: CSRFProtect):
 
 def _register_dashboard_protection(dash_app: Dash, url_base_pathname: str) -> None:
     """
-    Protect dashboard routes with role-based authentication.
+    Protect dashboard routes: require an authenticated user.
 
     This registers a before_request handler scoped to dashboard URLs only.
     Uses the Dash app's url_base_pathname to determine which routes to protect.
@@ -86,9 +85,6 @@ def _register_dashboard_protection(dash_app: Dash, url_base_pathname: str) -> No
 
         if not current_user.is_authenticated:
             return redirect(url_for("user.login", next=request.url))
-
-        if not dashboard_permission.can():
-            return abort(403)
 
 
 def _exempt_all_dash_endpoints(app: Flask, csrf: CSRFProtect, url_base_pathname: str) -> None:

--- a/sec_certs_page/dashboard/__init__.py
+++ b/sec_certs_page/dashboard/__init__.py
@@ -4,7 +4,7 @@ from logging import Logger
 import dash
 import dash_bootstrap_components as dbc
 from dash import html
-from flask import Flask, redirect, request, url_for
+from flask import Flask, flash, redirect, request, url_for
 from flask_login import current_user
 from flask_wtf import CSRFProtect
 
@@ -90,6 +90,7 @@ def _register_dashboard_protection(dash_app: Dash, url_base_pathname: str) -> No
             page["relative_path"].rstrip("/") for page in dash.page_registry.values() if page["path"] != "/"
         }
         if request.path.rstrip("/") in protected_paths:
+            flash("Dashboards are available to authorized users only. Please log in to use this feature.", "info")
             return redirect(url_for("user.login", next=request.url))
 
 

--- a/sec_certs_page/dashboard/__init__.py
+++ b/sec_certs_page/dashboard/__init__.py
@@ -83,7 +83,13 @@ def _register_dashboard_protection(dash_app: Dash, url_base_pathname: str) -> No
         if not request.path.startswith(url_base_pathname):
             return None
 
-        if not current_user.is_authenticated:
+        if current_user.is_authenticated:
+            return None
+
+        protected_paths = {
+            page["relative_path"].rstrip("/") for page in dash.page_registry.values() if page["path"] != "/"
+        }
+        if request.path.rstrip("/") in protected_paths:
             return redirect(url_for("user.login", next=request.url))
 
 

--- a/sec_certs_page/dashboard/pages/home.py
+++ b/sec_certs_page/dashboard/pages/home.py
@@ -54,7 +54,7 @@ def _build_collection_card(collection_name: CollectionName) -> dbc.Col:
             dbc.Button(
                 ["Open Dashboard", html.I(className="fas fa-arrow-right ms-2")],
                 href=f"{DASHBOARD_URL_BASE_PATHNAME}{collection_name.value}",
-                external_link=False,
+                external_link=True,
             ),
         ],
     )

--- a/sec_certs_page/jinja.py
+++ b/sec_certs_page/jinja.py
@@ -90,13 +90,6 @@ def is_admin():
     return Permission(RoleNeed("admin")).can()
 
 
-@app.template_global("can_access_dashboard")
-def can_access_dashboard():
-    from .common.permissions import dashboard_permission
-
-    return dashboard_permission.can()
-
-
 @app.template_global("sentry_traceparent")
 def sentry_traceparent():
     if sentry_sdk.is_initialized():

--- a/sec_certs_page/templates/common/base.html.jinja2
+++ b/sec_certs_page/templates/common/base.html.jinja2
@@ -268,9 +268,7 @@
                             <li><a class="dropdown-item" href="{{ url_for('cc.index') }}">Home</a></li>
                             <li><a class="dropdown-item" href="{{ url_for('cc.merged_search') }}">Search</a></li>
                             <li><a class="dropdown-item" href="{{ url_for('cc.analysis') }}">Analysis</a></li>
-                            {% if can_access_dashboard() %}
                             <li><a class="dropdown-item" href="/dashboard/cc">Dashboard</a></li>
-                            {% endif %}
                             <li><a class="dropdown-item" href="{{ url_for('cc.network') }}">References</a></li>
                             <li><a class="dropdown-item" href="{{ url_for('cc.data') }}">Data</a></li>
                         </ul>
@@ -308,9 +306,7 @@
                             <li><a class="dropdown-item" href="{{ url_for('fips.analysis') }}">Analysis</a></li>
                             <li><a class="dropdown-item" href="{{ url_for('fips.mip_index') }}">MIP</a></li>
                             <li><a class="dropdown-item" href="{{ url_for('fips.iut_index') }}">IUT</a></li>
-                            {% if can_access_dashboard() %}
                             <li><a class="dropdown-item" href="/dashboard/fips">Dashboard</a></li>
-                            {% endif %}
                             <li><a class="dropdown-item" href="{{ url_for('fips.network') }}">References</a></li>
                             <li><a class="dropdown-item" href="{{ url_for('fips.data') }}">Data</a></li>
                         </ul>
@@ -326,7 +322,6 @@
                             <li><a class="dropdown-item" href="{{ url_for('vuln.data') }}">Data</a></li>
                         </ul>
                     </li>
-                    {% if can_access_dashboard() %}
                     <li class="nav-item dropdown">
                         <button class="btn btn-dark dropdown-toggle {% if request.path.startswith('/dashboard') %}nav-current{% endif %}" data-bs-toggle="dropdown" aria-expanded="false">Dashboards
                         </button>
@@ -337,7 +332,6 @@
                             <li><a class="dropdown-item" href="/dashboard/fips">FIPS 140</a></li>
                         </ul>
                     </li>
-                    {% endif %}
                     <li class="nav-item dropdown">
                         <button class="btn btn-dark dropdown-toggle {% if request.blueprint == "about" %}nav-current{% endif %}"
                                 data-bs-toggle="dropdown" aria-expanded="false">

--- a/sec_certs_page/user/models.py
+++ b/sec_certs_page/user/models.py
@@ -46,7 +46,7 @@ class UserExistsError(Exception):
 
 
 class User(UserMixin):
-    ROLES = ["admin", "chat", "dashboard"]
+    ROLES = ["admin", "chat"]
     DEFAULT_ROLES = ["chat"]
 
     def __init__(


### PR DESCRIPTION
Following the completion of https://github.com/crocs-muni/sec-certs/issues/568, which addresses several identified UI issues, this PR now allows everyone to use dashboards without requiring a special role. 

For users who are not logged in, the navigation links and the dashboard home page are visible. However, when they attempt to create a dashboard or access dashboards for a specific scheme, they are redirected to the login page.