### PR TITLE
Incremental updating 

### DIFF
--- a/src/sec_certs/converter/base.py
+++ b/src/sec_certs/converter/base.py
@@ -11,8 +11,29 @@ class PDFConverter(ABC):
         if "HAS_JSON_OUTPUT" not in cls.__dict__:
             raise TypeError(f"{cls.__name__} must define HAS_JSON_OUTPUT")
 
-    @abstractmethod
     def convert(self, pdf_path: Path, txt_path: Path, json_path: Path | None = None) -> bool:
+        """
+        Convert a PDF file, writing the text to `txt_path` and, for converters that produce one, the
+        serialized document to `json_path`.
+
+        :param pdf_path: Path to the to-be-converted PDF file.
+        :param txt_path: Path to the resulting text file.
+        :param json_path: Path to the resulting JSON file.
+        :return: A boolean if the conversion was successful.
+        """
+        tmp_txt = txt_path.with_name(f"{txt_path.name}.tmp")
+        tmp_json = json_path.with_name(f"{json_path.name}.tmp") if json_path and self.HAS_JSON_OUTPUT else None
+
+        if not self._convert(pdf_path, tmp_txt, tmp_json):
+            return False
+
+        tmp_txt.replace(txt_path)
+        if json_path is not None and tmp_json is not None:
+            tmp_json.replace(json_path)
+        return True
+
+    @abstractmethod
+    def _convert(self, pdf_path: Path, txt_path: Path, json_path: Path | None = None) -> bool:
         raise NotImplementedError("Not meant to be implemented by the base class.")
 
     @classmethod

--- a/src/sec_certs/converter/docling.py
+++ b/src/sec_certs/converter/docling.py
@@ -102,7 +102,7 @@ class DoclingConverter(PDFConverter):
             }
         )
 
-    def convert(self, pdf_path: Path, txt_path: Path, json_path: Path | None = None) -> bool:
+    def _convert(self, pdf_path: Path, txt_path: Path, json_path: Path | None = None) -> bool:
         """
         Convert a PDF file and save the result as a text file to `txt_path`
         alongisde with a serialized DoclingDocument as JSON to `json_path`.

--- a/src/sec_certs/converter/pdftotext.py
+++ b/src/sec_certs/converter/pdftotext.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 class PdftotextConverter(PDFConverter):
     HAS_JSON_OUTPUT = False
 
-    def convert(self, pdf_path: Path, txt_path: Path, json_path: Path | None = None) -> bool:
+    def _convert(self, pdf_path: Path, txt_path: Path, json_path: Path | None = None) -> bool:
         """
         Convert a PDF file and save the resulst as a text file to `txt_path`.
 

--- a/src/sec_certs/dataset/auxiliary_dataset_handling.py
+++ b/src/sec_certs/dataset/auxiliary_dataset_handling.py
@@ -7,6 +7,7 @@ import logging
 import tempfile
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
+from enum import Enum
 from pathlib import Path
 from typing import Any, ClassVar
 
@@ -24,6 +25,19 @@ from sec_certs.utils.nvd_dataset_builder import CpeMatchNvdDatasetBuilder, CpeNv
 from sec_certs.utils.profiling import staged
 
 logger = logging.getLogger(__name__)
+
+
+class ProcessingMode(str, Enum):
+    """
+    How an auxiliary dataset shall be obtained when it is processed.
+    """
+
+    LOAD = "load"
+    """Use the dataset that is already on disk, do not reach out to the web."""
+    UPDATE = "update"
+    """Refresh the dataset from the web, carrying already computed processing results over."""
+    REBUILD = "rebuild"
+    """Discard whatever is on disk and build the dataset from scratch."""
 
 
 class AuxiliaryDatasetHandler(ABC):
@@ -55,16 +69,16 @@ class AuxiliaryDatasetHandler(ABC):
     def set_local_paths(self, aux_datasets_dir: str | Path | None) -> None:
         self.aux_datasets_dir = Path(aux_datasets_dir) if aux_datasets_dir is not None else None  # type: ignore
 
-    def process_dataset(self, download_fresh: bool = False) -> None:
+    def process_dataset(self, mode: ProcessingMode = ProcessingMode.LOAD) -> None:
         self.root_dir.mkdir(parents=True, exist_ok=True)
-        self._process_dataset_body(download_fresh)
+        self._process_dataset_body(mode)
 
     @abstractmethod
     def load_dataset(self) -> None:
         raise NotImplementedError("Not meant to be implemented by base class")
 
     @abstractmethod
-    def _process_dataset_body(self, download_fresh: bool = False) -> None:
+    def _process_dataset_body(self, mode: ProcessingMode = ProcessingMode.LOAD) -> None:
         raise NotImplementedError("Not meant to be implemented by base class")
 
 
@@ -74,8 +88,8 @@ class CPEDatasetHandler(AuxiliaryDatasetHandler):
         return self.root_dir / "cpe_dataset.json"
 
     @staged(logger, "Processing CPE dataset")
-    def _process_dataset_body(self, download_fresh: bool = False) -> None:
-        if not download_fresh and self.dset_path.exists():
+    def _process_dataset_body(self, mode: ProcessingMode = ProcessingMode.LOAD) -> None:
+        if mode is ProcessingMode.LOAD and self.dset_path.exists():
             logger.info("Preparing CPEDataset from json.")
             self.load_dataset()
             return
@@ -101,8 +115,8 @@ class CVEDatasetHandler(AuxiliaryDatasetHandler):
         return self.root_dir / "cve_dataset.json"
 
     @staged(logger, "Processing CVE dataset")
-    def _process_dataset_body(self, download_fresh: bool = False) -> None:
-        if not download_fresh and self.dset_path.exists():
+    def _process_dataset_body(self, mode: ProcessingMode = ProcessingMode.LOAD) -> None:
+        if mode is ProcessingMode.LOAD and self.dset_path.exists():
             logger.info("Preparing CVEDataset from json.")
             self.load_dataset()
             return
@@ -128,8 +142,8 @@ class CPEMatchDictHandler(AuxiliaryDatasetHandler):
         return self.root_dir / "cpe_match.json"
 
     @staged(logger, "Processing CPE Match dictionary")
-    def _process_dataset_body(self, download_fresh: bool = False) -> None:
-        if not download_fresh and self.dset_path.exists():
+    def _process_dataset_body(self, mode: ProcessingMode = ProcessingMode.LOAD) -> None:
+        if mode is ProcessingMode.LOAD and self.dset_path.exists():
             logger.info("Preparing CPE Match feed from json.")
             self.load_dataset()
             return
@@ -171,8 +185,8 @@ class FIPSAlgorithmDatasetHandler(AuxiliaryDatasetHandler):
         return self.root_dir / FIPSAlgorithmDataset.JSON_FILENAME
 
     @staged(logger, "Processing FIPS Algorithms")
-    def _process_dataset_body(self, download_fresh: bool = False) -> None:
-        if not download_fresh and self.dset_path.exists():
+    def _process_dataset_body(self, mode: ProcessingMode = ProcessingMode.LOAD) -> None:
+        if mode is ProcessingMode.LOAD and self.dset_path.exists():
             logger.info("Preparing FIPSAlgorithmDataset from json.")
             self.load_dataset()
             return
@@ -197,8 +211,8 @@ class CCSchemeDatasetHandler(AuxiliaryDatasetHandler):
         return self.root_dir / "cc_scheme.json"
 
     @staged(logger, "Processing CC Schemes")
-    def _process_dataset_body(self, download_fresh: bool = False) -> None:
-        if not download_fresh and self.dset_path.exists():
+    def _process_dataset_body(self, mode: ProcessingMode = ProcessingMode.LOAD) -> None:
+        if mode is ProcessingMode.LOAD and self.dset_path.exists():
             logger.info("Preparing CCSchemeDataset from json.")
             self.load_dataset()
             return
@@ -237,10 +251,10 @@ class CCMaintenanceUpdateDatasetHandler(AuxiliaryDatasetHandler):
         self.dset = CCDatasetMaintenanceUpdates.from_json(self.dset_path)
 
     @staged(logger, "Processing CC Maintenance updates")
-    def _process_dataset_body(self, download_fresh: bool = False):
+    def _process_dataset_body(self, mode: ProcessingMode = ProcessingMode.LOAD):
         from sec_certs.dataset.cc import CCDatasetMaintenanceUpdates
 
-        if not download_fresh and self.dset_path.exists():
+        if mode is ProcessingMode.LOAD and self.dset_path.exists():
             logger.info("Preparing CCDatasetMaintenanceUpdates from json.")
             self.load_dataset()
             return
@@ -255,9 +269,17 @@ class CCMaintenanceUpdateDatasetHandler(AuxiliaryDatasetHandler):
             root_dir=self.dset_path.parent,
             name="maintenance_updates",
         )
-        self.dset.download_all_artifacts()
-        self.dset.convert_all_pdfs()
-        self.dset.extract_data()
+
+        # The updates are derived from the CC certificates rather than scraped, so there is no
+        # get_certs_from_web to carry the results over for us.
+        updating = mode is ProcessingMode.UPDATE and self.dset_path.exists()
+        if updating:
+            logger.info("Carrying processing results of the maintenance updates from the previous run.")
+            self.dset._carry_processing_results(CCDatasetMaintenanceUpdates.from_json(self.dset_path).certs)
+
+        self.dset.download_all_artifacts(fresh=True)
+        self.dset.convert_all_pdfs(fresh=not updating)
+        self.dset.extract_data(fresh=not updating)
         self.dset.to_json()
 
 
@@ -274,12 +296,18 @@ class ProtectionProfileDatasetHandler(AuxiliaryDatasetHandler):
         self.dset = ProtectionProfileDataset.from_json(self.dset_path)
 
     @staged(logger, "Processing Protection profiles")
-    def _process_dataset_body(self, download_fresh: bool = False):
+    def _process_dataset_body(self, mode: ProcessingMode = ProcessingMode.LOAD):
         from sec_certs.dataset.protection_profile import ProtectionProfileDataset
 
-        if not download_fresh and self.dset_path.exists():
+        if mode is ProcessingMode.LOAD and self.dset_path.exists():
             logger.info("Preparing ProtectionProfileDataset from json.")
             self.load_dataset()
+            return
+
+        if mode is ProcessingMode.UPDATE and self.dset_path.exists():
+            logger.info("Updating ProtectionProfileDataset from json.")
+            self.load_dataset()
+            self.dset.update()
             return
 
         self.dset_path.parent.mkdir(exist_ok=True, parents=True)

--- a/src/sec_certs/dataset/auxiliary_dataset_handling.py
+++ b/src/sec_certs/dataset/auxiliary_dataset_handling.py
@@ -89,7 +89,7 @@ class CPEDatasetHandler(AuxiliaryDatasetHandler):
 
     @staged(logger, "Processing CPE dataset")
     def _process_dataset_body(self, mode: ProcessingMode = ProcessingMode.LOAD) -> None:
-        if mode is ProcessingMode.LOAD and self.dset_path.exists():
+        if mode == ProcessingMode.LOAD and self.dset_path.exists():
             logger.info("Preparing CPEDataset from json.")
             self.load_dataset()
             return
@@ -116,7 +116,7 @@ class CVEDatasetHandler(AuxiliaryDatasetHandler):
 
     @staged(logger, "Processing CVE dataset")
     def _process_dataset_body(self, mode: ProcessingMode = ProcessingMode.LOAD) -> None:
-        if mode is ProcessingMode.LOAD and self.dset_path.exists():
+        if mode == ProcessingMode.LOAD and self.dset_path.exists():
             logger.info("Preparing CVEDataset from json.")
             self.load_dataset()
             return
@@ -143,7 +143,7 @@ class CPEMatchDictHandler(AuxiliaryDatasetHandler):
 
     @staged(logger, "Processing CPE Match dictionary")
     def _process_dataset_body(self, mode: ProcessingMode = ProcessingMode.LOAD) -> None:
-        if mode is ProcessingMode.LOAD and self.dset_path.exists():
+        if mode == ProcessingMode.LOAD and self.dset_path.exists():
             logger.info("Preparing CPE Match feed from json.")
             self.load_dataset()
             return
@@ -186,7 +186,7 @@ class FIPSAlgorithmDatasetHandler(AuxiliaryDatasetHandler):
 
     @staged(logger, "Processing FIPS Algorithms")
     def _process_dataset_body(self, mode: ProcessingMode = ProcessingMode.LOAD) -> None:
