### PR TITLE
feat: allow finer control of aux processing modes

### DIFF
--- a/src/sec_certs/dataset/cc.py
+++ b/src/sec_certs/dataset/cc.py
@@ -330,7 +330,7 @@ class CCDataset(Dataset[CCCertificate], ComplexSerializableType):
     def process_auxiliary_datasets(
         self,
         mode: ProcessingMode = ProcessingMode.LOAD,
-        skip_schemes: bool = True,
+        skip_schemes: bool = False,
         **kwargs,
     ) -> None:
         if CCMaintenanceUpdateDatasetHandler in self.aux_handlers:

--- a/src/sec_certs/dataset/dataset.py
+++ b/src/sec_certs/dataset/dataset.py
@@ -5,7 +5,7 @@ import shutil
 import tarfile
 import tempfile
 from abc import ABC, abstractmethod
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -363,7 +363,12 @@ class Dataset(Generic[CertSubType], ComplexSerializableType, ABC):
     @staged(logger, "Processing auxiliary datasets.")
     @serialize
     @only_backed()
-    def process_auxiliary_datasets(self, mode: ProcessingMode = ProcessingMode.LOAD, **kwargs) -> None:
+    def process_auxiliary_datasets(
+        self,
+        mode: ProcessingMode = ProcessingMode.LOAD,
+        mode_overrides: Mapping[type[AuxiliaryDatasetHandler], ProcessingMode] = {},
+        **kwargs,
+    ) -> None:
         """
         Processes all auxiliary datasets (CPE, CVE, ...) that are required during computation.
 
@@ -371,10 +376,13 @@ class Dataset(Generic[CertSubType], ComplexSerializableType, ABC):
             processing results over, or rebuild them from scratch. Only the auxiliary datasets that are
             themselves processed (protection profiles, maintenance updates) can be updated incrementally,
             the rest are simply re-fetched.
+        :param mode_overrides: Individual aux handler overrides of `mode`, keyed by handler class.
+            Use it when you need finer control over how the auxiliary datasets are handled.
         """
         logger.info("Processing auxiliary datasets.")
-        for handler in self.aux_handlers.values():
-            handler.process_dataset(mode)
+        for handler_cls, handler in self.aux_handlers.items():
+            handler.process_dataset(mode_overrides.get(handler_cls, mode))
+
         self.state.auxiliary_datasets_processed = True
 
     @only_backed()


### PR DESCRIPTION
Just a some small changes to ensure that https://github.com/crocs-muni/sec-certs/pull/699 works correctly.

- Allow overriding the processing mode for auxiliary datasets individually, rather than being limited to just one mode. This feature is useful for loading auxiliary datasets shared across different datasets (such as CVEs, CPEs, and PPs) and for updating their own datasets (such as CCSchemes and FIPSAlgorithms) at the same time.

- Set the default value of `skip_schemes` in the CC `process_auxiliary_datasets` function back to False, as it was accidentally changed in one of the recent PRs