-        if mode is ProcessingMode.LOAD and self.dset_path.exists():
+        if mode == ProcessingMode.LOAD and self.dset_path.exists():
             logger.info("Preparing FIPSAlgorithmDataset from json.")
             self.load_dataset()
             return
@@ -212,7 +212,7 @@ class CCSchemeDatasetHandler(AuxiliaryDatasetHandler):
 
     @staged(logger, "Processing CC Schemes")
     def _process_dataset_body(self, mode: ProcessingMode = ProcessingMode.LOAD) -> None:
-        if mode is ProcessingMode.LOAD and self.dset_path.exists():
+        if mode == ProcessingMode.LOAD and self.dset_path.exists():
             logger.info("Preparing CCSchemeDataset from json.")
             self.load_dataset()
             return
@@ -254,7 +254,7 @@ class CCMaintenanceUpdateDatasetHandler(AuxiliaryDatasetHandler):
     def _process_dataset_body(self, mode: ProcessingMode = ProcessingMode.LOAD):
         from sec_certs.dataset.cc import CCDatasetMaintenanceUpdates
 
-        if mode is ProcessingMode.LOAD and self.dset_path.exists():
+        if mode == ProcessingMode.LOAD and self.dset_path.exists():
             logger.info("Preparing CCDatasetMaintenanceUpdates from json.")
             self.load_dataset()
             return
@@ -272,7 +272,7 @@ class CCMaintenanceUpdateDatasetHandler(AuxiliaryDatasetHandler):
 
         # The updates are derived from the CC certificates rather than scraped, so there is no
         # get_certs_from_web to carry the results over for us.
-        updating = mode is ProcessingMode.UPDATE and self.dset_path.exists()
+        updating = mode == ProcessingMode.UPDATE and self.dset_path.exists()
         if updating:
             logger.info("Carrying processing results of the maintenance updates from the previous run.")
             self.dset._carry_processing_results(CCDatasetMaintenanceUpdates.from_json(self.dset_path).certs)
@@ -299,12 +299,12 @@ class ProtectionProfileDatasetHandler(AuxiliaryDatasetHandler):
     def _process_dataset_body(self, mode: ProcessingMode = ProcessingMode.LOAD):
         from sec_certs.dataset.protection_profile import ProtectionProfileDataset
 
-        if mode is ProcessingMode.LOAD and self.dset_path.exists():
+        if mode == ProcessingMode.LOAD and self.dset_path.exists():
             logger.info("Preparing ProtectionProfileDataset from json.")
             self.load_dataset()
             return
 
-        if mode is ProcessingMode.UPDATE and self.dset_path.exists():
+        if mode == ProcessingMode.UPDATE and self.dset_path.exists():
             logger.info("Updating ProtectionProfileDataset from json.")
             self.load_dataset()
             self.dset.update()

--- a/src/sec_certs/dataset/cc.py
+++ b/src/sec_certs/dataset/cc.py
@@ -386,6 +386,7 @@ class CCDataset(Dataset[CCCertificate], ComplexSerializableType):
         keep_metadata: bool = True,
         get_active: bool = True,
         get_archived: bool = True,
+        carry_processing_results: bool = False,
     ) -> None:
         """
         Downloads CSV and HTML files that hold lists of certificates from common criteria website. Parses these files
@@ -395,9 +396,16 @@ class CCDataset(Dataset[CCCertificate], ComplexSerializableType):
         :param bool keep_metadata: If CSV and HTML files shall be kept on disk after download, defaults to True
         :param bool get_active: If active certificates shall be parsed, defaults to True
         :param bool get_archived: If archived certificates shall be parsed, defaults to True
+        :param bool carry_processing_results: If the dataset already holds certificates, carry their
+            already computed processing results over onto the freshly scraped certificates. So only certificates that are new,
+            changed or if files for them are missing can get reprocessed,
+            not the whole dataset. Defaults to False.
         """
         if to_download is True:
             self._download_csv_html_resources(get_active, get_archived)
+
+        old_certs = self.certs
+        self.certs = {}
 
         logger.info("Adding CSV certificates to CommonCriteria dataset.")
         csv_certs = self._get_all_certs_from_csv(get_active, get_archived)
@@ -412,6 +420,9 @@ class CCDataset(Dataset[CCCertificate], ComplexSerializableType):
 
         if not keep_metadata:
             shutil.rmtree(self.web_dir)
+
+        if carry_processing_results:
+            self._carry_processing_results(old_certs)
 
         self._set_local_paths()
         self.state.meta_sources_parsed = True

--- a/src/sec_certs/dataset/cc.py
+++ b/src/sec_certs/dataset/cc.py
@@ -27,9 +27,7 @@ from sec_certs.dataset.cc_eucc_common import (
     compute_heuristics_body,
     convert_all_pdfs_body,
     download_all_artifacts_body,
-    extract_all_frontpages,
-    extract_all_keywords,
-    extract_all_metadata,
+    extract_all_data,
 )
 from sec_certs.dataset.dataset import Dataset, logger
 from sec_certs.sample.cc import CCCertificate
@@ -640,11 +638,9 @@ class CCDataset(Dataset[CCCertificate], ComplexSerializableType):
         convert_all_pdfs_body(self, converter_cls, fresh)
 
     @only_backed()
-    def extract_data(self) -> None:
+    def extract_data(self, fresh: bool = True) -> None:
         logger.info("Extracting various data from certification artifacts.")
-        extract_all_metadata(self)
-        extract_all_frontpages(self)
-        extract_all_keywords(self)
+        extract_all_data(self, fresh)
 
     def _compute_heuristics_body(self, skip_schemes: bool = False) -> None:
         compute_heuristics_body(self, skip_schemes)

--- a/src/sec_certs/dataset/cc.py
+++ b/src/sec_certs/dataset/cc.py
@@ -345,7 +345,7 @@ class CCDataset(Dataset[CCCertificate], ComplexSerializableType):
             self.aux_handlers[CCSchemeDatasetHandler].only_schemes = {}  # type: ignore
         super().process_auxiliary_datasets(download_fresh, **kwargs)
 
-    def _merge_certs(self, certs: dict[str, CCCertificate], cert_source: str | None = None) -> None:
+    def _merge_certs_from_other_source(self, certs: dict[str, CCCertificate], cert_source: str | None = None) -> None:
         """
         Merges dictionary of certificates into the dataset. Assuming they all are CommonCriteria certificates
         """
@@ -354,7 +354,7 @@ class CCDataset(Dataset[CCCertificate], ComplexSerializableType):
         self.certs.update(new_certs)
 
         for crt in certs_to_merge:
-            self[crt.dgst].merge(crt, cert_source)
+            self[crt.dgst].merge_from_other_source(crt, cert_source)
 
         logger.info(f"Added {len(new_certs)} new and merged further {len(certs_to_merge)} certificates to the dataset.")
 
@@ -401,12 +401,12 @@ class CCDataset(Dataset[CCCertificate], ComplexSerializableType):
 
         logger.info("Adding CSV certificates to CommonCriteria dataset.")
         csv_certs = self._get_all_certs_from_csv(get_active, get_archived)
-        self._merge_certs(csv_certs, cert_source="csv")
+        self._merge_certs_from_other_source(csv_certs, cert_source="csv")
 
         # Someway along the way, 3 certificates get lost.
         logger.info("Adding HTML certificates to CommonCriteria dataset.")
         html_certs = self._get_all_certs_from_html(get_active, get_archived)
-        self._merge_certs(html_certs, cert_source="html")
+        self._merge_certs_from_other_source(html_certs, cert_source="html")
 
         logger.info(f"The resulting dataset has {len(self)} certificates.")
 

--- a/src/sec_certs/dataset/cc.py
+++ b/src/sec_certs/dataset/cc.py
@@ -420,9 +420,10 @@ class CCDataset(Dataset[CCCertificate], ComplexSerializableType):
             shutil.rmtree(self.web_dir)
 
         if carry_processing_results:
+            # Reconciling the carried results sets the local paths already.
             self._carry_processing_results(old_certs)
-
-        self._set_local_paths()
+        else:
+            self._set_local_paths()
         self.state.meta_sources_parsed = True
 
     def _get_all_certs_from_csv(self, get_active: bool, get_archived: bool) -> dict[str, CCCertificate]:

--- a/src/sec_certs/dataset/cc.py
+++ b/src/sec_certs/dataset/cc.py
@@ -21,6 +21,7 @@ from sec_certs.dataset.auxiliary_dataset_handling import (
     CPEDatasetHandler,
     CPEMatchDictHandler,
     CVEDatasetHandler,
+    ProcessingMode,
     ProtectionProfileDatasetHandler,
 )
 from sec_certs.dataset.cc_eucc_common import (
@@ -328,8 +329,8 @@ class CCDataset(Dataset[CCCertificate], ComplexSerializableType):
     @only_backed()
     def process_auxiliary_datasets(
         self,
-        download_fresh: bool = False,
-        skip_schemes: bool = False,
+        mode: ProcessingMode = ProcessingMode.LOAD,
+        skip_schemes: bool = True,
         **kwargs,
     ) -> None:
         if CCMaintenanceUpdateDatasetHandler in self.aux_handlers:
@@ -341,7 +342,7 @@ class CCDataset(Dataset[CCCertificate], ComplexSerializableType):
 
         if skip_schemes:
             self.aux_handlers[CCSchemeDatasetHandler].only_schemes = {}  # type: ignore
-        super().process_auxiliary_datasets(download_fresh, **kwargs)
+        super().process_auxiliary_datasets(mode, **kwargs)
 
     def _merge_certs_from_other_source(self, certs: dict[str, CCCertificate], cert_source: str | None = None) -> None:
         """
@@ -679,7 +680,7 @@ class CCDatasetMaintenanceUpdates(CCDataset, ComplexSerializableType):
 
     def process_auxiliary_datasets(
         self,
-        download_fresh: bool = False,
+        mode: ProcessingMode = ProcessingMode.LOAD,
         skip_schemes: bool = False,
         **kwargs,
     ) -> None:

--- a/src/sec_certs/dataset/cc_eucc_common.py
+++ b/src/sec_certs/dataset/cc_eucc_common.py
@@ -179,8 +179,8 @@ def convert_all_pdfs_body(obj: CCDataset | EUCCDataset, converter_cls: type[PDFC
     convert_certs_pdfs(obj, converter_cls, fresh)
 
 
-def extract_generic(obj: CCDataset | EUCCDataset, doc_type: DocType, worker_func: Callable) -> None:
-    certs_to_process = [x for x in obj if getattr(x.state, doc_type.short).is_ok_to_analyze()]
+def extract_generic(obj: CCDataset | EUCCDataset, doc_type: DocType, worker_func: Callable, dgsts: set[str]) -> None:
+    certs_to_process = [obj[dgst] for dgst in dgsts]
 
     if not certs_to_process:
         return
@@ -195,56 +195,71 @@ def extract_generic(obj: CCDataset | EUCCDataset, doc_type: DocType, worker_func
 
 
 @staged(logger, "Extracting report metadata")
-def extract_report_metadata(obj: CCDataset | EUCCDataset):
-    extract_generic(obj, DocType.REPORT, extract_report_pdf_metadata)
+def extract_report_metadata(obj: CCDataset | EUCCDataset, dgsts: set[str]):
+    extract_generic(obj, DocType.REPORT, extract_report_pdf_metadata, dgsts)
 
 
 @staged(logger, "Extracting target metadata")
-def extract_target_metadata(obj: CCDataset | EUCCDataset):
-    extract_generic(obj, DocType.TARGET, extract_st_pdf_metadata)
+def extract_target_metadata(obj: CCDataset | EUCCDataset, dgsts: set[str]):
+    extract_generic(obj, DocType.TARGET, extract_st_pdf_metadata, dgsts)
 
 
 @staged(logger, "Extracting cert metadata")
-def extract_cert_metadata(obj: CCDataset | EUCCDataset):
-    extract_generic(obj, DocType.CERTIFICATE, extract_cert_pdf_metadata)
+def extract_cert_metadata(obj: CCDataset | EUCCDataset, dgsts: set[str]):
+    extract_generic(obj, DocType.CERTIFICATE, extract_cert_pdf_metadata, dgsts)
 
 
 @staged(logger, "Extracting report keywords")
-def extract_report_keywords(obj: CCDataset | EUCCDataset):
-    extract_generic(obj, DocType.REPORT, extract_report_pdf_keywords)
+def extract_report_keywords(obj: CCDataset | EUCCDataset, dgsts: set[str]):
+    extract_generic(obj, DocType.REPORT, extract_report_pdf_keywords, dgsts)
 
 
 @staged(logger, "Extracting target keywords")
-def extract_target_keywords(obj: CCDataset | EUCCDataset):
-    extract_generic(obj, DocType.TARGET, extract_st_pdf_keywords)
+def extract_target_keywords(obj: CCDataset | EUCCDataset, dgsts: set[str]):
+    extract_generic(obj, DocType.TARGET, extract_st_pdf_keywords, dgsts)
 
 
 @staged(logger, "Extracting cert keywords")
-def extract_cert_keywords(obj: CCDataset | EUCCDataset):
-    extract_generic(obj, DocType.CERTIFICATE, extract_cert_pdf_keywords)
+def extract_cert_keywords(obj: CCDataset | EUCCDataset, dgsts: set[str]):
+    extract_generic(obj, DocType.CERTIFICATE, extract_cert_pdf_keywords, dgsts)
 
 
 # Frontpage (Special case)
 @staged(logger, "Extracting report frontpages")
-def extract_report_frontpage(obj: CCDataset | EUCCDataset) -> None:
-    extract_generic(obj, DocType.REPORT, extract_report_pdf_frontpage)
+def extract_report_frontpage(obj: CCDataset | EUCCDataset, dgsts: set[str]) -> None:
+    extract_generic(obj, DocType.REPORT, extract_report_pdf_frontpage, dgsts)
 
 
-def extract_all_metadata(obj: CCDataset | EUCCDataset):
-    extract_report_metadata(obj)
-    extract_target_metadata(obj)
-    extract_cert_metadata(obj)
+def extract_all_metadata(obj: CCDataset | EUCCDataset, dgsts: dict[DocType, set[str]]):
+    extract_report_metadata(obj, dgsts[DocType.REPORT])
+    extract_target_metadata(obj, dgsts[DocType.TARGET])
+    extract_cert_metadata(obj, dgsts[DocType.CERTIFICATE])
 
 
-def extract_all_keywords(obj: CCDataset | EUCCDataset):
-    extract_report_keywords(obj)
-    extract_target_keywords(obj)
-    extract_cert_keywords(obj)
+def extract_all_keywords(obj: CCDataset | EUCCDataset, dgsts: dict[DocType, set[str]]):
+    extract_report_keywords(obj, dgsts[DocType.REPORT])
+    extract_target_keywords(obj, dgsts[DocType.TARGET])
+    extract_cert_keywords(obj, dgsts[DocType.CERTIFICATE])
 
 
-def extract_all_frontpages(obj: CCDataset | EUCCDataset):
-    extract_report_frontpage(obj)
-    # We have no frontpage extraction for targets or certificates themselves, only for the reports.
+def extract_all_frontpages(obj: CCDataset | EUCCDataset, dgsts: dict[DocType, set[str]]):
+    extract_report_frontpage(obj, dgsts[DocType.REPORT])
+
+
+def extract_all_data(obj: CCDataset | EUCCDataset, fresh: bool = True) -> None:
+    doc_types = (DocType.REPORT, DocType.TARGET, DocType.CERTIFICATE)
+    dgsts: dict[DocType, set[str]] = {
+        doc_type: {x.dgst for x in obj if getattr(x.state, doc_type.short).is_ok_to_extract(fresh)}
+        for doc_type in doc_types
+    }
+
+    for doc_type in doc_types:
+        for dgst in dgsts[doc_type]:
+            getattr(obj[dgst].state, doc_type.short).extract_ok = True
+
+    extract_all_metadata(obj, dgsts)
+    extract_all_frontpages(obj, dgsts)
+    extract_all_keywords(obj, dgsts)
 
 
 def compute_heuristics_body(obj: CCDataset | EUCCDataset, skip_schemes: bool = False) -> None:

--- a/src/sec_certs/dataset/dataset.py
+++ b/src/sec_certs/dataset/dataset.py
@@ -17,7 +17,7 @@ from packaging.version import parse as parse_version
 from pydantic import AnyHttpUrl
 
 from sec_certs._version import __version__
-from sec_certs.dataset.auxiliary_dataset_handling import AuxiliaryDatasetHandler
+from sec_certs.dataset.auxiliary_dataset_handling import AuxiliaryDatasetHandler, ProcessingMode
 from sec_certs.sample.certificate import Certificate
 from sec_certs.serialization.json import (
     ComplexSerializableType,
@@ -237,7 +237,7 @@ class Dataset(Generic[CertSubType], ComplexSerializableType, ABC):
                     tar.extractall(str(path))
                 dset = cls.from_json(path / "dataset.json")  # type: ignore
                 if auxiliary_datasets:
-                    dset.process_auxiliary_datasets(download_fresh=False)
+                    dset.process_auxiliary_datasets(mode=ProcessingMode.LOAD)
         else:
             with tempfile.TemporaryDirectory() as tmp_dir:
                 dset_path = Path(tmp_dir) / "dataset.json"
@@ -254,7 +254,7 @@ class Dataset(Generic[CertSubType], ComplexSerializableType, ABC):
                     # Clear the path, as it points to temporary file
                     dset._root_dir = None
             if auxiliary_datasets:
-                dset.process_auxiliary_datasets(download_fresh=True)
+                dset.process_auxiliary_datasets(mode=ProcessingMode.REBUILD)
         return dset
 
     def to_dict(self) -> dict[str, Any]:
@@ -363,13 +363,18 @@ class Dataset(Generic[CertSubType], ComplexSerializableType, ABC):
     @staged(logger, "Processing auxiliary datasets.")
     @serialize
     @only_backed()
-    def process_auxiliary_datasets(self, download_fresh: bool = False, **kwargs) -> None:
+    def process_auxiliary_datasets(self, mode: ProcessingMode = ProcessingMode.LOAD, **kwargs) -> None:
         """
         Processes all auxiliary datasets (CPE, CVE, ...) that are required during computation.
+
+        :param mode: Whether to use the datasets on disk, refresh them while carrying already computed
+            processing results over, or rebuild them from scratch. Only the auxiliary datasets that are
+            themselves processed (protection profiles, maintenance updates) can be updated incrementally,
+            the rest are simply re-fetched.
         """
         logger.info("Processing auxiliary datasets.")
         for handler in self.aux_handlers.values():
-            handler.process_dataset(download_fresh)
+            handler.process_dataset(mode)
         self.state.auxiliary_datasets_processed = True
 
     @only_backed()
@@ -514,22 +519,24 @@ class Dataset(Generic[CertSubType], ComplexSerializableType, ABC):
 
     @only_backed()
     @staged(logger, "Updating the dataset")
-    def update(self, update_aux: bool = True):
+    def update(self, aux_mode: ProcessingMode = ProcessingMode.UPDATE):
         """
         Update the dataset by running the whole pipeline over it.
 
         Processing results already computed for a certificate are carried over, so work that depends on an artifact
         that hasn't changed is not repeated. Concretely, fresh metadata is scraped, auxiliary datasets are
-        optionally refreshed, and all artifacts are re-downloaded (to check whether their hash changed)
+        refreshed, and all artifacts are re-downloaded (to check whether their hash changed)
         but only new, changed or previously failed artifacts are converted and extracted. Heuristics are
         always recomputed, since they depend on the whole dataset and the auxiliary datasets.
 
-        :param update_aux: whether to re-download the auxiliary datasets.
+        :param aux_mode: how to process the auxiliary datasets, see
+            :meth:`~sec_certs.dataset.dataset.Dataset.process_auxiliary_datasets`. Pass
+            :attr:`~sec_certs.dataset.auxiliary_dataset_handling.ProcessingMode.LOAD` to keep the ones on disk.
         """
         self.timestamp = datetime.now()
         self.state.sec_certs_version = __version__
         self.get_certs_from_web(carry_processing_results=True)
-        self.process_auxiliary_datasets(download_fresh=update_aux)
+        self.process_auxiliary_datasets(mode=aux_mode)
         self.download_all_artifacts(fresh=True)
         self.convert_all_pdfs(fresh=False)
         self.analyze_certificates(fresh=False)

--- a/src/sec_certs/dataset/dataset.py
+++ b/src/sec_certs/dataset/dataset.py
@@ -271,6 +271,8 @@ class Dataset(Generic[CertSubType], ComplexSerializableType, ABC):
     def from_dict(cls, dct: dict) -> Dataset:
         certs = {x.dgst: x for x in dct["certs"]}
         dset = cls(certs, name=dct["name"], description=dct["description"], state=dct["state"])
+        if ts := dct.get("timestamp"):
+            dset.timestamp = ts if isinstance(ts, datetime) else datetime.fromisoformat(ts)
         if len(dset) != (claimed := dct["n_certs"]):
             logger.error(
                 f"The actual number of certs in dataset ({len(dset)}) does not match the claimed number ({claimed})."

--- a/src/sec_certs/dataset/dataset.py
+++ b/src/sec_certs/dataset/dataset.py
@@ -487,6 +487,20 @@ class Dataset(Generic[CertSubType], ComplexSerializableType, ABC):
             logger.warning("Updating dataset with certificates outside of the dataset!")
         self.certs.update({x.dgst: x for x in certs})
 
+    def _carry_processing_results(self, previous: dict[str, CertSubType]) -> None:
+        logger.info("Carrying over processing results from the previous run onto the freshly scraped certificates.")
+
+        count = 0
+        for dgst, cert in self.certs.items():
+            if (prev := previous.get(dgst)) is not None:
+                cert.state = prev.state
+                cert.pdf_data = prev.pdf_data
+                cert.heuristics = prev.heuristics
+                count += 1
+
+        logger.info(f"Carried processing results for {count} certificates")
+        self.reconcile_document_states()
+
     def reconcile_document_states(self):
         """
         Reconciles the recorded documents flags with the files in dataset directories.

--- a/src/sec_certs/dataset/dataset.py
+++ b/src/sec_certs/dataset/dataset.py
@@ -428,11 +428,13 @@ class Dataset(Generic[CertSubType], ComplexSerializableType, ABC):
 
     @serialize
     @only_backed()
-    def analyze_certificates(self) -> None:
+    def analyze_certificates(self, fresh: bool = True) -> None:
         """
         Does two things:
             - Extracts data from certificates (keywords, etc.)
             - Computes various heuristics on the certificates.
+
+        :param fresh: If False, only certificates whose extraction has not yet succeeded are analyzed.
         """
         if not self.state.pdfs_converted:
             logger.info(
@@ -445,17 +447,17 @@ class Dataset(Generic[CertSubType], ComplexSerializableType, ABC):
             )
 
         logger.info("Analyzing certificates.")
-        self._analyze_certificates_body()
+        self._analyze_certificates_body(fresh)
         self.state.certs_analyzed = True
 
-    def _analyze_certificates_body(self) -> None:
+    def _analyze_certificates_body(self, fresh: bool = True) -> None:
         logger.info("Extracting data and heuristics.")
-        self.extract_data()
+        self.extract_data(fresh)
         self.compute_heuristics()
 
     @abstractmethod
     @only_backed()
-    def extract_data(self) -> None:
+    def extract_data(self, fresh: bool = True) -> None:
         raise NotImplementedError("Not meant to be implemented by the base class.")
 
     @serialize
@@ -484,3 +486,13 @@ class Dataset(Generic[CertSubType], ComplexSerializableType, ABC):
         if any(x not in self for x in certs):
             logger.warning("Updating dataset with certificates outside of the dataset!")
         self.certs.update({x.dgst: x for x in certs})
+
+    def reconcile_document_states(self):
+        """
+        Reconciles the recorded documents flags with the files in dataset directories.
+        A missing document, or one whose content no longer matches the hash recorded when it was processed,
+        invalidates according processing stage and everything derived from it.
+        """
+        self._set_local_paths()
+        for cert in self:
+            cert.state.reconcile_document_states()

--- a/src/sec_certs/dataset/dataset.py
+++ b/src/sec_certs/dataset/dataset.py
@@ -355,7 +355,7 @@ class Dataset(Generic[CertSubType], ComplexSerializableType, ABC):
         return {crt for crt in self if crt.name and crt.name == name}
 
     @abstractmethod
-    def get_certs_from_web(self) -> None:
+    def get_certs_from_web(self, carry_processing_results: bool = False) -> None:
         raise NotImplementedError("Not meant to be implemented by the base class.")
 
     @staged(logger, "Processing auxiliary datasets.")

--- a/src/sec_certs/dataset/dataset.py
+++ b/src/sec_certs/dataset/dataset.py
@@ -495,7 +495,6 @@ class Dataset(Generic[CertSubType], ComplexSerializableType, ABC):
             if (prev := previous.get(dgst)) is not None:
                 cert.state = prev.state
                 cert.pdf_data = prev.pdf_data
-                cert.heuristics = prev.heuristics
                 count += 1
 
         logger.info(f"Carried processing results for {count} certificates")

--- a/src/sec_certs/dataset/dataset.py
+++ b/src/sec_certs/dataset/dataset.py
@@ -18,14 +18,14 @@ from pydantic import AnyHttpUrl
 
 from sec_certs._version import __version__
 from sec_certs.dataset.auxiliary_dataset_handling import AuxiliaryDatasetHandler, ProcessingMode
-from sec_certs.sample.certificate import Certificate
+from sec_certs.sample.certificate import Certificate, InternalState
 from sec_certs.serialization.json import (
     ComplexSerializableType,
     get_class_fullname,
     only_backed,
     serialize,
 )
-from sec_certs.utils import helpers
+from sec_certs.utils import helpers, parallel_processing
 from sec_certs.utils.profiling import staged
 
 if TYPE_CHECKING:
@@ -514,8 +514,12 @@ class Dataset(Generic[CertSubType], ComplexSerializableType, ABC):
         invalidates according processing stage and everything derived from it.
         """
         self._set_local_paths()
-        for cert in self:
-            cert.state.reconcile_document_states()
+        parallel_processing.process_parallel(
+            InternalState.reconcile_document_states,
+            [cert.state for cert in self],
+            use_threading=True,
+            progress_bar_desc=f"Reconciling document states of {self.name}",
+        )
 
     @only_backed()
     @staged(logger, "Updating the dataset")

--- a/src/sec_certs/dataset/dataset.py
+++ b/src/sec_certs/dataset/dataset.py
@@ -511,3 +511,25 @@ class Dataset(Generic[CertSubType], ComplexSerializableType, ABC):
         self._set_local_paths()
         for cert in self:
             cert.state.reconcile_document_states()
+
+    @only_backed()
+    @staged(logger, "Updating the dataset")
+    def update(self, update_aux: bool = True):
+        """
+        Update the dataset by running the whole pipeline over it.
+
+        Processing results already computed for a certificate are carried over, so work that depends on an artifact
+        that hasn't changed is not repeated. Concretely, fresh metadata is scraped, auxiliary datasets are
+        optionally refreshed, and all artifacts are re-downloaded (to check whether their hash changed)
+        but only new, changed or previously failed artifacts are converted and extracted. Heuristics are
+        always recomputed, since they depend on the whole dataset and the auxiliary datasets.
+
+        :param update_aux: whether to re-download the auxiliary datasets.
+        """
+        self.timestamp = datetime.now()
+        self.state.sec_certs_version = __version__
+        self.get_certs_from_web(carry_processing_results=True)
+        self.process_auxiliary_datasets(download_fresh=update_aux)
+        self.download_all_artifacts(fresh=True)
+        self.convert_all_pdfs(fresh=False)
+        self.analyze_certificates(fresh=False)

--- a/src/sec_certs/dataset/eucc.py
+++ b/src/sec_certs/dataset/eucc.py
@@ -383,17 +383,26 @@ class EUCCDataset(Dataset[EUCCCertificate], ComplexSerializableType):
     @serialize
     @staged(logger, "Downloading and processing metadata from ENISA EUCC page.")
     @only_backed()
-    def get_certs_from_web(self, to_download: bool = True) -> None:
+    def get_certs_from_web(self, to_download: bool = True, carry_processing_results: bool = False) -> None:
         """
         Downloads certificate metadata from the ENISA website, parses the downloaded files, and constructs EUCC objects to
         populate the dataset.
 
         :param bool to_download: If fresh data shall be downloaded (or existing files utilized), defaults to True
+        :param bool carry_processing_results: If the dataset already holds certificates, carry their
+            already computed processing results over onto the freshly scraped certificates. So only certificates that are new,
+            changed or if files for them are missing can get reprocessed,
+            not the whole dataset. Defaults to False.
         """
+
+        old_certs = self.certs
         if to_download is True:
             self._download_metadata()
 
         logger.info(f"The resulting dataset has {len(self)} certificates.")
+
+        if carry_processing_results:
+            self._carry_processing_results(old_certs)
 
         self.root_dir.mkdir(parents=True, exist_ok=True)
         self._set_local_paths()

--- a/src/sec_certs/dataset/eucc.py
+++ b/src/sec_certs/dataset/eucc.py
@@ -399,11 +399,12 @@ class EUCCDataset(Dataset[EUCCCertificate], ComplexSerializableType):
 
         logger.info(f"The resulting dataset has {len(self)} certificates.")
 
-        if carry_processing_results:
-            self._carry_processing_results(old_certs)
-
         self.root_dir.mkdir(parents=True, exist_ok=True)
-        self._set_local_paths()
+        if carry_processing_results:
+            # Reconciling the carried results sets the local paths already.
+            self._carry_processing_results(old_certs)
+        else:
+            self._set_local_paths()
         self.state.meta_sources_parsed = True
 
     def process_auxiliary_datasets(self, download_fresh: bool = False, skip_schemes: bool = False, **kwargs) -> None:

--- a/src/sec_certs/dataset/eucc.py
+++ b/src/sec_certs/dataset/eucc.py
@@ -16,6 +16,7 @@ from sec_certs.dataset.auxiliary_dataset_handling import (
     CPEDatasetHandler,
     CPEMatchDictHandler,
     CVEDatasetHandler,
+    ProcessingMode,
     ProtectionProfileDatasetHandler,
 )
 from sec_certs.dataset.cc_eucc_common import (
@@ -407,13 +408,15 @@ class EUCCDataset(Dataset[EUCCCertificate], ComplexSerializableType):
             self._set_local_paths()
         self.state.meta_sources_parsed = True
 
-    def process_auxiliary_datasets(self, download_fresh: bool = False, skip_schemes: bool = False, **kwargs) -> None:
+    def process_auxiliary_datasets(
+        self, mode: ProcessingMode = ProcessingMode.LOAD, skip_schemes: bool = False, **kwargs
+    ) -> None:
         if CCSchemeDatasetHandler in self.aux_handlers:
             self.aux_handlers[CCSchemeDatasetHandler].only_schemes = {x.scheme for x in self}  # type: ignore
 
         if skip_schemes:
             self.aux_handlers[CCSchemeDatasetHandler].only_schemes = {}  # type: ignore
-        super().process_auxiliary_datasets(download_fresh, **kwargs)
+        super().process_auxiliary_datasets(mode, **kwargs)
 
     def _set_local_paths(self):
         super()._set_local_paths()

--- a/src/sec_certs/dataset/eucc.py
+++ b/src/sec_certs/dataset/eucc.py
@@ -22,9 +22,7 @@ from sec_certs.dataset.cc_eucc_common import (
     compute_heuristics_body,
     convert_all_pdfs_body,
     download_all_artifacts_body,
-    extract_all_frontpages,
-    extract_all_keywords,
-    extract_all_metadata,
+    extract_all_data,
 )
 from sec_certs.dataset.dataset import Dataset, logger
 from sec_certs.sample.eucc import EUCCCertificate
@@ -441,11 +439,9 @@ class EUCCDataset(Dataset[EUCCCertificate], ComplexSerializableType):
         convert_all_pdfs_body(self, converter_cls, fresh)
 
     @only_backed()
-    def extract_data(self) -> None:
+    def extract_data(self, fresh: bool = True) -> None:
         logger.info("Extracting various data from certification artifacts.")
-        extract_all_metadata(self)
-        extract_all_frontpages(self)
-        extract_all_keywords(self)
+        extract_all_data(self, fresh)
 
     def _compute_heuristics_body(self, skip_schemes: bool = False) -> None:
         compute_heuristics_body(self, skip_schemes)

--- a/src/sec_certs/dataset/fips.py
+++ b/src/sec_certs/dataset/fips.py
@@ -136,6 +136,8 @@ class FIPSDataset(Dataset[FIPSCertificate], ComplexSerializableType):
         self.update_with_certs(processed_certs)
 
     def _compute_heuristics_body(self):
+        for cert in self:
+            cert.heuristics.algorithms = cert.pdf_data.module_algorithms | cert.pdf_data.policy_algorithms
         compute_cpe_heuristics(self.aux_handlers[CPEDatasetHandler].dset, self.certs.values())
         compute_related_cves(
             self.aux_handlers[CPEDatasetHandler].dset,

--- a/src/sec_certs/dataset/fips.py
+++ b/src/sec_certs/dataset/fips.py
@@ -294,6 +294,12 @@ class FIPSDataset(Dataset[FIPSCertificate], ComplexSerializableType):
         self._set_local_paths()
         self.state.meta_sources_parsed = True
 
+    def _carry_processing_results(self, previous: dict[str, FIPSCertificate]) -> None:
+        super()._carry_processing_results(previous)
+        for dgst, cert in self.certs.items():
+            if (prev := previous.get(dgst)) is not None:
+                cert.web_data = prev.web_data
+
     @staged(logger, "Extracting Algorithms from policy tables.")
     def _extract_algorithms_from_policy_tables(self, dgsts: set[str]):
         certs_to_process = [self[dgst] for dgst in dgsts]

--- a/src/sec_certs/dataset/fips.py
+++ b/src/sec_certs/dataset/fips.py
@@ -291,9 +291,10 @@ class FIPSDataset(Dataset[FIPSCertificate], ComplexSerializableType):
             shutil.rmtree(self.web_dir)
 
         if carry_processing_results:
+            # Reconciling the carried results sets the local paths already.
             self._carry_processing_results(old_certs)
-
-        self._set_local_paths()
+        else:
+            self._set_local_paths()
         self.state.meta_sources_parsed = True
 
     def _carry_processing_results(self, previous: dict[str, FIPSCertificate]) -> None:

--- a/src/sec_certs/dataset/fips.py
+++ b/src/sec_certs/dataset/fips.py
@@ -268,17 +268,23 @@ class FIPSDataset(Dataset[FIPSCertificate], ComplexSerializableType):
     @serialize
     @staged(logger, "Downloading and processing certificates.")
     @only_backed()
-    def get_certs_from_web(self, to_download: bool = True, keep_metadata: bool = True) -> None:
+    def get_certs_from_web(
+        self, to_download: bool = True, keep_metadata: bool = True, carry_processing_results: bool = False
+    ) -> None:
         self.web_dir.mkdir(parents=True, exist_ok=True)
 
         if to_download:
             self._download_html_resources()
 
+        old_certs = self.certs
         self.certs = {x.dgst: x for x in self._get_all_certs_from_html_sources()}
         logger.info(f"The dataset now contains {len(self)} certificates.")
 
         if not keep_metadata:
             shutil.rmtree(self.web_dir)
+
+        if carry_processing_results:
+            self._carry_processing_results(old_certs)
 
         self._set_local_paths()
         self.state.meta_sources_parsed = True

--- a/src/sec_certs/dataset/fips.py
+++ b/src/sec_certs/dataset/fips.py
@@ -121,12 +121,12 @@ class FIPSDataset(Dataset[FIPSCertificate], ComplexSerializableType):
         except KeyError:
             return super().__getitem__(fips_dgst(item))
 
-    def _extract_data_from_html_modules(self) -> None:
+    def _extract_data_from_html_modules(self, dgsts: set[str]) -> None:
         """
         Extracts data from html module file
         """
         logger.info("Extracting data from html modules.")
-        certs_to_process = [x for x in self if x.state.module.is_ok_to_analyze()]
+        certs_to_process = [self[dgst] for dgst in dgsts]
         processed_certs = cert_processing.process_parallel(
             FIPSCertificate.parse_html_module,
             certs_to_process,
@@ -148,16 +148,21 @@ class FIPSDataset(Dataset[FIPSCertificate], ComplexSerializableType):
 
     @serialize
     @only_backed()
-    def extract_data(self) -> None:
+    def extract_data(self, fresh: bool = True) -> None:
         logger.info("Extracting various data from certification artifacts.")
-        self._extract_data_from_html_modules()
-        self._extract_policy_pdf_metadata()
-        self._extract_policy_pdf_keywords()
-        self._extract_algorithms_from_policy_tables()
+        module_dgsts = {x.dgst for x in self if x.state.module.is_ok_to_extract(fresh)}
+        policy_dgsts = {x.dgst for x in self if x.state.policy.is_ok_to_extract(fresh)}
+        for dgst in policy_dgsts:
+            self[dgst].state.policy.extract_ok = True
 
-    def _extract_policy_pdf_keywords(self) -> None:
+        self._extract_data_from_html_modules(module_dgsts)
+        self._extract_policy_pdf_metadata(policy_dgsts)
+        self._extract_policy_pdf_keywords(policy_dgsts)
+        self._extract_algorithms_from_policy_tables(policy_dgsts)
+
+    def _extract_policy_pdf_keywords(self, dgsts: set[str]) -> None:
         logger.info("Extracting keywords from policy pdfs.")
-        certs_to_process = [x for x in self if x.state.policy.is_ok_to_analyze()]
+        certs_to_process = [self[dgst] for dgst in dgsts]
         processed_certs = cert_processing.process_parallel(
             FIPSCertificate.extract_policy_pdf_keywords,
             certs_to_process,
@@ -290,8 +295,8 @@ class FIPSDataset(Dataset[FIPSCertificate], ComplexSerializableType):
         self.state.meta_sources_parsed = True
 
     @staged(logger, "Extracting Algorithms from policy tables.")
-    def _extract_algorithms_from_policy_tables(self):
-        certs_to_process = [x for x in self if x.state.policy.is_ok_to_analyze()]
+    def _extract_algorithms_from_policy_tables(self, dgsts: set[str]):
+        certs_to_process = [self[dgst] for dgst in dgsts]
         cert_processing.process_parallel(
             FIPSCertificate.get_algorithms_from_policy_tables,
             certs_to_process,
@@ -300,8 +305,8 @@ class FIPSDataset(Dataset[FIPSCertificate], ComplexSerializableType):
         )
 
     @staged(logger, "Extracting security policy metadata from the pdfs.")
-    def _extract_policy_pdf_metadata(self) -> None:
-        certs_to_process = [x for x in self if x.state.policy.is_ok_to_analyze()]
+    def _extract_policy_pdf_metadata(self, dgsts: set[str]) -> None:
+        certs_to_process = [self[dgst] for dgst in dgsts]
         processed_certs = cert_processing.process_parallel(
             FIPSCertificate.extract_policy_pdf_metadata,
             certs_to_process,

--- a/src/sec_certs/dataset/protection_profile.py
+++ b/src/sec_certs/dataset/protection_profile.py
@@ -211,9 +211,10 @@ class ProtectionProfileDataset(Dataset[ProtectionProfile], ComplexSerializableTy
             shutil.rmtree(self.web_dir)
 
         if carry_processing_results:
+            # Reconciling the carried results sets the local paths already.
             self._carry_processing_results(old_certs)
-
-        self._set_local_paths()
+        else:
+            self._set_local_paths()
         self.state.meta_sources_parsed = True
 
     def _get_all_certs_from_html(

--- a/src/sec_certs/dataset/protection_profile.py
+++ b/src/sec_certs/dataset/protection_profile.py
@@ -381,26 +381,35 @@ class ProtectionProfileDataset(Dataset[ProtectionProfile], ComplexSerializableTy
         )
 
     @only_backed()
-    def extract_data(self):
+    def extract_data(self, fresh: bool = True):
         """
         Extracts pdf metadata and keywords from converted text documents.
         """
         logger.info("Extracting various data from certification artifacts.")
-        self._extract_pdf_metadata()
-        self._extract_pdf_keywords()
+        doc_types = ["report", "pp"]
+        dgsts: dict[str, set[str]] = {
+            doc_type: {x.dgst for x in self if getattr(x.state, doc_type).is_ok_to_extract(fresh)}
+            for doc_type in doc_types
+        }
+        for doc_type in doc_types:
+            for dgst in dgsts[doc_type]:
+                getattr(self[dgst].state, doc_type).extract_ok = True
+
+        self._extract_pdf_metadata(dgsts)
+        self._extract_pdf_keywords(dgsts)
 
     @staged(logger, "Extracting metadata from certification artifacts.")
-    def _extract_pdf_metadata(self):
-        self._extract_report_metadata()
-        self._extract_pp_metadata()
+    def _extract_pdf_metadata(self, dgsts: dict[str, set[str]]):
+        self._extract_report_metadata(dgsts["report"])
+        self._extract_pp_metadata(dgsts["pp"])
 
     @staged(logger, "Extracting keywords from certification artifacts.")
-    def _extract_pdf_keywords(self):
-        self._extract_report_keywords()
-        self._extract_pp_keywords()
+    def _extract_pdf_keywords(self, dgsts: dict[str, set[str]]):
+        self._extract_report_keywords(dgsts["report"])
+        self._extract_pp_keywords(dgsts["pp"])
 
-    def _extract_report_metadata(self):
-        certs_to_process = [x for x in self if x.state.report.is_ok_to_analyze()]
+    def _extract_report_metadata(self, dgsts: set[str]):
+        certs_to_process = [self[dgst] for dgst in dgsts]
         processed_certs = cert_processing.process_parallel(
             ProtectionProfile.extract_report_pdf_metadata,
             certs_to_process,
@@ -409,8 +418,8 @@ class ProtectionProfileDataset(Dataset[ProtectionProfile], ComplexSerializableTy
         )
         self.update_with_certs(processed_certs)
 
-    def _extract_pp_metadata(self):
-        certs_to_process = [x for x in self if x.state.pp.is_ok_to_analyze()]
+    def _extract_pp_metadata(self, dgsts: set[str]):
+        certs_to_process = [self[dgst] for dgst in dgsts]
         processed_certs = cert_processing.process_parallel(
             ProtectionProfile.extract_pp_pdf_metadata,
             certs_to_process,
@@ -419,8 +428,8 @@ class ProtectionProfileDataset(Dataset[ProtectionProfile], ComplexSerializableTy
         )
         self.update_with_certs(processed_certs)
 
-    def _extract_report_keywords(self):
-        certs_to_process = [x for x in self if x.state.report.is_ok_to_analyze()]
+    def _extract_report_keywords(self, dgsts: set[str]):
+        certs_to_process = [self[dgst] for dgst in dgsts]
         processed_certs = cert_processing.process_parallel(
             ProtectionProfile.extract_report_pdf_keywords,
             certs_to_process,
@@ -429,8 +438,8 @@ class ProtectionProfileDataset(Dataset[ProtectionProfile], ComplexSerializableTy
         )
         self.update_with_certs(processed_certs)
 
-    def _extract_pp_keywords(self):
-        certs_to_process = [x for x in self if x.state.pp.is_ok_to_analyze()]
+    def _extract_pp_keywords(self, dgsts: set[str]):
+        certs_to_process = [self[dgst] for dgst in dgsts]
         processed_certs = cert_processing.process_parallel(
             ProtectionProfile.extract_pp_pdf_keywords,
             certs_to_process,

--- a/src/sec_certs/dataset/protection_profile.py
+++ b/src/sec_certs/dataset/protection_profile.py
@@ -180,6 +180,7 @@ class ProtectionProfileDataset(Dataset[ProtectionProfile], ComplexSerializableTy
         get_archived: bool = True,
         get_collaborative: bool = True,
         get_schemes: bool | None = None,
+        carry_processing_results: bool = False,
     ) -> None:
         """
         Fetches list of protection profiles together with metadata from commoncriteriaportal.org
@@ -191,6 +192,8 @@ class ProtectionProfileDataset(Dataset[ProtectionProfile], ComplexSerializableTy
 
         if to_download:
             self._download_html_resources(get_active, get_archived, get_collaborative)
+
+        old_certs = self.certs
 
         logger.info("Adding HTML certificates to ProtectionProfile dataset.")
         self.certs = self._get_all_certs_from_html(get_active, get_archived, get_collaborative)
@@ -206,6 +209,9 @@ class ProtectionProfileDataset(Dataset[ProtectionProfile], ComplexSerializableTy
 
         if not keep_metadata:
             shutil.rmtree(self.web_dir)
+
+        if carry_processing_results:
+            self._carry_processing_results(old_certs)
 
         self._set_local_paths()
         self.state.meta_sources_parsed = True

--- a/src/sec_certs/sample/cc.py
+++ b/src/sec_certs/sample/cc.py
@@ -28,7 +28,7 @@ from sec_certs.utils import helpers, sanitization
 
 
 class CCCertificate(
-    Certificate["CCCertificate", "Heuristics", "PdfData"],
+    Certificate["CCCertificate", "Heuristics", "PdfData", "InternalState"],
     PandasSerializableType,
     ComplexSerializableType,
 ):

--- a/src/sec_certs/sample/cc.py
+++ b/src/sec_certs/sample/cc.py
@@ -204,7 +204,7 @@ class CCCertificate(
             self.heuristics.cert_lab[0] if (self.heuristics.cert_lab and self.heuristics.cert_lab[0]) else np.nan,
         )
 
-    def merge(self, other: CCCertificate, other_source: str | None = None) -> None:
+    def merge_from_other_source(self, other: CCCertificate, other_source: str | None = None) -> None:
         """
         Merges with other CC sample. Assuming they come from different sources, e.g., csv and html.
         Assuming that html source has better protection profiles, they overwrite CSV info.
@@ -226,7 +226,11 @@ class CCCertificate(
         }
 
         for att, val in vars(self).items():
-            if (not val) or (other_source == "html" and att in html_preferred_attrs) or (att == "state"):
+            if (
+                (not val)
+                or (other_source == "html" and att in html_preferred_attrs)
+                or (att in ["state", "heuristics", "pdf_data"])
+            ):
                 setattr(self, att, getattr(other, att))
             else:
                 if getattr(self, att) != getattr(other, att):

--- a/src/sec_certs/sample/cc_eucc_common.py
+++ b/src/sec_certs/sample/cc_eucc_common.py
@@ -400,7 +400,12 @@ def download_pdf(cert: CCCertificate | EUCCCertificate, doc_type: DocType):
         doc_state.download_ok = False
     else:
         doc_state.download_ok = True
-        doc_state.source_hash = helpers.get_sha256_filepath(doc_state.source_path)
+        source_hash = helpers.get_sha256_filepath(doc_state.source_path)
+        if source_hash != doc_state.source_hash:
+            doc_state.reset_conversion()
+
+        doc_state.source_hash = source_hash
+
         setattr(cert.pdf_data, f"{doc_type.short}_filename", unquote_plus(str(urlparse(link).path).split("/")[-1]))
     return cert
 

--- a/src/sec_certs/sample/cc_eucc_common.py
+++ b/src/sec_certs/sample/cc_eucc_common.py
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
 
 
 @dataclass
-class InternalState(BaseInternalState):
+class InternalState(BaseInternalState, ComplexSerializableType):
     """
     Holds internal state of the certificate, whether downloads and converts of individual components succeeded. Also
     holds information about errors and paths to the files.

--- a/src/sec_certs/sample/cc_eucc_common.py
+++ b/src/sec_certs/sample/cc_eucc_common.py
@@ -271,7 +271,6 @@ def extract_pdf_metadata_(cert: CCCertificate | EUCCCertificate, doc_type: DocTy
     try:
         metadata = extract_pdf_metadata(doc_state.source_path)
         setattr(cert.pdf_data, f"{doc_type.short}_metadata", metadata)
-        doc_state.extract_ok = True
     except ValueError:
         doc_state.extract_ok = False
     return cert

--- a/src/sec_certs/sample/cc_eucc_common.py
+++ b/src/sec_certs/sample/cc_eucc_common.py
@@ -29,6 +29,7 @@ from sec_certs.cert_rules import SARS_IMPLIED_FROM_EAL, cc_rules, rules
 from sec_certs.configuration import config
 from sec_certs.sample.cc_certificate_id import canonical_from_meta, canonicalize
 from sec_certs.sample.certificate import Heuristics as BaseHeuristics
+from sec_certs.sample.certificate import InternalState as BaseInternalState
 from sec_certs.sample.certificate import PdfData as BasePdfData
 from sec_certs.sample.certificate import References, logger
 from sec_certs.sample.document_state import DocumentState
@@ -46,7 +47,7 @@ if TYPE_CHECKING:
 
 
 @dataclass
-class InternalState(ComplexSerializableType):
+class InternalState(BaseInternalState):
     """
     Holds internal state of the certificate, whether downloads and converts of individual components succeeded. Also
     holds information about errors and paths to the files.

--- a/src/sec_certs/sample/certificate.py
+++ b/src/sec_certs/sample/certificate.py
@@ -4,11 +4,13 @@ import copy
 import logging
 from abc import ABC, abstractmethod
 from collections import ChainMap
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from typing import Any, Generic, TypeVar
 
 import sec_certs.utils.extract
 from sec_certs.cert_rules import PANDAS_KEYWORDS_CATEGORIES
+from sec_certs.sample.document_state import DocumentState
 from sec_certs.serialization.json import ComplexSerializableType
 
 logger = logging.getLogger(__name__)
@@ -16,6 +18,7 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T", bound="Certificate")
 H = TypeVar("H", bound="Heuristics")
 P = TypeVar("P", bound="PdfData")
+S = TypeVar("S", bound="InternalState")
 
 
 @dataclass
@@ -46,11 +49,23 @@ class PdfData:
         )
 
 
-class Certificate(Generic[T, H, P], ABC, ComplexSerializableType):
+class InternalState(ComplexSerializableType):
+    def document_states(self) -> Iterator[DocumentState]:
+        for value in vars(self).values():
+            if isinstance(value, DocumentState):
+                yield value
+
+    def reconcile_document_states(self) -> None:
+        for doc_state in self.document_states():
+            doc_state.reconcile_state()
+
+
+class Certificate(Generic[T, H, P, S], ABC, ComplexSerializableType):
     manufacturer: str | None
     name: str | None
     pdf_data: P
     heuristics: H
+    state: S
 
     def __init__(self, *args, **kwargs):
         pass

--- a/src/sec_certs/sample/certificate.py
+++ b/src/sec_certs/sample/certificate.py
@@ -49,7 +49,7 @@ class PdfData:
         )
 
 
-class InternalState(ComplexSerializableType):
+class InternalState:
     def document_states(self) -> Iterator[DocumentState]:
         for value in vars(self).values():
             if isinstance(value, DocumentState):

--- a/src/sec_certs/sample/document_state.py
+++ b/src/sec_certs/sample/document_state.py
@@ -47,10 +47,14 @@ class DocumentState(ComplexSerializableType):
             self.reset_download()
             return
 
-        if self.convert_ok and (
-            self._is_artifact_stale(self._txt_path, self.txt_hash)
-            or self.json_hash is not None
-            and self._is_artifact_stale(self._json_path, self.json_hash)
+        # Assuming paths are set before this, so _txt_path is None means no conversion artifact (e.g. FIPS module html).
+        if (
+            self.convert_ok
+            and self._txt_path is not None
+            and (
+                self._is_artifact_stale(self._txt_path, self.txt_hash)
+                or (self.json_hash is not None and self._is_artifact_stale(self._json_path, self.json_hash))
+            )
         ):
             self.reset_conversion()
 

--- a/src/sec_certs/sample/document_state.py
+++ b/src/sec_certs/sample/document_state.py
@@ -60,7 +60,7 @@ class DocumentState(ComplexSerializableType):
     def is_ok_to_convert(self, fresh: bool = True) -> bool:
         return self.download_ok if fresh else self.download_ok and not self.convert_ok
 
-    def is_ok_to_analyze(self, fresh: bool = True) -> bool:
+    def is_ok_to_extract(self, fresh: bool = True) -> bool:
         if fresh:
             return self.download_ok and self.convert_ok
         else:

--- a/src/sec_certs/sample/document_state.py
+++ b/src/sec_certs/sample/document_state.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from sec_certs.serialization.json import ComplexSerializableType
+from sec_certs.utils.helpers import get_sha256_filepath
 
 
 @dataclass
@@ -20,6 +21,38 @@ class DocumentState(ComplexSerializableType):
     _source_path: Path | None = None
     _txt_path: Path | None = None
     _json_path: Path | None = None
+
+    def reset_extraction(self) -> None:
+        self.extract_ok = False
+
+    def reset_conversion(self) -> None:
+        self.convert_ok = False
+        self.txt_hash = None
+        self.json_hash = None
+        self.reset_extraction()
+
+    def reset_download(self) -> None:
+        self.download_ok = False
+        self.source_hash = None
+        self.reset_conversion()
+
+    @staticmethod
+    def _is_artifact_stale(path: Path | None, recorded_hash: str | None) -> bool:
+        if path is None or not path.exists():
+            return True
+        return recorded_hash is None or get_sha256_filepath(path) != recorded_hash
+
+    def reconcile_state(self) -> None:
+        if self.download_ok and self._is_artifact_stale(self._source_path, self.source_hash):
+            self.reset_download()
+            return
+
+        if self.convert_ok and (
+            self._is_artifact_stale(self._txt_path, self.txt_hash)
+            or self.json_hash is not None
+            and self._is_artifact_stale(self._json_path, self.json_hash)
+        ):
+            self.reset_conversion()
 
     def is_ok_to_download(self, fresh: bool = True) -> bool:
         return True if fresh else not self.download_ok

--- a/src/sec_certs/sample/eucc.py
+++ b/src/sec_certs/sample/eucc.py
@@ -31,7 +31,7 @@ with (Path(__file__).parent.parent / "rules.yaml").open(encoding="utf-8") as f:
 
 @dataclass
 class EUCCCertificate(
-    Certificate["EUCCCertificate", "Heuristics", "PdfData"],
+    Certificate["EUCCCertificate", "Heuristics", "PdfData", "InternalState"],
     ComplexSerializableType,
 ):
     """

--- a/src/sec_certs/sample/fips.py
+++ b/src/sec_certs/sample/fips.py
@@ -323,6 +323,8 @@ class FIPSCertificate(
 
         keywords: dict = field(default_factory=dict)
         policy_metadata: dict[str, Any] = field(default_factory=dict)
+        module_algorithms: set[str] = field(default_factory=set)
+        policy_algorithms: set[str] = field(default_factory=set)
 
         @property
         def certlike_algorithm_numbers(self) -> set[str]:
@@ -458,7 +460,7 @@ class FIPSCertificate(
 
         parser = FIPSHTMLParser(soup)
         algorithms, cert.web_data = parser.get_web_data_and_algorithms()
-        cert.heuristics.algorithms |= algorithms
+        cert.pdf_data.module_algorithms = algorithms
         cert.state.module.extract_ok = True
 
         return cert
@@ -558,7 +560,7 @@ class FIPSCertificate(
             repair_pdf(cert.state.policy.source_path)
             try:
                 tabular_data = read_pdf(cert.state.policy.source_path, pages=list(table_rich_page_numbers), silent=True)
-                cert.heuristics.algorithms |= set(
+                cert.pdf_data.policy_algorithms = set(
                     itertools.chain.from_iterable(
                         tables.get_algs_from_table(df.to_string())
                         for df in tabular_data

--- a/src/sec_certs/sample/fips.py
+++ b/src/sec_certs/sample/fips.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 
 
 @dataclass
-class InternalState(BaseInternalState):
+class InternalState(BaseInternalState, ComplexSerializableType):
     module: DocumentState = field(default_factory=DocumentState)
     policy: DocumentState = field(default_factory=DocumentState)
 

--- a/src/sec_certs/sample/fips.py
+++ b/src/sec_certs/sample/fips.py
@@ -19,6 +19,7 @@ from sec_certs.cert_rules import FIPS_ALGS_IN_TABLE, fips_rules
 from sec_certs.configuration import config
 from sec_certs.sample.certificate import Certificate, References, logger
 from sec_certs.sample.certificate import Heuristics as BaseHeuristics
+from sec_certs.sample.certificate import InternalState as BaseInternalState
 from sec_certs.sample.certificate import PdfData as BasePdfData
 from sec_certs.sample.cpe import CPE
 from sec_certs.sample.document_state import DocumentState
@@ -33,7 +34,7 @@ if TYPE_CHECKING:
 
 
 @dataclass
-class InternalState(ComplexSerializableType):
+class InternalState(BaseInternalState):
     module: DocumentState = field(default_factory=DocumentState)
     policy: DocumentState = field(default_factory=DocumentState)
 
@@ -214,7 +215,7 @@ DETAILS_KEY_TO_NORMALIZATION_FUNCTION: dict[str, Callable] = {
 
 
 class FIPSCertificate(
-    Certificate["FIPSCertificate", "FIPSCertificate.Heuristics", "FIPSCertificate.PdfData"],
+    Certificate["FIPSCertificate", "FIPSCertificate.Heuristics", "FIPSCertificate.PdfData", "InternalState"],
     PandasSerializableType,
     ComplexSerializableType,
 ):

--- a/src/sec_certs/sample/fips.py
+++ b/src/sec_certs/sample/fips.py
@@ -465,16 +465,22 @@ class FIPSCertificate(
 
     @staticmethod
     def download_module(cert: FIPSCertificate) -> FIPSCertificate:
+        doc_state = cert.state.module
         if (
-            exit_code := helpers.download_file(
-                cert.module_html_url, cert.state.module.source_path, proxy=config.fips_use_proxy
-            )
+            exit_code := helpers.download_file(cert.module_html_url, doc_state.source_path, proxy=config.fips_use_proxy)
         ) != requests.codes.ok:
             error_msg = f"failed to download html module from {cert.module_html_url}, code {exit_code}"
             logger.error(f"Cert dgst: {cert.dgst} " + error_msg)
             cert.state.module.download_ok = False
         else:
             cert.state.module.download_ok = True
+            raw = doc_state.source_path.read_text(encoding="utf-8")
+            doc_state.source_path.write_text(helpers.normalize_cloudflare_html(raw), encoding="utf-8")
+
+            source_hash = helpers.get_sha256_filepath(doc_state.source_path)
+            if source_hash != doc_state.source_hash:
+                doc_state.reset_extraction()
+            doc_state.source_hash = source_hash
             cert.state.module.convert_ok = True  # No conversion needed for html, so we set it to True
 
         return cert

--- a/src/sec_certs/sample/fips.py
+++ b/src/sec_certs/sample/fips.py
@@ -478,11 +478,6 @@ class FIPSCertificate(
             cert.state.module.download_ok = True
             raw = doc_state.source_path.read_text(encoding="utf-8")
             doc_state.source_path.write_text(helpers.normalize_cloudflare_html(raw), encoding="utf-8")
-
-            source_hash = helpers.get_sha256_filepath(doc_state.source_path)
-            if source_hash != doc_state.source_hash:
-                doc_state.reset_extraction()
-            doc_state.source_hash = source_hash
             cert.state.module.convert_ok = True  # No conversion needed for html, so we set it to True
 
         return cert

--- a/src/sec_certs/sample/fips.py
+++ b/src/sec_certs/sample/fips.py
@@ -491,7 +491,10 @@ class FIPSCertificate(
             cert.state.policy.download_ok = False
         else:
             cert.state.policy.download_ok = True
-            cert.state.policy.source_hash = helpers.get_sha256_filepath(cert.state.policy.source_path)
+            source_hash = helpers.get_sha256_filepath(cert.state.policy.source_path)
+            if source_hash != cert.state.policy.source_hash:
+                cert.state.policy.reset_conversion()
+            cert.state.policy.source_hash = source_hash
         return cert
 
     @staticmethod

--- a/src/sec_certs/sample/fips.py
+++ b/src/sec_certs/sample/fips.py
@@ -524,7 +524,6 @@ class FIPSCertificate(
         """
         try:
             cert.pdf_data.policy_metadata = extract_pdf_metadata(cert.state.policy.source_path)
-            cert.state.policy.extract_ok = True
         except ValueError:
             cert.state.policy.extract_ok = False
         return cert

--- a/src/sec_certs/sample/protection_profile.py
+++ b/src/sec_certs/sample/protection_profile.py
@@ -14,6 +14,7 @@ from sec_certs.cert_rules import cc_rules
 from sec_certs.configuration import config
 from sec_certs.sample.certificate import Certificate, logger
 from sec_certs.sample.certificate import Heuristics as BaseHeuristics
+from sec_certs.sample.certificate import InternalState as BaseInternalState
 from sec_certs.sample.certificate import PdfData as BasePdfData
 from sec_certs.sample.document_state import DocumentState
 from sec_certs.sample.pp_scheme import PPSchemeRecord
@@ -27,7 +28,12 @@ if TYPE_CHECKING:
 
 
 class ProtectionProfile(
-    Certificate["ProtectionProfile", "ProtectionProfile.Heuristics", "ProtectionProfile.PdfData"],
+    Certificate[
+        "ProtectionProfile",
+        "ProtectionProfile.Heuristics",
+        "ProtectionProfile.PdfData",
+        "ProtectionProfile.InternalState",
+    ],
     ComplexSerializableType,
 ):
     @dataclass
@@ -203,7 +209,7 @@ class ProtectionProfile(
             )
 
     @dataclass
-    class InternalState(ComplexSerializableType):
+    class InternalState(BaseInternalState):
         """
         Class to hold internal state for each of the documents.
         """

--- a/src/sec_certs/sample/protection_profile.py
+++ b/src/sec_certs/sample/protection_profile.py
@@ -209,7 +209,7 @@ class ProtectionProfile(
             )
 
     @dataclass
-    class InternalState(BaseInternalState):
+    class InternalState(BaseInternalState, ComplexSerializableType):
         """
         Class to hold internal state for each of the documents.
         """

--- a/src/sec_certs/sample/protection_profile.py
+++ b/src/sec_certs/sample/protection_profile.py
@@ -396,7 +396,6 @@ class ProtectionProfile(
         """
         try:
             cert.pdf_data.report_metadata = extract_pdf_metadata(cert.state.report.source_path)
-            cert.state.report.extract_ok = True
         except ValueError:
             cert.state.report.extract_ok = False
         return cert
@@ -408,7 +407,6 @@ class ProtectionProfile(
         """
         try:
             cert.pdf_data.pp_metadata = extract_pdf_metadata(cert.state.pp.source_path)
-            cert.state.pp.extract_ok = True
         except ValueError:
             cert.state.pp.extract_ok = False
 

--- a/src/sec_certs/sample/protection_profile.py
+++ b/src/sec_certs/sample/protection_profile.py
@@ -326,7 +326,10 @@ class ProtectionProfile(
             cert.state.report.download_ok = False
         else:
             cert.state.report.download_ok = True
-            cert.state.report.source_hash = helpers.get_sha256_filepath(cert.state.report.source_path)
+            source_hash = helpers.get_sha256_filepath(cert.state.report.source_path)
+            if source_hash != cert.state.report.source_hash:
+                cert.state.report.reset_conversion()
+            cert.state.report.source_hash = source_hash
             cert.pdf_data.report_filename = unquote_plus(str(urlparse(cert.web_data.report_link).path).split("/")[-1])
         return cert
 
@@ -348,7 +351,10 @@ class ProtectionProfile(
             cert.state.pp.download_ok = False
         else:
             cert.state.pp.download_ok = True
-            cert.state.pp.source_hash = helpers.get_sha256_filepath(cert.state.pp.source_path)
+            source_hash = helpers.get_sha256_filepath(cert.state.pp.source_path)
+            if source_hash != cert.state.pp.source_hash:
+                cert.state.pp.reset_conversion()
+            cert.state.pp.source_hash = source_hash
             cert.pdf_data.pp_filename = unquote_plus(str(urlparse(cert.web_data.pp_link).path).split("/")[-1])
         return cert
 

--- a/src/sec_certs/serialization/schemas/fips_certificate.json
+++ b/src/sec_certs/serialization/schemas/fips_certificate.json
@@ -382,6 +382,38 @@
           "$ref": "base.json#/definitions/document_metadata",
           "title": "Security Policy Metadata",
           "description": "Metadata extracted from the security policy document."
+        },
+        "module_algorithms": {
+          "type": "object",
+          "properties": {
+            "_type": {
+              "const": "Set"
+            },
+            "elements": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "title": "Module Algorithms",
+          "description": "Algorithms extracted from the HTML module page."
+        },
+        "policy_algorithms": {
+          "type": "object",
+          "properties": {
+            "_type": {
+              "const": "Set"
+            },
+            "elements": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "title": "Policy Algorithms",
+          "description": "Algorithms extracted from the security policy PDF tables."
         }
       },
       "title": "Extracted PDF Data",

--- a/src/sec_certs/utils/helpers.py
+++ b/src/sec_certs/utils/helpers.py
@@ -182,6 +182,17 @@ def get_sha256_filepath(filepath: str | Path) -> str:
     return hash_sha256.hexdigest()
 
 
+def normalize_cloudflare_html(html: str) -> str:
+    """
+    Strip the tokens Cloudflare rewrites on every response, so the same page has the same hash across runs.
+    The stripped tokens (email obfuscation, injected challenge script) are not read when parsing the module.
+    """
+    html = re.sub(r"(/cdn-cgi/l/email-protection)#[0-9a-fA-F]+", r"\1", html)
+    html = re.sub(r'data-cfemail="[0-9a-fA-F]+"', 'data-cfemail=""', html)
+    html = re.sub(r"(__CF\$cv\$params=\{r:')[^']*(',t:')[^']*('\})", r"\1\2\3", html)
+    return html
+
+
 def to_utc(timestamp: datetime) -> datetime:
     offset = timestamp.utcoffset()
     if offset is None:

--- a/src/sec_certs/utils/helpers.py
+++ b/src/sec_certs/utils/helpers.py
@@ -136,11 +136,13 @@ def download_file(  # noqa: C901
             ctx = nullcontext
 
         if r.status_code == requests.codes.ok:
-            with ctx() as pbar, output.open("wb") as f:
+            tmp = output.with_name(f"{output.name}.tmp")
+            with ctx() as pbar, tmp.open("wb") as f:
                 for data in r.iter_content(1024):
                     f.write(data)
                     if show_progress_bar:
                         pbar.update(len(data))
+            tmp.replace(output)
 
         return r.status_code
     except requests.exceptions.Timeout:

--- a/src/sec_certs/utils/helpers.py
+++ b/src/sec_certs/utils/helpers.py
@@ -179,7 +179,7 @@ def get_first_16_bytes_sha256(string: str) -> str:
 def get_sha256_filepath(filepath: str | Path) -> str:
     hash_sha256 = hashlib.sha256()
     with Path(filepath).open("rb") as f:
-        for chunk in iter(lambda: f.read(4096), b""):
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
             hash_sha256.update(chunk)
     return hash_sha256.hexdigest()
 

--- a/src/sec_certs/utils/pdf.py
+++ b/src/sec_certs/utils/pdf.py
@@ -160,17 +160,8 @@ def extract_pdf_metadata(filepath: Path) -> dict[str, Any]:  # noqa: C901
 
     metadata: dict[str, Any] = {}
 
-    try:
-        metadata["pdf_file_size_bytes"] = filepath.stat().st_size
-        with filepath.open("rb") as handle:
-            pdf = PdfReader(handle, strict=False)
-            metadata["pdf_is_encrypted"] = pdf.is_encrypted
-
-        # see https://stackoverflow.com/questions/26242952/pypdf-2-decrypt-not-working
-        if metadata["pdf_is_encrypted"]:
-            pikepdf.open(filepath, allow_overwriting_input=True).save()
-
-        with filepath.open("rb") as handle:
+    def read_metadata(source: Path) -> None:
+        with source.open("rb") as handle:
             pdf = PdfReader(handle, strict=False)
             metadata["pdf_number_of_pages"] = len(pdf.pages)
             pdf_document_info = pdf.metadata
@@ -194,6 +185,21 @@ def extract_pdf_metadata(filepath: Path) -> dict[str, Any]:  # noqa: C901
                 except Exception:
                     pass
             metadata["pdf_hyperlinks"] = links
+
+    try:
+        metadata["pdf_file_size_bytes"] = filepath.stat().st_size
+        with filepath.open("rb") as handle:
+            pdf = PdfReader(handle, strict=False)
+            metadata["pdf_is_encrypted"] = pdf.is_encrypted
+
+        # see https://stackoverflow.com/questions/26242952/pypdf-2-decrypt-not-working
+        if metadata["pdf_is_encrypted"]:
+            with TemporaryDirectory() as tmp_dir:
+                decrypted = Path(tmp_dir) / filepath.name
+                pikepdf.open(filepath).save(decrypted)
+                read_metadata(decrypted)
+        else:
+            read_metadata(filepath)
 
     except Exception as e:
         relative_filepath = "/".join(str(filepath).split("/")[-4:])

--- a/tests/cc/test_cc_aux_datasets.py
+++ b/tests/cc/test_cc_aux_datasets.py
@@ -18,6 +18,7 @@ from sec_certs.dataset.auxiliary_dataset_handling import (
     CPEMatchDictHandler,
     CVEDatasetHandler,
     FIPSAlgorithmDatasetHandler,
+    ProcessingMode,
     ProtectionProfileDatasetHandler,
 )
 
@@ -54,7 +55,7 @@ def test_cpe_dataset_handler_process_dataset(preferred_source_aux_datasets, temp
         monkeypatch.setattr("sec_certs.utils.nvd_dataset_builder.CpeNvdDatasetBuilder.build_dataset", mock_get_dset)
 
     monkeypatch.setattr("sec_certs.dataset.cpe.CPEDataset.to_json", lambda x: None)
-    handler.process_dataset(download_fresh=True)
+    handler.process_dataset(mode=ProcessingMode.REBUILD)
 
     assert handler.dset == mock_dset
     assert handler.dset_path == temp_dir / "cpe_dataset.json"
@@ -81,7 +82,7 @@ def test_cve_dataset_handler_process_dataset(preferred_source_aux_datasets, temp
     else:
         monkeypatch.setattr("sec_certs.utils.nvd_dataset_builder.CveNvdDatasetBuilder.build_dataset", mock_get_dset)
     monkeypatch.setattr("sec_certs.dataset.cve.CVEDataset.to_json", lambda x: None)
-    handler.process_dataset(download_fresh=True)
+    handler.process_dataset(mode=ProcessingMode.REBUILD)
 
     assert handler.dset == mock_dset
     assert handler.dset_path == temp_dir / "cve_dataset.json"
@@ -115,7 +116,7 @@ def test_cpe_match_dict_handler_process_dataset(preferred_source_aux_datasets, t
         monkeypatch.setattr("sec_certs.utils.helpers.download_file", mock_download_file)
         monkeypatch.setattr("gzip.open", mock_open(read_data=(mock_dset_str_single_quotes.encode())))
 
-    handler.process_dataset(download_fresh=True)
+    handler.process_dataset(mode=ProcessingMode.REBUILD)
 
     assert handler.dset == mock_dset
 
@@ -135,7 +136,7 @@ def test_fips_algorithm_dataset_handler_process_dataset(temp_dir, monkeypatch):
         return mock_dset
 
     monkeypatch.setattr("sec_certs.dataset.fips_algorithm.FIPSAlgorithmDataset.from_web", mock_from_web)
-    handler.process_dataset(download_fresh=True)
+    handler.process_dataset(mode=ProcessingMode.REBUILD)
     assert handler.dset == mock_dset
     assert handler.dset_path == temp_dir / "algorithms" / "algorithms_dataset.json"
 
@@ -156,7 +157,7 @@ def test_cc_scheme_dataset_handler_process_dataset(temp_dir, monkeypatch):
 
     monkeypatch.setattr("sec_certs.dataset.cc_scheme.CCSchemeDataset.from_web", mock_from_web)
     monkeypatch.setattr("sec_certs.dataset.cc_scheme.CCSchemeDataset.to_json", lambda x: None)
-    handler.process_dataset(download_fresh=True)
+    handler.process_dataset(mode=ProcessingMode.REBUILD)
     assert handler.dset == mock_dset
     assert handler.dset_path == temp_dir / "cc_scheme.json"
     assert handler.dset.json_path == handler.dset_path
@@ -177,11 +178,11 @@ def test_cc_maintenance_update_dataset_handler_process_dataset(temp_dir, monkeyp
         "sec_certs.sample.cc_maintenance_update.CCMaintenanceUpdate.get_updates_from_cc_cert",
         lambda x: [],
     )
-    monkeypatch.setattr("sec_certs.dataset.dataset.Dataset.download_all_artifacts", lambda x: None)
-    monkeypatch.setattr("sec_certs.dataset.dataset.Dataset.convert_all_pdfs", lambda x: None)
-    monkeypatch.setattr("sec_certs.dataset.cc.CCDataset.extract_data", lambda x: None)
+    monkeypatch.setattr("sec_certs.dataset.dataset.Dataset.download_all_artifacts", lambda x, **kwargs: None)
+    monkeypatch.setattr("sec_certs.dataset.dataset.Dataset.convert_all_pdfs", lambda x, **kwargs: None)
+    monkeypatch.setattr("sec_certs.dataset.cc.CCDataset.extract_data", lambda x, **kwargs: None)
     monkeypatch.setattr("sec_certs.dataset.dataset.Dataset.to_json", lambda x: None)
-    handler.process_dataset(download_fresh=True)
+    handler.process_dataset(mode=ProcessingMode.REBUILD)
     assert handler.dset == mock_dset
 
 
@@ -209,5 +210,5 @@ def test_protection_profile_dataset_handler_process_dataset(temp_dir, monkeypatc
         "sec_certs.dataset.protection_profile.ProtectionProfileDataset.analyze_certificates", lambda x: None
     )
     monkeypatch.setattr("sec_certs.dataset.protection_profile.ProtectionProfileDataset.to_json", lambda x: None)
-    handler.process_dataset(download_fresh=True)
+    handler.process_dataset(mode=ProcessingMode.REBUILD)
     assert handler.dset == mock_dset

--- a/tests/data/fips/certificate/fictional_cert.json
+++ b/tests/data/fips/certificate/fictional_cert.json
@@ -30,7 +30,15 @@
     "pdf_data": {
         "_type": "sec_certs.sample.fips.FIPSCertificate.PdfData",
         "keywords": {},
-        "policy_metadata": {}
+        "policy_metadata": {},
+        "module_algorithms": {
+            "_type": "Set",
+            "elements": []
+        },
+        "policy_algorithms": {
+            "_type": "Set",
+            "elements": []
+        }
     },
     "heuristics": {
         "_type": "sec_certs.sample.fips.FIPSCertificate.Heuristics",
@@ -77,7 +85,7 @@
             "download_ok": true,
             "convert_ok": true,
             "extract_ok": false,
-            "source_hash": null,
+            "source_hash": "93d46d9439fe8a6d09ec9d5e29001ff5389769b0490f8c0ed743ac9885f0c9d3",
             "txt_hash": null,
             "json_hash": null
         },

--- a/tests/data/fips/certificate/fictional_cert.json
+++ b/tests/data/fips/certificate/fictional_cert.json
@@ -85,7 +85,7 @@
             "download_ok": true,
             "convert_ok": true,
             "extract_ok": false,
-            "source_hash": "227f1c1a0bb52da88ba0ba03d2a35ec8ce38ac2c8d48fa6b2621eae8ebe62a4a",
+            "source_hash": null,
             "txt_hash": null,
             "json_hash": null
         },

--- a/tests/data/fips/certificate/fictional_cert.json
+++ b/tests/data/fips/certificate/fictional_cert.json
@@ -85,7 +85,7 @@
             "download_ok": true,
             "convert_ok": true,
             "extract_ok": false,
-            "source_hash": "93d46d9439fe8a6d09ec9d5e29001ff5389769b0490f8c0ed743ac9885f0c9d3",
+            "source_hash": "227f1c1a0bb52da88ba0ba03d2a35ec8ce38ac2c8d48fa6b2621eae8ebe62a4a",
             "txt_hash": null,
             "json_hash": null
         },

--- a/tests/data/fips/dataset/toy_dataset.json
+++ b/tests/data/fips/dataset/toy_dataset.json
@@ -46,7 +46,15 @@
             "pdf_data": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.PdfData",
                 "keywords": {},
-                "policy_metadata": {}
+                "policy_metadata": {},
+                "module_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                },
+                "policy_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                }
             },
             "heuristics": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.Heuristics",
@@ -140,7 +148,15 @@
             "pdf_data": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.PdfData",
                 "keywords": {},
-                "policy_metadata": {}
+                "policy_metadata": {},
+                "module_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                },
+                "policy_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                }
             },
             "heuristics": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.Heuristics",
@@ -234,7 +250,15 @@
             "pdf_data": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.PdfData",
                 "keywords": {},
-                "policy_metadata": {}
+                "policy_metadata": {},
+                "module_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                },
+                "policy_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                }
             },
             "heuristics": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.Heuristics",
@@ -328,7 +352,15 @@
             "pdf_data": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.PdfData",
                 "keywords": {},
-                "policy_metadata": {}
+                "policy_metadata": {},
+                "module_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                },
+                "policy_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                }
             },
             "heuristics": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.Heuristics",
@@ -422,7 +454,15 @@
             "pdf_data": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.PdfData",
                 "keywords": {},
-                "policy_metadata": {}
+                "policy_metadata": {},
+                "module_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                },
+                "policy_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                }
             },
             "heuristics": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.Heuristics",
@@ -516,7 +556,15 @@
             "pdf_data": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.PdfData",
                 "keywords": {},
-                "policy_metadata": {}
+                "policy_metadata": {},
+                "module_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                },
+                "policy_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                }
             },
             "heuristics": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.Heuristics",
@@ -610,7 +658,15 @@
             "pdf_data": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.PdfData",
                 "keywords": {},
-                "policy_metadata": {}
+                "policy_metadata": {},
+                "module_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                },
+                "policy_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                }
             },
             "heuristics": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.Heuristics",
@@ -704,7 +760,15 @@
             "pdf_data": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.PdfData",
                 "keywords": {},
-                "policy_metadata": {}
+                "policy_metadata": {},
+                "module_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                },
+                "policy_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                }
             },
             "heuristics": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.Heuristics",
@@ -798,7 +862,15 @@
             "pdf_data": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.PdfData",
                 "keywords": {},
-                "policy_metadata": {}
+                "policy_metadata": {},
+                "module_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                },
+                "policy_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                }
             },
             "heuristics": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.Heuristics",
@@ -892,7 +964,15 @@
             "pdf_data": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.PdfData",
                 "keywords": {},
-                "policy_metadata": {}
+                "policy_metadata": {},
+                "module_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                },
+                "policy_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                }
             },
             "heuristics": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.Heuristics",
@@ -986,7 +1066,15 @@
             "pdf_data": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.PdfData",
                 "keywords": {},
-                "policy_metadata": {}
+                "policy_metadata": {},
+                "module_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                },
+                "policy_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                }
             },
             "heuristics": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.Heuristics",
@@ -1080,7 +1168,15 @@
             "pdf_data": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.PdfData",
                 "keywords": {},
-                "policy_metadata": {}
+                "policy_metadata": {},
+                "module_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                },
+                "policy_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                }
             },
             "heuristics": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.Heuristics",
@@ -1174,7 +1270,15 @@
             "pdf_data": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.PdfData",
                 "keywords": {},
-                "policy_metadata": {}
+                "policy_metadata": {},
+                "module_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                },
+                "policy_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                }
             },
             "heuristics": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.Heuristics",
@@ -1268,7 +1372,15 @@
             "pdf_data": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.PdfData",
                 "keywords": {},
-                "policy_metadata": {}
+                "policy_metadata": {},
+                "module_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                },
+                "policy_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                }
             },
             "heuristics": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.Heuristics",
@@ -1362,7 +1474,15 @@
             "pdf_data": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.PdfData",
                 "keywords": {},
-                "policy_metadata": {}
+                "policy_metadata": {},
+                "module_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                },
+                "policy_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                }
             },
             "heuristics": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.Heuristics",
@@ -1456,7 +1576,15 @@
             "pdf_data": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.PdfData",
                 "keywords": {},
-                "policy_metadata": {}
+                "policy_metadata": {},
+                "module_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                },
+                "policy_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                }
             },
             "heuristics": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.Heuristics",
@@ -1550,7 +1678,15 @@
             "pdf_data": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.PdfData",
                 "keywords": {},
-                "policy_metadata": {}
+                "policy_metadata": {},
+                "module_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                },
+                "policy_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                }
             },
             "heuristics": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.Heuristics",
@@ -1644,7 +1780,15 @@
             "pdf_data": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.PdfData",
                 "keywords": {},
-                "policy_metadata": {}
+                "policy_metadata": {},
+                "module_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                },
+                "policy_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                }
             },
             "heuristics": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.Heuristics",
@@ -1738,7 +1882,15 @@
             "pdf_data": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.PdfData",
                 "keywords": {},
-                "policy_metadata": {}
+                "policy_metadata": {},
+                "module_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                },
+                "policy_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                }
             },
             "heuristics": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.Heuristics",
@@ -1832,7 +1984,15 @@
             "pdf_data": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.PdfData",
                 "keywords": {},
-                "policy_metadata": {}
+                "policy_metadata": {},
+                "module_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                },
+                "policy_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                }
             },
             "heuristics": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.Heuristics",
@@ -1926,7 +2086,15 @@
             "pdf_data": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.PdfData",
                 "keywords": {},
-                "policy_metadata": {}
+                "policy_metadata": {},
+                "module_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                },
+                "policy_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                }
             },
             "heuristics": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.Heuristics",
@@ -2020,7 +2188,15 @@
             "pdf_data": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.PdfData",
                 "keywords": {},
-                "policy_metadata": {}
+                "policy_metadata": {},
+                "module_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                },
+                "policy_algorithms": {
+                    "_type": "Set",
+                    "elements": []
+                }
             },
             "heuristics": {
                 "_type": "sec_certs.sample.fips.FIPSCertificate.Heuristics",

--- a/tests/fips/conftest.py
+++ b/tests/fips/conftest.py
@@ -46,6 +46,9 @@ def processed_dataset(
     toy_dataset.convert_all_pdfs()
     toy_dataset.extract_data()
 
+    for cert in toy_dataset.certs.values():
+        cert.heuristics.algorithms = cert.pdf_data.module_algorithms | cert.pdf_data.policy_algorithms
+
     compute_cpe_heuristics(toy_dataset.aux_handlers[CPEDatasetHandler].dset, toy_dataset.certs.values())
     compute_related_cves(
         toy_dataset.aux_handlers[CPEDatasetHandler].dset,


### PR DESCRIPTION
First part of https://github.com/crocs-muni/sec-certs/issues/570.

This PR introduces an option to retain the state associated with artifacts from the existing certificates in the dataset when fetching new metadata. This allows for converting and extracting data only from certificates that are either new or have changed artifacts. 

With this, Docling can be used on the server, as we will convert only a few documents during the weekly update, rather than processing the entire dataset, which could take several days.

Most of the functionality was already there (the states and hashes for artifacts, fresh flags in the pipeline steps, and so on). I just added what was missing so it can actually be used.

Summary of changes:

- Add a `carry_processing_results` option to `get_certs_from_web` across all four datasets. When set, `state` and `pdf_data` (and `web_data` for FIPS) of the certificates already held are carried over onto the freshly scraped ones, so the metadata scrape no longer discards everything that was processed before.
- Reconcile the carried over state against the files on disk. Each artifact is compared with the hash recorded when it was processed, and a missing or mismatched file invalidates the stage that produced it and everything derived from it.
- Compare the source hash on download and reset the conversion when it differs.
- Make the extraction step incremental with a `fresh` flag, mirroring the flag the other steps already had.
- Move the FIPS algorithms from `heuristics.algorithms` into `pdf_data`, and compute their union in the heuristics step. Heuristics are not carried over, so a certificate whose policy hasn't changed would never re-run the policy table extraction and would silently lose them.
- Add an `update()` orchestrator running the whole pipeline the way it is meant to be run in this mode: all artifacts are downloaded fresh, since that is the only way to learn whether a document changed, and the remaining steps then run with `fresh=False,` so they process only what is new, changed or previously failed. Heuristics are always recomputed as it depends on the whole dataset.

Follow-ups:
- Adding tests
- Wiring on page